### PR TITLE
feat: stale session detection and workflow improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ MCP server for multi-session Claude Code coordination via [Temporal](https://tem
 
 Multiple Claude Code sessions discover each other, exchange messages in real time, and coordinate work — across machines, not just localhost.
 
+Inspired by [claude-peers](https://github.com/louislva/claude-peers-mcp) and seeing how it interacted with Claude Code's experimental channel capability. claude-tempo takes the concept further with Temporal as the coordination backbone — adding durable state, cross-machine messaging, structured orchestration, and automatic stale session cleanup.
+
 ## How it works
 
 **claude-tempo** uses Temporal workflows as the coordination layer:
@@ -182,8 +184,8 @@ await conductor.signal('command', {
   source: 'cli',
 });
 
-// Check status
-const status = await conductor.query('status');
+// Check history of commands and reports
+const history = await conductor.query('history');
 ```
 
 You can also connect external channel plugins (e.g., Discord):
@@ -238,6 +240,7 @@ Sessions start with a random 8-character hex ID. Use `set_name` to give a sessio
 - Other players use the name to send messages via `cue` and discover sessions via `ensemble`
 - `recruit` automatically tells the new session to set its name
 - Names must be unique within an ensemble — `set_name` rejects duplicates
+- Names must contain only letters, numbers, hyphens, and underscores
 
 ## Configuration
 
@@ -256,6 +259,16 @@ Sessions start with a random 8-character hex ID. Use `set_name` to give a sessio
 - **Durable history**: Full audit trail of every message in Temporal's event history
 - **No custom infrastructure**: No broker daemon, no database — just Temporal
 - **Extensible**: The conductor's signal/query contract is a public API anyone can build on
+
+## Stale session cleanup
+
+When a Claude Code session crashes or is closed without graceful shutdown, its Temporal workflow detects the problem automatically:
+
+- If a message is sent to a dead session and remains undelivered for **3 minutes**, the workflow self-completes
+- Before exiting, it notifies the conductor with the undelivered message content so work can be reassigned
+- Idle sessions with no pending messages remain running (they aren't hurting anyone) until the 24-hour execution timeout
+
+This means you don't need to manually clean up crashed sessions — just `cue` the dead player and the system handles the rest.
 
 ## Known limitations
 

--- a/src/tools/recruit.ts
+++ b/src/tools/recruit.ts
@@ -34,6 +34,17 @@ export function registerRecruitTool(
         name: string;
         initialMessage?: string;
       };
+      // Validate name to prevent search attribute query injection
+      if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+        return {
+          content: [{
+            type: 'text' as const,
+            text: `Invalid name "${name}". Names must contain only letters, numbers, hyphens, and underscores.`,
+          }],
+          isError: true,
+        };
+      }
+
       try {
         // Check if a session with this name is already active
         const existing = await resolveSession(client, config.ensemble, name);

--- a/src/tools/set-name.ts
+++ b/src/tools/set-name.ts
@@ -23,6 +23,14 @@ export function registerSetNameTool(
     async (args) => {
       const { name } = args as { name: string };
 
+      // Validate name to prevent search attribute query injection
+      if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+        return {
+          content: [{ type: 'text' as const, text: `Invalid name "${name}". Names must contain only letters, numbers, hyphens, and underscores.` }],
+          isError: true,
+        };
+      }
+
       // Check if the name is already taken
       const existing = await resolveSession(client, config.ensemble, name);
       if (existing && existing.workflowId !== handle.workflowId) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -17,6 +17,10 @@ export interface SessionInput {
   part?: string;
   /** Restored from continue-as-new (undelivered only) */
   messages?: Message[];
+  /** Restored from continue-as-new (conductor only) */
+  commandHistory?: Command[];
+  /** Restored from continue-as-new (conductor only) */
+  reportHistory?: PlayerReport[];
   autoSummary?: string;
 }
 
@@ -40,12 +44,6 @@ export interface PlayerReport {
   text: string;
   type: 'result' | 'blocker' | 'question';
   timestamp: string;
-}
-
-export interface ConductorStatus {
-  ensemble: Array<{ playerId: string; part: string }>;
-  activeTasks: string[];
-  lastUpdate: string;
 }
 
 export interface HistoryEntry {

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -5,6 +5,7 @@ import {
   workflowInfo,
   allHandlersFinished,
   upsertSearchAttributes,
+  getExternalWorkflowHandle,
   uuid4,
 } from '@temporalio/workflow';
 
@@ -14,7 +15,6 @@ import {
   Command,
   PlayerReport,
   HistoryEntry,
-  ConductorStatus,
   receiveMessageSignal,
   setPartSignal,
   setNameSignal,
@@ -25,11 +25,12 @@ import {
   pendingMessagesQuery,
   commandSignal,
   playerReportSignal,
-  statusQuery,
   historyQuery,
 } from './signals';
 
 export async function claudeSessionWorkflow(input: SessionInput): Promise<void> {
+  const STALE_MESSAGE_MS = 3 * 60 * 1000; // 3 minutes
+
   // State (carried across continue-as-new)
   let part = input.part ?? input.autoSummary ?? 'No description set';
   const messages: Message[] = input.messages ?? [];
@@ -74,11 +75,14 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
   setHandler(getMetadataQuery, () => input.metadata);
   setHandler(pendingMessagesQuery, () => messages.filter((m) => !m.delivered));
 
+  // ── Conductor State ──
+
+  const commandHistory: Command[] = input.commandHistory ?? [];
+  const reportHistory: PlayerReport[] = input.reportHistory ?? [];
+
   // ── Conductor-specific Handlers ──
 
   if (input.metadata.isConductor) {
-    const commandHistory: Command[] = [];
-    const reportHistory: PlayerReport[] = [];
 
     setHandler(commandSignal, (cmd) => {
       commandHistory.push({
@@ -110,12 +114,6 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
       });
     });
 
-    setHandler(statusQuery, (): ConductorStatus => ({
-      ensemble: [], // Populated by the MCP server via listWorkflows, not the workflow itself
-      activeTasks: [],
-      lastUpdate: new Date().toISOString(),
-    }));
-
     setHandler(historyQuery, (): HistoryEntry[] => {
       const entries: HistoryEntry[] = [
         ...commandHistory.map((c): HistoryEntry => ({
@@ -135,8 +133,22 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
 
   // ── Main Loop ──
 
+  let staleExit = false;
+
   while (!shuttingDown) {
-    await condition(() => shuttingDown, '1 minute');
+    await condition(() => shuttingDown, '5 minutes');
+
+    if (shuttingDown) break;
+
+    // Detect stale session: messages pending longer than threshold means poller is dead
+    const now = Date.now();
+    const staleMessages = messages.filter(
+      (m) => !m.delivered && now - new Date(m.timestamp).getTime() > STALE_MESSAGE_MS,
+    );
+    if (staleMessages.length > 0) {
+      staleExit = true;
+      break;
+    }
 
     // Prevent unbounded history growth
     const info = workflowInfo();
@@ -146,7 +158,25 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
         ...input,
         part,
         messages: messages.filter((m) => !m.delivered),
+        ...(input.metadata.isConductor ? { commandHistory, reportHistory } : {}),
       });
+    }
+  }
+
+  // Notify conductor with undelivered messages before exiting
+  if (staleExit && !input.metadata.isConductor) {
+    try {
+      const undelivered = messages.filter((m) => !m.delivered);
+      const summary = undelivered.map((m) => `  From ${m.from}: ${m.text}`).join('\n');
+      const conductorWfId = `claude-session-${input.metadata.ensemble}-conductor`;
+      const handle = getExternalWorkflowHandle(conductorWfId);
+      await handle.signal(playerReportSignal, {
+        playerId: input.metadata.playerId,
+        text: `Session ended — ${undelivered.length} undelivered message(s):\n${summary}`,
+        type: 'blocker',
+      });
+    } catch {
+      // No conductor running — that's fine
     }
   }
 

--- a/src/workflows/signals.ts
+++ b/src/workflows/signals.ts
@@ -2,7 +2,6 @@ import { defineSignal, defineQuery } from '@temporalio/workflow';
 import type {
   SessionMetadata,
   Message,
-  ConductorStatus,
   HistoryEntry,
 } from '../types';
 
@@ -13,7 +12,6 @@ export type {
   Message,
   Command,
   PlayerReport,
-  ConductorStatus,
   HistoryEntry,
 } from '../types';
 
@@ -38,5 +36,4 @@ export const playerReportSignal = defineSignal<[{ playerId: string; text: string
 
 // ── Conductor Queries ──
 
-export const statusQuery = defineQuery<ConductorStatus>('status');
 export const historyQuery = defineQuery<HistoryEntry[]>('history');


### PR DESCRIPTION
## Summary
- Detect dead sessions by monitoring undelivered messages — if a cued message goes unacknowledged for 3 minutes, the workflow self-completes and notifies the conductor with the lost message content
- Preserve conductor command/report history across continue-as-new (was silently dropped)
- Validate player names in `set_name` and `recruit` to prevent search attribute query injection
- Remove dead `statusQuery` code, reduce main loop timer from 1min to 5min

## Test plan
- [x] Recruited test player, verified message delivery works
- [x] Killed test player terminal, cued it, confirmed workflow self-completed after stale detection
- [x] Confirmed conductor received blocker notification with undelivered message content
- [x] Confirmed invalid names are rejected by `set_name`
- [x] Build passes (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)