### PR TITLE
fix(cli): Windows terminal spawning, npx MCP resolution, and player naming

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,9 +1,0 @@
-{
-  "mcpServers": {
-    "claude-tempo": {
-      "command": "node",
-      "args": ["dist/server.js"],
-      "cwd": "/Users/drewpayment/dev/claude-tempo"
-    }
-  }
-}

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ The `claude-tempo` CLI handles setup, session management, and diagnostics.
 | Command | Description |
 |---------|-------------|
 | `up [ensemble]` | First-time setup: start Temporal, configure MCP, launch conductor |
+| `down` | Stop Temporal, terminate sessions, remove MCP config |
 | `server` | Start the Temporal dev server and register search attributes |
 | `conduct [ensemble]` | Start a conductor session (one per ensemble) |
 | `start [ensemble]` | Start a player session |
@@ -154,7 +155,7 @@ The `claude-tempo` CLI handles setup, session management, and diagnostics.
 
 ```
 --temporal-address <addr>   Temporal server address (default: localhost:7233)
--n, --name <name>           Set the session window name (start/conduct/up)
+-n, --name <name>           Set the player name for the session (start/conduct/up)
 --skip-preflight            Skip preflight checks (start/conduct)
 --background, -d            Run Temporal in background (server only)
 --dir <path>                Target directory for init (default: cwd)
@@ -211,14 +212,14 @@ claude-tempo server -d              # shorthand
 {
   "mcpServers": {
     "claude-tempo": {
-      "command": "claude-tempo-server",
-      "args": []
+      "command": "npx",
+      "args": ["claude-tempo-server"]
     }
   }
 }
 ```
 
-No source code or absolute paths needed — `claude-tempo-server` is installed on PATH via the npm package.
+Uses `npx` to resolve the server binary, so it works regardless of PATH configuration.
 
 ### `status` — ensemble overview
 
@@ -330,13 +331,13 @@ The `recruit` tool and CLI automatically detect and open sessions in your termin
 | Terminal.app | `.command` file | — | — |
 | gnome-terminal | — | `--` flag | — |
 | konsole / xterm | — | `-e` flag | — |
-| cmd.exe / PowerShell | — | — | `shell:true` |
+| cmd.exe / PowerShell | — | — | `start` command |
 
 All macOS terminals use approaches that preserve the user's full shell environment (fish, zsh, bash) including node version managers (fnm, nvm).
 
 ### Session naming
 
-Sessions start with a random 8-character hex ID. Use `set_name` to give a session a human-readable name:
+Sessions start with a random 8-character hex ID. You can set a name at launch with `-n` or use `set_name` inside a session:
 
 - Names are stored as Temporal search attributes (`ClaudeTempoPlayerId`) and updated in-place — no workflow restart needed
 - Other players use the name to send messages via `cue` and discover sessions via `ensemble`
@@ -353,6 +354,7 @@ Sessions start with a random 8-character hex ID. Use `set_name` to give a sessio
 | `CLAUDE_TEMPO_TASK_QUEUE` | `claude-tempo` | Task queue name |
 | `CLAUDE_TEMPO_ENSEMBLE` | `default` | Ensemble name (isolates groups of players) |
 | `CLAUDE_TEMPO_CONDUCTOR` | `false` | Set to `true` to enable conductor mode |
+| `CLAUDE_TEMPO_PLAYER_NAME` | *(random hex)* | Set a player name on startup (used by `-n` flag) |
 
 ## Development
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-tempo",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-tempo",
-      "version": "0.1.0",
+      "version": "0.1.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "type": "commonjs",
   "main": "dist/server.js",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -4,6 +4,7 @@ import { execFileSync, spawn as cpSpawn, ChildProcess } from 'child_process';
 import { homedir } from 'os';
 import { Connection, Client } from '@temporalio/client';
 import { spawnInTerminal } from '../spawn';
+import { conductorWorkflowId } from '../config';
 import { runPreflight } from './preflight';
 import * as out from './output';
 
@@ -34,6 +35,24 @@ export async function start(opts: StartOpts) {
   }
 
   const role = opts.conductor ? 'conductor' : 'player';
+
+  // Check if a conductor workflow already exists for this ensemble
+  if (opts.conductor) {
+    try {
+      const connection = await Connection.connect({ address: opts.temporalAddress });
+      const client = new Client({ connection });
+      const conductorWfId = conductorWorkflowId(opts.ensemble);
+      const handle = client.workflow.getHandle(conductorWfId);
+      const desc = await handle.describe();
+      if (desc.status.name === 'RUNNING') {
+        out.warn(`A conductor workflow already exists for ensemble "${opts.ensemble}". Reconnecting...`);
+      }
+      await connection.close();
+    } catch {
+      // No existing conductor — proceed normally
+    }
+  }
+
   out.log(`Starting ${out.bold(role)} in ensemble ${out.cyan(opts.ensemble)}`);
 
   const claudeArgs = [
@@ -49,6 +68,9 @@ export async function start(opts: StartOpts) {
   };
   if (opts.conductor) {
     envVars.CLAUDE_TEMPO_CONDUCTOR = 'true';
+  }
+  if (opts.name) {
+    envVars.CLAUDE_TEMPO_PLAYER_NAME = opts.name;
   }
 
   const { pid } = spawnInTerminal(claudeArgs, workDir, envVars);
@@ -167,8 +189,8 @@ export async function init(opts: InitOpts) {
   const mcpPath = join(opts.dir, '.mcp.json');
 
   const entry = {
-    command: 'claude-tempo-server',
-    args: [] as string[],
+    command: 'npx',
+    args: ['claude-tempo-server'],
   };
 
   if (existsSync(mcpPath)) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -57,7 +57,7 @@ async function main() {
 
   const config = getConfig();
   const isConductor = process.env.CLAUDE_TEMPO_CONDUCTOR === 'true';
-  let playerId = isConductor ? 'conductor' : crypto.randomBytes(4).toString('hex');
+  let playerId = isConductor ? 'conductor' : (process.env.CLAUDE_TEMPO_PLAYER_NAME || crypto.randomBytes(4).toString('hex'));
   const getPlayerId = () => playerId;
   const setPlayerId = (id: string) => { playerId = id; };
   const workDir = process.cwd();

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -177,11 +177,12 @@ export function spawnInTerminal(
   }
 
   if (process.platform === 'win32') {
-    const child = spawn(claudeBin, claudeArgs, {
+    // Use 'start' to open a visible terminal window, and pass the full
+    // command as a single string to avoid DEP0190 deprecation warning
+    const child = spawn('cmd.exe', ['/c', 'start', '""', claudeBin, ...claudeArgs], {
       cwd: workDir,
       detached: true,
       stdio: 'ignore',
-      shell: true,
       env: { ...process.env, ...envVars },
     });
     child.unref();


### PR DESCRIPTION
## Summary
- **Windows spawn fix**: Use `start` command to open visible terminal windows (replaces broken `shell: true` removal and avoids DEP0190 deprecation warning)
- **MCP resolution**: Use `npx claude-tempo-server` in `.mcp.json` instead of bare `claude-tempo-server` for reliable cross-platform resolution
- **Player naming**: Add `CLAUDE_TEMPO_PLAYER_NAME` env var so `-n` flag sets the player name in the ensemble at startup
- **Conductor reconnect**: Warn (don't block) when a conductor workflow already exists, preserving undelivered messages
- **Docs**: Add `down` command to README, update `.mcp.json` example, document new env var

## Test plan
- [x] `claude-tempo up` opens visible conductor terminal on Windows
- [x] `claude-tempo start <ensemble> -n <name>` sets player name
- [x] `claude-tempo conduct` shows warning when conductor already exists
- [x] `claude-tempo status` shows sessions correctly
- [x] `claude-tempo down` terminates sessions
- [x] Published as v0.1.2 to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)