### PR TITLE
feat(cli): add --agent support to up command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -126,6 +126,7 @@ async function main() {
         ensemble,
         temporalAddress: args.temporalAddress,
         name: args.name,
+        agent: args.agent ?? 'claude',
       });
       break;
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -384,6 +384,7 @@ interface UpOpts {
   ensemble: string;
   temporalAddress: string;
   name?: string;
+  agent: AgentType;
 }
 
 export async function up(opts: UpOpts) {
@@ -447,17 +448,29 @@ export async function up(opts: UpOpts) {
 
   // Step 5: Launch conductor
   console.log();
-  out.log(`Launching conductor in ensemble ${out.cyan(opts.ensemble)}...`);
-  const claudeArgs = [
-    '--dangerously-skip-permissions',
-    '--dangerously-load-development-channels', 'server:claude-tempo',
-  ];
-  if (opts.name) claudeArgs.push('-n', opts.name);
+  out.log(`Launching conductor in ensemble ${out.cyan(opts.ensemble)}${opts.agent === 'copilot' ? out.dim(' (copilot)') : ''}...`);
 
-  const { pid } = spawnInTerminal(claudeArgs, process.cwd(), {
-    [ENV.ENSEMBLE]: opts.ensemble,
-    [ENV.CONDUCTOR]: 'true',
-  });
+  let pid: number | undefined;
+  if (opts.agent === 'copilot') {
+    ({ pid } = spawnCopilotBridge({
+      name: opts.name || `${opts.ensemble}-conductor`,
+      ensemble: opts.ensemble,
+      temporalAddress: opts.temporalAddress,
+      isConductor: true,
+      workDir: process.cwd(),
+    }));
+  } else {
+    const claudeArgs = [
+      '--dangerously-skip-permissions',
+      '--dangerously-load-development-channels', 'server:claude-tempo',
+    ];
+    if (opts.name) claudeArgs.push('-n', opts.name);
+
+    ({ pid } = spawnInTerminal(claudeArgs, process.cwd(), {
+      [ENV.ENSEMBLE]: opts.ensemble,
+      [ENV.CONDUCTOR]: 'true',
+    }));
+  }
 
   console.log();
   out.success('You\'re all set!');


### PR DESCRIPTION
## Summary
- Add `agent` field to `UpOpts` (type `AgentType`, default `'claude'`)
- Branch on agent type in Step 5: `'copilot'` uses `spawnCopilotBridge()`, `'claude'` uses existing `spawnInTerminal()` path
- Pass `args.agent` through from CLI parser in `src/cli.ts`
- Enables `claude-tempo up default --agent copilot` on machines without Claude Code

## Test plan
- [x] `npm run build` passes
- [ ] `claude-tempo up` still spawns Claude Code conductor (default behavior unchanged)
- [ ] `claude-tempo up default --agent copilot` spawns copilot bridge conductor

🤖 Generated with [Claude Code](https://claude.com/claude-code)