### PR TITLE
fix(ensemble): respect custom conductor names from lineup (#39)

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -685,7 +685,7 @@ export async function up(opts: UpOpts) {
     }));
   } else {
     // Default conductor name so the Claude Code session name matches the ensemble role
-    const sessionName = opts.name || 'conductor';
+    const sessionName = opts.name || lineup?.conductor?.name || 'conductor';
 
     // Resolve conductor agent type from lineup
     const conductorType = lineup?.conductor?.agent && lineup.conductor.agent !== 'default' && lineup.conductor.agent !== 'copilot'

--- a/src/ensemble/loader.ts
+++ b/src/ensemble/loader.ts
@@ -55,6 +55,16 @@ export function loadLineup(filePath: string): EnsembleLineup {
     }
   }
 
+  // Validate conductor name if present
+  if (doc.conductor?.name != null) {
+    if (typeof doc.conductor.name !== 'string' || !doc.conductor.name) {
+      throw new Error(`Invalid lineup: conductor.name must be a non-empty string`);
+    }
+    if (!/^[a-zA-Z0-9_-]+$/.test(doc.conductor.name)) {
+      throw new Error(`Invalid lineup: conductor.name "${doc.conductor.name}" contains invalid characters`);
+    }
+  }
+
   return {
     name: doc.name,
     description: doc.description,

--- a/src/ensemble/saver.ts
+++ b/src/ensemble/saver.ts
@@ -44,7 +44,10 @@ export async function saveLineup(
       const workDir = (meta.workDir as string) || undefined;
 
       if (isConductor) {
+        const conductorName = (meta.playerId as string) || undefined;
         conductor = {
+          // Only save name if it's not the default 'conductor'
+          ...(conductorName && conductorName !== 'conductor' ? { name: conductorName } : {}),
           agent: agentType === 'copilot' ? 'copilot' : undefined,
         };
       } else {

--- a/src/ensemble/schema.ts
+++ b/src/ensemble/schema.ts
@@ -4,6 +4,7 @@ export interface EnsembleLineup {
   name: string;
   description?: string;
   conductor?: {
+    name?: string;        // custom conductor name (defaults to "conductor")
     type?: string;        // agent definition name (e.g., "tempo-conductor")
     agent?: string;       // "default", "copilot", or path to agent .md file
     instructions?: string; // natural language instructions sent as initialMessage

--- a/src/server.ts
+++ b/src/server.ts
@@ -52,10 +52,11 @@ async function main() {
   const config = getConfig();
   const isConductor = process.env[ENV.CONDUCTOR] === 'true';
   const requestedName = process.env[ENV.PLAYER_NAME] || '';
-  // Prevent non-conductor sessions from using "conductor" as a name,
+  // Conductors use their requested name or fall back to 'conductor'.
+  // Non-conductors are prevented from using "conductor" as a name,
   // which would collide with the conductor's deterministic workflow ID.
   let playerId = isConductor
-    ? 'conductor'
+    ? (requestedName || 'conductor')
     : (requestedName && requestedName !== 'conductor' ? requestedName : '') || crypto.randomBytes(4).toString('hex');
   const getPlayerId = () => playerId;
   const setPlayerId = (id: string) => { playerId = id; };
@@ -212,7 +213,7 @@ async function main() {
   }
 
   // Create MCP server
-  const hasRequestedName = Boolean(requestedName && requestedName !== 'conductor');
+  const hasRequestedName = isConductor || Boolean(requestedName && requestedName !== 'conductor');
   const playerTypeLine = playerType
     ? `Your player type is "${playerType}"${playerTypeDescription ? ` (${playerTypeDescription})` : ''}. `
     : '';

--- a/test/ensemble.test.ts
+++ b/test/ensemble.test.ts
@@ -148,6 +148,22 @@ players:
       expect(() => loadLineup(filePath)).to.throw('players[0].name is required');
     });
 
+    it('accepts lineup with custom conductor name', function () {
+      const filePath = join(tmpDir, 'custom-conductor-name.yaml');
+      writeFileSync(filePath, `name: test\nconductor:\n  name: maestro\nplayers:\n  - name: p1\n`);
+
+      const lineup = loadLineup(filePath);
+      expect(lineup.conductor).to.exist;
+      expect(lineup.conductor!.name).to.equal('maestro');
+    });
+
+    it('rejects lineup with invalid conductor name', function () {
+      const filePath = join(tmpDir, 'bad-conductor-name.yaml');
+      writeFileSync(filePath, `name: test\nconductor:\n  name: "bad name!"\nplayers:\n  - name: p1\n`);
+
+      expect(() => loadLineup(filePath)).to.throw('conductor.name');
+    });
+
     it('rejects schedule missing timing fields', function () {
       const filePath = join(tmpDir, 'bad-schedule.yaml');
       writeFileSync(filePath, `name: test\nplayers:\n  - name: p1\nschedules:\n  - name: sched\n    message: hello\n    target: p1\n`);

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -479,6 +479,37 @@ describe('multi-session integration', function () {
       });
     });
 
+    it('conductor respects custom name from metadata', async function () {
+      const ensemble = 'custom-cond-name';
+      await withWorker(async () => {
+        // Start a conductor with a custom name (simulates lineup conductor.name)
+        const hCond = await startSession({
+          metadata: conductorMetadata({ playerId: 'maestro', ensemble }),
+        });
+
+        const hPlayer = await startSession({
+          metadata: playerMetadata({ playerId: 'worker-1', ensemble }),
+        });
+
+        const members = await waitForEnsembleMembers(getClient(), ensemble, 2);
+        expect(members).to.have.lengthOf(2);
+
+        // Conductor should have the custom name, not default 'conductor'
+        const cond = members.find((m) => m.isConductor);
+        expect(cond).to.exist;
+        expect(cond!.playerId).to.equal('maestro');
+
+        // Should be resolvable by custom name
+        expect(await resolveByName(getClient(), ensemble, 'maestro')).to.not.be.null;
+        // Should NOT be resolvable by default 'conductor' name
+        expect(await resolveByName(getClient(), ensemble, 'conductor')).to.be.null;
+
+        await hCond.signal(updateMetadataSignal, { status: 'terminated' });
+        await hPlayer.signal(updateMetadataSignal, { status: 'terminated' });
+        await Promise.all([hCond.result(), hPlayer.result()]);
+      });
+    });
+
     it('conductor and players survive conductor rename', async function () {
       const ensemble = 'cond-rename-survive';
       await withWorker(async () => {


### PR DESCRIPTION
## Summary
- Fixed 4 locations that hardcoded `'conductor'` as the player name, ignoring lineup and CLI overrides
- Conductor name now flows correctly through the full chain: `schema → loader → CLI → server`
- Fixed latent bug where default conductors were unnecessarily prompted to call `set_name`
- Added 3 new tests covering custom conductor name propagation

## Changes
- `src/ensemble/schema.ts` — conductor name field added to schema
- `src/ensemble/loader.ts` — passes conductor name through instead of hardcoding
- `src/ensemble/saver.ts` — preserves custom conductor name when saving lineup state
- `src/cli/commands.ts` — CLI respects conductor name from lineup/flag
- `src/server.ts` — server uses resolved conductor name, not literal `'conductor'`
- `test/ensemble.test.ts` + `test/integration.test.ts` — 3 new tests (251 total, all passing)

## Test Plan
- [x] 251 tests pass (QA verified)
- [x] Build clean
- [x] Type check clean

## Issues Closed
- Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)