### PR TITLE
fix(package): add package.json and workflow-bundle to exports map

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "repository": {
     "type": "git",
@@ -25,7 +25,9 @@
     "./signals": {
       "types": "./dist/workflows/signals.d.ts",
       "default": "./dist/workflows/signals.js"
-    }
+    },
+    "./workflow-bundle": "./workflow-bundle.js",
+    "./package.json": "./package.json"
   },
   "bin": {
     "claude-tempo": "dist/cli.js",


### PR DESCRIPTION
## Summary
- Add `"./package.json": "./package.json"` to exports so consumers can `require.resolve('claude-tempo/package.json')` to find the package root
- Add `"./workflow-bundle": "./workflow-bundle.js"` so consumers can `require.resolve('claude-tempo/workflow-bundle')` instead of fragile relative path hacks
- Bump version to 0.2.2

Fixes maestro's `temporal-client.ts` failing to resolve `claude-tempo/package.json`.

## Test plan
- [x] `npm run build` passes
- [x] `require.resolve('./workflow-bundle.js')` resolves correctly
- [x] `require('./package.json')` returns correct name/version

🤖 Generated with [Claude Code](https://claude.com/claude-code)