### PR TITLE
fix(copilot): strengthen system prompt and exclude shell tools

### DIFF
--- a/src/copilot-bridge.ts
+++ b/src/copilot-bridge.ts
@@ -154,15 +154,19 @@ async function main() {
     systemMessage: {
       mode: 'append' as const,
       content:
-        `You are part of the "${config.ensemble}" ensemble of Claude Code sessions coordinated via Temporal. ` +
-        `IMPORTANT: If you receive a message instructing you to call \`set_name\`, do so immediately before anything else. ` +
-        `When you receive a message from another session, treat it like a coworker asking for help — respond promptly, then resume your work. ` +
-        `Use \`set_name\` to give yourself a human-readable name. ` +
-        `Use \`ensemble\` to see who else is active. ` +
-        `Use \`cue\` to reply directly to the player who messaged you, or to ask others for help. ` +
-        `Use \`recruit\` if you need a session in a directory where none exists. ` +
-        `Use \`report\` to notify the conductor of task completion, blockers, or questions — always report when you finish a recruited task.`,
+        `You are part of the "${config.ensemble}" ensemble coordinated via Temporal. ` +
+        `You have MCP tools available — ALWAYS use these tools directly, NEVER try to run them as shell commands:\n` +
+        `- set_name: Set your player name (call this FIRST if instructed)\n` +
+        `- ensemble: List active sessions\n` +
+        `- cue: Send a message to another player\n` +
+        `- set_part: Update your status/description\n` +
+        `- listen: Check for pending messages\n` +
+        `- recruit: Spawn a new player session\n` +
+        `- report: Report to the conductor\n` +
+        `- terminate: Terminate a session\n\n` +
+        `When you receive a message from another session, treat it like a coworker asking for help — respond promptly using your MCP tools.`,
     },
+    excludedTools: ['powershell', 'shell'],
     ...(model ? { model } : {}),
   };
 


### PR DESCRIPTION
## Summary
- Rewrite Copilot bridge system message to explicitly list all MCP tools and instruct the agent to use them directly, never as shell commands
- Add `excludedTools: ['powershell', 'shell']` to session config to prevent the agent from using native shell tools that compete with MCP tools (keeps `grep`, `read`, `write` available for file work)

Fixes issue where Copilot agent would try to run MCP tool names as shell commands via `powershell` instead of calling the actual MCP tools.

## Test plan
- [x] `npm run build` passes
- [ ] Copilot bridge session uses MCP `ensemble` tool instead of trying `powershell ensemble`
- [ ] File operations (grep, read, write) still work for actual code tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)