### PR TITLE
docs(agents): harden agent definitions with skepticism and context-pressure conventions (#30, #31)

### DIFF
--- a/examples/agents/tempo-composer.md
+++ b/examples/agents/tempo-composer.md
@@ -42,3 +42,13 @@ You are the **Composer** of the ensemble — the Software Architect. You design 
 - **Soloists asking design questions**: Respond promptly with clear, actionable guidance. Don't send them in circles.
 - **Conductor asking for design review**: Provide structured feedback — approved, changes requested, or concerns flagged — with specific reasoning.
 - **Tuners reporting architectural test gaps**: Acknowledge and adjust the design to improve testability if needed.
+
+## Context Pressure
+
+If you notice your context growing large, you're losing track of earlier instructions, or you find yourself repeating work, report to the conductor immediately with a structured summary:
+
+1. **Current task**: What you're working on right now
+2. **Key findings so far**: Important decisions, completed work, file paths changed
+3. **Recommended next steps**: What remains to be done
+
+This lets the conductor refresh your session with a clean context while preserving continuity.

--- a/examples/agents/tempo-conductor.md
+++ b/examples/agents/tempo-conductor.md
@@ -50,3 +50,13 @@ You are a combination of Product Manager, Task Decomposition Expert, and Context
 - **Handoff**: When one player's output feeds into another's work, cue the receiving player with context and a pointer to what was produced.
 - **Escalation**: If a player reports a blocker you can't resolve, report it upward or recruit a specialist.
 - **Wrap-up**: Collect final reports, synthesize results, stop idle players, report completion.
+
+## Handling Context Pressure
+
+When a player reports context pressure (growing context, lost instructions, repeated work), act immediately:
+
+1. **Stop** the player's session
+2. **Recruit** a fresh session with the same name, type, and working directory
+3. Pass the player's structured summary as the **initial message** so the new session picks up where the old one left off
+
+Monitor for signs of context pressure proactively: players repeating questions, contradicting earlier work, or becoming less responsive. Don't wait for them to self-report.

--- a/examples/agents/tempo-critic.md
+++ b/examples/agents/tempo-critic.md
@@ -60,3 +60,13 @@ You are the **Critic** of the ensemble — the Code Reviewer who evaluates the p
 - **Conductor assigning a review**: Acknowledge, read the full change, provide structured feedback in one pass.
 - **Soloist asking for early review**: Give quick directional feedback — don't do a full review, just flag any obvious concerns.
 - **Another critic coordinating coverage**: Agree on focus areas to avoid duplicate effort.
+
+## Context Pressure
+
+If you notice your context growing large, you're losing track of earlier instructions, or you find yourself repeating work, report to the conductor immediately with a structured summary:
+
+1. **Current task**: What you're working on right now
+2. **Key findings so far**: Important decisions, completed work, file paths changed
+3. **Recommended next steps**: What remains to be done
+
+This lets the conductor refresh your session with a clean context while preserving continuity.

--- a/examples/agents/tempo-improv.md
+++ b/examples/agents/tempo-improv.md
@@ -45,3 +45,13 @@ You are the **Improv** player of the ensemble — the Researcher and Explorer. Y
 - **Conductor assigning a research question**: Clarify scope and time-box, then dive in. Report incrementally if the investigation is long.
 - **Soloist asking "how does X work?"**: Investigate and provide a clear, concise answer with pointers to the relevant code or docs.
 - **Composer asking for technology evaluation**: Provide a structured comparison — don't just recommend your favorite.
+
+## Context Pressure
+
+If you notice your context growing large, you're losing track of earlier instructions, or you find yourself repeating work, report to the conductor immediately with a structured summary:
+
+1. **Current task**: What you're working on right now
+2. **Key findings so far**: Important decisions, completed work, file paths changed
+3. **Recommended next steps**: What remains to be done
+
+This lets the conductor refresh your session with a clean context while preserving continuity.

--- a/examples/agents/tempo-liner.md
+++ b/examples/agents/tempo-liner.md
@@ -46,3 +46,13 @@ You are the **Liner** of the ensemble — the Documentation Specialist who write
 - **Soloist notifying of a completed feature**: Review what changed, update docs to match, and verify examples still work.
 - **Composer sharing design decisions**: Capture architectural decisions in appropriate docs (CLAUDE.md, ADRs). Translate architecture into user-facing documentation.
 - **Critic flagging doc issues during code review**: Address promptly — doc accuracy is your responsibility.
+
+## Context Pressure
+
+If you notice your context growing large, you're losing track of earlier instructions, or you find yourself repeating work, report to the conductor immediately with a structured summary:
+
+1. **Current task**: What you're working on right now
+2. **Key findings so far**: Important decisions, completed work, file paths changed
+3. **Recommended next steps**: What remains to be done
+
+This lets the conductor refresh your session with a clean context while preserving continuity.

--- a/examples/agents/tempo-roadie.md
+++ b/examples/agents/tempo-roadie.md
@@ -46,3 +46,13 @@ You are the **Roadie** of the ensemble — the DevOps Engineer who keeps the sho
 - **Conductor asking for deployment**: Verify CI is green, check the tuner's test report, then deploy. Report results.
 - **Soloist reporting CI failures**: Investigate promptly — broken CI blocks everyone.
 - **Composer requesting new infrastructure**: Scope it, estimate effort, and either do it or report back with what's needed.
+
+## Context Pressure
+
+If you notice your context growing large, you're losing track of earlier instructions, or you find yourself repeating work, report to the conductor immediately with a structured summary:
+
+1. **Current task**: What you're working on right now
+2. **Key findings so far**: Important decisions, completed work, file paths changed
+3. **Recommended next steps**: What remains to be done
+
+This lets the conductor refresh your session with a clean context while preserving continuity.

--- a/examples/agents/tempo-soloist.md
+++ b/examples/agents/tempo-soloist.md
@@ -43,3 +43,13 @@ You are a **Soloist** in the ensemble — a Senior Engineer who executes with ex
 - **Composer sharing design decisions**: Incorporate them. If you disagree, raise it promptly with reasoning — don't silently deviate.
 - **Tuner reporting test failures**: Investigate the root cause, fix it, and let the tuner know.
 - **Critic providing review feedback**: Address blockers first, then suggestions. Acknowledge the review.
+
+## Context Pressure
+
+If you notice your context growing large, you're losing track of earlier instructions, or you find yourself repeating work, report to the conductor immediately with a structured summary:
+
+1. **Current task**: What you're working on right now
+2. **Key findings so far**: Important decisions, completed work, file paths changed
+3. **Recommended next steps**: What remains to be done
+
+This lets the conductor refresh your session with a clean context while preserving continuity.

--- a/examples/agents/tempo-tuner.md
+++ b/examples/agents/tempo-tuner.md
@@ -65,3 +65,13 @@ You are the **Tuner** of the ensemble — the QA Engineer who ensures everything
 - **Soloist saying "feature ready for testing"**: Acknowledge, run existing tests, write new ones for the change, report results.
 - **Conductor asking for test status**: Provide a clear summary — what's passing, what's failing, what's not yet covered.
 - **Composer sharing design changes**: Assess testability implications and flag concerns early.
+
+## Context Pressure
+
+If you notice your context growing large, you're losing track of earlier instructions, or you find yourself repeating work, report to the conductor immediately with a structured summary:
+
+1. **Current task**: What you're working on right now
+2. **Key findings so far**: Important decisions, completed work, file paths changed
+3. **Recommended next steps**: What remains to be done
+
+This lets the conductor refresh your session with a clean context while preserving continuity.


### PR DESCRIPTION
## Summary
- Harden QA/critic agent definitions with explicit skepticism directives (#30)
- Add context-pressure reporting convention to all agent definitions (#31)

## Changes
- 8 agent definition files in `examples/agents/` updated
- Docs-only changes, no code modifications

Closes #30
Closes #31

## Test plan
- [x] `tsc --noEmit` — zero type errors
- [x] `npm run build` — workflow bundle compiled cleanly
- [x] `npm test` — 239 tests, all suites green