### PR TITLE
feat(tools): standalone worktree conductor tool (#36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Worktree isolation** — Lineup players now support `isolation: worktree` (with a required `branch` field). When set, `load_lineup` auto-creates a git worktree at a temp path and runs `npm install` before recruiting. Uses `execFileSync` with args arrays to prevent shell injection. `worktreePath` flows through session metadata and is documented in the wire protocol (#36)
+- **`worktree` MCP tool** — Conductors can provision isolated git worktrees for players. `create` checks out a new branch in a sibling directory, installs dependencies, and notifies the player with the path; `remove` cleans up the worktree after the task completes and notifies the player; `list` shows all active worktree assignments. Worktree state is stored in the conductor workflow (`WorktreeEntry`) and survives `continueAsNew`. Cross-machine worktrees are not supported — conductor and player must be on the same host (#36).
 
 ### Fixed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,9 +65,13 @@ src/
 │   ├── quality-gate.ts # Define quality gates for tasks (conductor only)
 │   ├── evaluate-gate.ts # Mark gate criteria as passed/failed (conductor only)
 │   ├── gates.ts       # List quality gates and their status (conductor only)
+│   ├── worktree.ts    # Manage git worktrees for player isolation (conductor only)
 │   └── helpers.ts     # Zod/MCP tool registration wrapper
 ├── utils/
-│   └── validation.ts  # Shared validation constants (name/message/path limits, encore defaults) and helpers
+│   ├── validation.ts  # Shared validation constants (name/message/path limits, encore defaults) and helpers
+│   ├── worktree.ts    # Git worktree create/remove helpers (cross-platform)
+│   ├── safe-path.ts   # Path safety utilities
+│   └── duration.ts    # Duration parsing helpers
 ├── types.ts           # Shared type definitions
 ├── channel.ts         # Claude channel notification helper
 ├── git-info.ts        # Git repository detection helper
@@ -120,6 +124,7 @@ npm test
 - **Schedule**: A one-shot or recurring message delivery configured via the `schedule` tool. Backed by a durable `claudeSchedulerWorkflow` — survives restarts. Supports delay (`delay`), fixed time (`at`), recurring interval (`every`), and cron expressions (`cron`) with optional IANA timezone (`timezone`). Cron schedules use `croner` for expression parsing and next-fire computation. Managed via `schedule`, `unschedule`, and `schedules` tools.
 - **Lineup**: A YAML file defining an ensemble configuration — which players to recruit, their types, working directories, and optional startup messages. Load via `load_lineup` to bootstrap a full ensemble in one step; save via `save_lineup` to snapshot a running ensemble's state for later reuse.
 - **Quality Gate**: A named checklist of criteria a conductor tracks to verify a task is complete. Created via `quality_gate` (conductor only), evaluated via `evaluate_gate`, and listed via `gates`. Each criterion has a `pending` → `passed` | `failed` status; the gate's aggregate status is derived automatically (all passed → `passed`, any failed → `failed`, else `open`). Gates are stored in the conductor workflow and survive `continueAsNew`.
+- **Worktree**: A git worktree provisioned by the conductor for a player, giving them an isolated checkout on a separate branch. Managed via the `worktree` tool (conductor only): `create` provisions the worktree and notifies the player, `remove` cleans up after the task, `list` shows all active worktrees. Worktree assignments are stored in the conductor workflow (`WorktreeEntry` records: player, path, branch, gitRoot, createdAt, createdBy).
 - **Wire protocol**: All Temporal signal, query, update, and workflow names are documented in [`docs/WIRE-PROTOCOL.md`](docs/WIRE-PROTOCOL.md). These names are stable as of v0.10 — renaming or removing any is a breaking change requiring a major version bump.
 
 ## Dashboard

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ These tools are available inside Claude Code sessions connected to claude-tempo:
 | `broadcast` | Send a message to all active players. Optional `type` filter limits to a specific player type. |
 | `encore` | Revive a stale player session — restarts the process and reconnects to the existing workflow with context restored. |
 | `recall` | Read your own message history. Shows received messages by default; pass `includeSent: true` for the full timeline. |
+| `worktree` | Manage git worktrees for player isolation. Actions: `create`, `remove`, `list`. Conductor only. |
 | `quality_gate` | Define or replace a quality gate for a task — a named checklist of criteria that must pass. Conductor only. |
 | `evaluate_gate` | Mark one or more criteria on a quality gate as passed or failed. Conductor only. |
 | `gates` | List quality gates and their status. Filter by task name or status (`open`, `passed`, `failed`). Conductor only. |

--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -75,6 +75,8 @@ Conductor-specific signals, only registered when `input.metadata.isConductor` is
 | `playerReport` | `{ playerId: string; text: string; type: 'result' \| 'blocker' \| 'question' }` | Delivers a report from a player to the conductor. Appended to `reportHistory` and injected into the conductor's inbox. |
 | `setQualityGate` | `{ task: string; criteria: string[]; createdBy: string }` | Defines or replaces a quality gate for the given task. Each criterion starts as `'pending'`. If a gate with the same `task` already exists, it is fully replaced. |
 | `evaluateGateCriteria` | `{ task: string; evaluations: Array<{ index: number; status: 'passed' \| 'failed'; notes?: string }>; evaluatedBy: string }` | Marks one or more criteria on an existing quality gate as `'passed'` or `'failed'`. Out-of-bounds indices are silently ignored. Gate aggregate status is re-derived after each evaluation. |
+| `setWorktree` | `WorktreeEntry` | Records a worktree assignment for a player. `WorktreeEntry` has fields: `player`, `path`, `branch`, `gitRoot`, `createdAt`, `createdBy`. Upserts by player name. |
+| `removeWorktree` | `string` | Removes a worktree entry by player name. |
 
 ---
 
@@ -84,6 +86,7 @@ Conductor-specific signals, only registered when `input.metadata.isConductor` is
 |------------|-------------|-------------|
 | `history` | `HistoryEntry[]` | Returns the conductor's combined command + report history, sorted chronologically. Each entry has a `type` (`'command'` or `'report'`) and a `timestamp`. |
 | `qualityGates` | `QualityGate[]` | Returns all quality gates. Each gate has a `task` key, `criteria` array, `createdBy`, `createdAt`, and a derived `status` (`'open'`, `'passed'`, or `'failed'`). |
+| `worktrees` | `WorktreeEntry[]` | Returns all active worktree assignments. Each entry has `player`, `path`, `branch`, `gitRoot`, `createdAt`, and `createdBy`. |
 
 ---
 
@@ -143,6 +146,17 @@ Types referenced above are defined in `src/types.ts` and re-exported from `src/w
 | `createdBy` | `string` | Player ID of the conductor that created the gate. |
 | `createdAt` | `string` | ISO timestamp of gate creation. |
 | `status` | `'open' \| 'passed' \| 'failed'` | Derived: all criteria passed → `'passed'`; any failed → `'failed'`; otherwise `'open'`. |
+
+### `WorktreeEntry`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `player` | `string` | Player name assigned to this worktree. Used as the upsert key. |
+| `path` | `string` | Absolute path to the worktree directory. |
+| `branch` | `string` | Git branch checked out in the worktree. |
+| `gitRoot` | `string` | Absolute path to the original git root (used by `git worktree remove`). |
+| `createdAt` | `string` | ISO timestamp of worktree creation. |
+| `createdBy` | `string` | Player ID of the conductor that created the worktree. |
 
 ### `RecruitOutboxEntry` (selected fields)
 

--- a/examples/agents/tempo-conductor.md
+++ b/examples/agents/tempo-conductor.md
@@ -53,7 +53,7 @@ You are a combination of Product Manager, Task Decomposition Expert, and Context
 
 ## Worktree Coordination
 
-Use git worktrees when two or more engineers need to work in the same repo on different branches simultaneously. Each worktree is an independent checkout — players can build, test, and commit without interfering with each other.
+Use the `worktree` tool to give players isolated git checkouts when two or more engineers need to work in the same repo on different branches simultaneously. Each worktree is an independent checkout — players can build, test, and commit without interfering with each other.
 
 ### When to use
 
@@ -63,28 +63,16 @@ Use git worktrees when two or more engineers need to work in the same repo on di
 
 ### How to coordinate
 
-1. **Create the worktree** (you or a player with shell access):
-   ```
-   git worktree add ../ct-{task} {branch}
-   ```
-2. **Install dependencies** in the new worktree:
-   ```
-   cd ../ct-{task} && npm install
-   ```
-3. **Recruit with `workDir`** pointing to the worktree:
-   ```
-   recruit({ name: "eng-33", workDir: "../ct-{task}", ... })
-   ```
-4. **Clean up** after the task: stop the player first, then remove the worktree:
-   ```
-   git worktree remove ../ct-{task}
-   ```
+1. **Create**: `worktree({ action: "create", player: "eng-33" })` — provisions the worktree, installs dependencies, and notifies the player with the path and branch.
+2. **Work**: the player receives a cue with their worktree path and branch. They commit and push as normal.
+3. **Remove**: `worktree({ action: "remove", player: "eng-33" })` — cleans up the worktree and notifies the player. Stop the player session first on Windows (NTFS locks).
+4. **List**: `worktree({ action: "list" })` — shows all active worktree assignments.
 
-`recruit` already accepts `workDir` — no new tools are needed for manual worktree coordination.
+By default, `create` names the branch `{ensemble}/{player-name}`. Pass `branch` to override.
 
 ### Platform notes
 
-- **Windows**: Use short sibling paths (e.g. `../ct-feat33`) to avoid MAX_PATH limits. Always stop players before removing worktrees — NTFS file locks will block cleanup while a session is active.
+- **Windows**: Worktrees are placed in short sibling directories (e.g. `../ct-feat33`) to avoid MAX_PATH limits. Stop the player session before calling `remove` — NTFS file locks will block cleanup while a session is active.
 
 ## Handling Context Pressure
 

--- a/src/ensemble/loader.ts
+++ b/src/ensemble/loader.ts
@@ -31,12 +31,6 @@ export function loadLineup(filePath: string): EnsembleLineup {
     if (!/^[a-zA-Z0-9_-]+$/.test(p.name)) {
       throw new Error(`Invalid lineup: players[${i}].name "${p.name}" contains invalid characters`);
     }
-    if (p.isolation != null && p.isolation !== 'worktree') {
-      throw new Error(`Invalid lineup: players[${i}].isolation must be "worktree" if specified`);
-    }
-    if (p.branch != null && (typeof p.branch !== 'string' || !p.branch)) {
-      throw new Error(`Invalid lineup: players[${i}].branch must be a non-empty string`);
-    }
   }
 
   // Validate schedules if present
@@ -82,8 +76,6 @@ export function loadLineup(filePath: string): EnsembleLineup {
       ...(p.agent != null && { agent: p.agent }),
       ...(p.instructions != null && { instructions: p.instructions }),
       ...(Array.isArray(p.allowedTools) && { allowedTools: p.allowedTools.map(String) }),
-      ...(p.isolation != null && { isolation: p.isolation }),
-      ...(p.branch != null && { branch: p.branch }),
     })),
     schedules: doc.schedules,
   };

--- a/src/ensemble/schema.ts
+++ b/src/ensemble/schema.ts
@@ -16,8 +16,6 @@ export interface EnsembleLineup {
     agent?: string;       // "default", "copilot", or path to agent .md file
     instructions?: string;
     allowedTools?: string[]; // Tool restrictions (e.g., ["Read", "Glob", "Grep"])
-    isolation?: 'worktree'; // Run in a git worktree for code isolation
-    branch?: string;        // Branch name for the worktree (defaults to {ensemble}/{player-name})
     /** Transient: resolved agent definition name (set by loadAndResolveLineup). */
     _agentDefinition?: string;
     /** Transient: resolved absolute path to .md file (set by loadAndResolveLineup). */

--- a/src/server.ts
+++ b/src/server.ts
@@ -33,6 +33,7 @@ import { registerEncoreTool } from './tools/encore';
 import { registerQualityGateTool } from './tools/quality-gate';
 import { registerEvaluateGateTool } from './tools/evaluate-gate';
 import { registerGatesTool } from './tools/gates';
+import { registerWorktreeTool } from './tools/worktree';
 import { startMessagePoller } from './channel';
 import { resolveAgentType } from './ensemble/agent-types';
 
@@ -264,6 +265,7 @@ async function main() {
     registerQualityGateTool(mcpServer, handle, getPlayerId);
     registerEvaluateGateTool(mcpServer, handle, getPlayerId);
     registerGatesTool(mcpServer, handle);
+    registerWorktreeTool(mcpServer, client, config, handle, getPlayerId);
   }
 
   const MAESTRO_ACK = '\n\n[IMPORTANT: This message is from a human (Maestro). Immediately cue the sender back with a brief acknowledgment and your planned next step before doing the work.]';

--- a/src/tools/load-lineup.ts
+++ b/src/tools/load-lineup.ts
@@ -15,7 +15,6 @@ import { parseDuration } from '../utils/duration';
 import { safeLineupPath } from '../utils/safe-path';
 import { defineTool } from './helpers';
 import { PLAYER_NAME_MAX, PATH_MAX } from '../utils/validation';
-import { createWorktree, installDependencies } from '../utils/worktree';
 
 const log = (...args: unknown[]) => console.error('[claude-tempo:load-lineup]', ...args);
 
@@ -98,8 +97,7 @@ export function registerLoadLineupTool(
         // Recruit players sequentially
         for (const player of lineup.players) {
           const playerName = player.name;
-          let workDir = player.workDir || process.cwd();
-          let worktreePath: string | undefined;
+          const workDir = player.workDir || process.cwd();
           const agentType: AgentType = player.agent === 'copilot' ? 'copilot' : 'claude';
           const isCustomAgent = player.agent && player.agent !== 'default' && player.agent !== 'copilot';
           const systemPrompt = player._agentDefinition ? undefined : (isCustomAgent ? player.agent : undefined);
@@ -123,32 +121,6 @@ export function registerLoadLineupTool(
               }
             }
             continue;
-          }
-
-          // Create worktree if isolation is requested
-          if (player.isolation === 'worktree') {
-            try {
-              // Determine git root: use the player's workDir as the git root,
-              // or fall back to cwd (which should be a git repo).
-              const gitRoot = workDir;
-              const result = createWorktree({
-                gitRoot,
-                ensemble: config.ensemble,
-                playerName,
-                branch: player.branch,
-              });
-              worktreePath = result.path;
-              workDir = result.path;
-              log(`Worktree for "${playerName}": ${result.path} (branch: ${result.branch}, created: ${result.created})`);
-
-              // Install dependencies — blocking but failure is non-fatal
-              if (result.created) {
-                installDependencies(result.path);
-              }
-            } catch (err) {
-              failed.push(`${playerName}: worktree creation failed — ${err}`);
-              continue;
-            }
           }
 
           // Record existing workflows to detect the new one
@@ -236,16 +208,6 @@ export function registerLoadLineupTool(
           if (!newWorkflowId) {
             failed.push(`${playerName}: spawned but did not register within 15s`);
             continue;
-          }
-
-          // Record worktree path in session metadata
-          if (worktreePath && newWorkflowId) {
-            try {
-              const newHandle = client.workflow.getHandle(newWorkflowId);
-              await newHandle.signal('updateMetadata', { worktreePath });
-            } catch (err) {
-              log(`Failed to set worktreePath metadata for "${playerName}":`, err);
-            }
           }
 
           // Send initial instructions if provided

--- a/src/tools/worktree.ts
+++ b/src/tools/worktree.ts
@@ -1,0 +1,186 @@
+import { z } from 'zod';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client, WorkflowHandle } from '@temporalio/client';
+import { Config } from '../config';
+import { WorktreeEntry } from '../types';
+import { resolveSession } from './resolve';
+import { submitOutboxUpdate } from '../workflows/signals';
+import { defineTool } from './helpers';
+import { createWorktree, installDependencies, removeWorktree } from '../utils/worktree';
+import { PLAYER_NAME_MAX } from '../utils/validation';
+
+export function registerWorktreeTool(
+  server: McpServer,
+  client: Client,
+  config: Config,
+  handle: WorkflowHandle,
+  getPlayerId: () => string,
+) {
+  defineTool(
+    server,
+    'worktree',
+    'Manage git worktrees for player isolation. Conductor only. Actions: create (provision worktree for a player), remove (clean up), list (show active worktrees).',
+    {
+      action: z.enum(['create', 'remove', 'list']).describe('Action to perform'),
+      player: z.string().max(PLAYER_NAME_MAX).optional().describe('Player name (required for create/remove)'),
+      branch: z.string().optional().describe('Git branch for the worktree (defaults to {ensemble}/{player-name})'),
+    },
+    async (args) => {
+      const { action, player, branch } = args as {
+        action: 'create' | 'remove' | 'list';
+        player?: string;
+        branch?: string;
+      };
+
+      try {
+        switch (action) {
+          case 'create': {
+            if (!player) {
+              return {
+                content: [{ type: 'text' as const, text: '`player` is required for create action.' }],
+                isError: true,
+              };
+            }
+
+            // Verify player exists
+            const targetHandle = await resolveSession(client, config.ensemble, player);
+            if (!targetHandle) {
+              return {
+                content: [{ type: 'text' as const, text: `No active session found for "${player}".` }],
+                isError: true,
+              };
+            }
+
+            // Check target is on same host (cross-machine worktrees not supported)
+            const targetMeta = await targetHandle.query('getMetadata') as { hostname?: string };
+            const { hostname } = await import('os').then((os) => ({ hostname: os.hostname() }));
+            if (targetMeta.hostname && targetMeta.hostname !== hostname) {
+              return {
+                content: [{ type: 'text' as const, text: `Cannot create worktree for "${player}" — they are on host "${targetMeta.hostname}" but worktrees must be created locally.` }],
+                isError: true,
+              };
+            }
+
+            const gitRoot = process.cwd();
+            const result = createWorktree({
+              gitRoot,
+              ensemble: config.ensemble,
+              playerName: player,
+              branch,
+            });
+
+            if (result.created) {
+              installDependencies(result.path);
+            }
+
+            // Record in conductor's worktree state
+            const entry: WorktreeEntry = {
+              player,
+              path: result.path,
+              branch: result.branch,
+              gitRoot,
+              createdAt: new Date().toISOString(),
+              createdBy: getPlayerId(),
+            };
+            await handle.signal('setWorktree', entry);
+
+            // Auto-cue the player with worktree info
+            const cueMessage = [
+              `\u{1f33f} **Worktree ready** for your task:`,
+              `- **Path**: \`${result.path}\``,
+              `- **Branch**: \`${result.branch}\``,
+              '',
+              `Run \`cd ${result.path}\` to switch to your isolated workspace.`,
+              `All your changes will be on branch \`${result.branch}\`.`,
+              `When done, commit and push \u2014 the conductor will handle cleanup.`,
+            ].join('\n');
+
+            await handle.executeUpdate(submitOutboxUpdate, {
+              args: [{
+                type: 'cue' as const,
+                targetPlayerId: player,
+                message: cueMessage,
+              }],
+            });
+
+            return {
+              content: [{
+                type: 'text' as const,
+                text: `Worktree created for **${player}**:\n- Path: \`${result.path}\`\n- Branch: \`${result.branch}\`\n- Created: ${result.created ? 'new' : 'reused existing'}\n\nPlayer has been notified.`,
+              }],
+            };
+          }
+
+          case 'remove': {
+            if (!player) {
+              return {
+                content: [{ type: 'text' as const, text: '`player` is required for remove action.' }],
+                isError: true,
+              };
+            }
+
+            // Look up worktree entry from conductor state
+            const entries: WorktreeEntry[] = await handle.query('worktrees');
+            const entry = entries.find((w) => w.player === player);
+            if (!entry) {
+              return {
+                content: [{ type: 'text' as const, text: `No worktree found for player "${player}".` }],
+                isError: true,
+              };
+            }
+
+            // Remove from disk
+            removeWorktree(entry.path);
+
+            // Remove from conductor state
+            await handle.signal('removeWorktree', player);
+
+            // Auto-cue the player
+            try {
+              await handle.executeUpdate(submitOutboxUpdate, {
+                args: [{
+                  type: 'cue' as const,
+                  targetPlayerId: player,
+                  message: `Worktree removed. You're back in the shared repository.`,
+                }],
+              });
+            } catch {
+              // Player may no longer be active — non-fatal
+            }
+
+            return {
+              content: [{
+                type: 'text' as const,
+                text: `Worktree for **${player}** removed (branch: \`${entry.branch}\`).`,
+              }],
+            };
+          }
+
+          case 'list': {
+            const entries: WorktreeEntry[] = await handle.query('worktrees');
+            if (entries.length === 0) {
+              return {
+                content: [{ type: 'text' as const, text: 'No active worktrees.' }],
+              };
+            }
+
+            const lines = entries.map((w) =>
+              `- **${w.player}**: \`${w.path}\` (branch: \`${w.branch}\`, created: ${w.createdAt} by ${w.createdBy})`,
+            );
+            return {
+              content: [{
+                type: 'text' as const,
+                text: `${entries.length} active worktree${entries.length === 1 ? '' : 's'}:\n${lines.join('\n')}`,
+              }],
+            };
+          }
+        }
+      } catch (err) {
+        return {
+          content: [{ type: 'text' as const, text: `Worktree operation failed: ${err}` }],
+          isError: true,
+        };
+      }
+    },
+  );
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,6 +53,8 @@ export interface SessionInput {
   disableStaleDetection?: boolean;
   /** Restored from continue-as-new (conductor only) */
   qualityGates?: QualityGate[];
+  /** Restored from continue-as-new (conductor only) */
+  worktrees?: WorktreeEntry[];
   /** Temporal config passed through for outbox activities (non-secret fields only). */
   temporalConfig?: {
     temporalAddress: string;
@@ -181,6 +183,23 @@ export interface QualityGate {
   createdAt: string;
   /** Derived: all passed → passed, any failed → failed, else open. */
   status: 'open' | 'passed' | 'failed';
+}
+
+// ── Worktree Types ──
+
+export interface WorktreeEntry {
+  /** Player name assigned to this worktree. */
+  player: string;
+  /** Absolute path to worktree directory. */
+  path: string;
+  /** Git branch for this worktree. */
+  branch: string;
+  /** Original git root (for git worktree remove). */
+  gitRoot: string;
+  /** ISO timestamp of creation. */
+  createdAt: string;
+  /** Player ID of creator. */
+  createdBy: string;
 }
 
 export interface ScheduleEntry {

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -24,6 +24,7 @@ import {
   OutboxEntry,
   OutboxEntryInput,
   QualityGate,
+  WorktreeEntry,
   receiveMessageSignal,
   setPartSignal,
   setNameSignal,
@@ -44,6 +45,9 @@ import {
   setQualityGateSignal,
   evaluateGateCriteriaSignal,
   qualityGatesQuery,
+  setWorktreeSignal,
+  removeWorktreeSignal,
+  worktreesQuery,
 } from './signals';
 
 // ── Outbox Activity Proxies ──
@@ -74,6 +78,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
   patched('v0.10-initial');
   patched('v0.11-check-and-set-status');
   patched('v0.13-quality-gates');
+  patched('v0.14-worktrees');
 
   // Ensure search attributes are always current — critical when reconnecting
   // via WorkflowIdConflictPolicy.USE_EXISTING, which skips the attributes
@@ -225,6 +230,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
   const commandHistory: Command[] = input.commandHistory ?? [];
   const reportHistory: PlayerReport[] = input.reportHistory ?? [];
   const qualityGates: QualityGate[] = input.qualityGates ?? [];
+  const worktrees: WorktreeEntry[] = input.worktrees ?? [];
 
   // ── Conductor-specific Handlers ──
 
@@ -318,6 +324,26 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
     });
 
     setHandler(qualityGatesQuery, () => qualityGates);
+
+    // ── Worktree Handlers ──
+
+    setHandler(setWorktreeSignal, (entry: WorktreeEntry) => {
+      const existing = worktrees.findIndex((w) => w.player === entry.player);
+      if (existing >= 0) {
+        worktrees[existing] = entry;
+      } else {
+        worktrees.push(entry);
+      }
+    });
+
+    setHandler(removeWorktreeSignal, (playerName: string) => {
+      const idx = worktrees.findIndex((w) => w.player === playerName);
+      if (idx >= 0) {
+        worktrees.splice(idx, 1);
+      }
+    });
+
+    setHandler(worktreesQuery, () => worktrees);
   }
 
   // ── Main Loop ──
@@ -482,7 +508,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
         messages: messages.filter((m) => !m.delivered),
         sentMessages: sentMessages.slice(-50),
         outbox: outbox.filter((e) => e.status === 'pending' || e.status === 'processing'),
-        ...(input.metadata.isConductor ? { commandHistory, reportHistory, qualityGates } : {}),
+        ...(input.metadata.isConductor ? { commandHistory, reportHistory, qualityGates, worktrees } : {}),
       });
     }
   }

--- a/src/workflows/signals.ts
+++ b/src/workflows/signals.ts
@@ -7,6 +7,7 @@ import type {
   OutboxEntry,
   OutboxEntryInput,
   QualityGate,
+  WorktreeEntry,
 } from '../types';
 
 // Re-export types for convenience within workflow code
@@ -29,6 +30,7 @@ export type {
   EncoreOutboxEntry,
   QualityGate,
   QualityGateCriterion,
+  WorktreeEntry,
 } from '../types';
 
 // ── Player Signals ──
@@ -72,3 +74,9 @@ export const outboxQuery = defineQuery<OutboxEntry[]>('outbox');
 export const setQualityGateSignal = defineSignal<[{ task: string; criteria: string[]; createdBy: string }]>('setQualityGate');
 export const evaluateGateCriteriaSignal = defineSignal<[{ task: string; evaluations: Array<{ index: number; status: 'passed' | 'failed'; notes?: string }>; evaluatedBy: string }]>('evaluateGateCriteria');
 export const qualityGatesQuery = defineQuery<QualityGate[]>('qualityGates');
+
+// ── Worktree Signals + Query (conductor-only) ──
+
+export const setWorktreeSignal = defineSignal<[WorktreeEntry]>('setWorktree');
+export const removeWorktreeSignal = defineSignal<[string]>('removeWorktree');
+export const worktreesQuery = defineQuery<WorktreeEntry[]>('worktrees');

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -30,6 +30,9 @@ import {
   setQualityGateSignal,
   evaluateGateCriteriaSignal,
   qualityGatesQuery,
+  setWorktreeSignal,
+  removeWorktreeSignal,
+  worktreesQuery,
 } from '../src/workflows/signals';
 
 // Re-export signals/queries for convenience in test files
@@ -53,6 +56,9 @@ export {
   setQualityGateSignal,
   evaluateGateCriteriaSignal,
   qualityGatesQuery,
+  setWorktreeSignal,
+  removeWorktreeSignal,
+  worktreesQuery,
 };
 
 let testEnv: TestWorkflowEnvironment;

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,6 +1,19 @@
 import { expect } from 'chai';
 import * as path from 'path';
+import { WorktreeEntry } from '../src/types';
 import { worktreeBasePath } from '../src/utils/worktree';
+import {
+  setupTestEnv,
+  teardownTestEnv,
+  withWorker,
+  startSession,
+  conductorMetadata,
+  playerMetadata,
+  updateMetadataSignal,
+  setWorktreeSignal,
+  removeWorktreeSignal,
+  worktreesQuery,
+} from './helpers';
 
 describe('worktree helpers', function () {
   describe('worktreeBasePath', function () {
@@ -12,7 +25,6 @@ describe('worktree helpers', function () {
     });
 
     it('handles gitRoot with trailing separator', function () {
-      // path.dirname normalizes trailing separators
       const gitRoot = path.resolve('/repos/my-project');
       const result = worktreeBasePath(gitRoot, 'test');
       expect(result).to.include('.ct-worktrees');
@@ -29,7 +41,6 @@ describe('worktree helpers', function () {
     it('produces cross-platform consistent paths using path.join', function () {
       const gitRoot = path.resolve('/repos/project');
       const result = worktreeBasePath(gitRoot, 'ensemble-1');
-      // Ensure the result uses the platform's path separator
       expect(result).to.equal(
         path.join(path.dirname(gitRoot), '.ct-worktrees', 'ensemble-1'),
       );
@@ -38,8 +49,6 @@ describe('worktree helpers', function () {
 
   describe('branch naming defaults', function () {
     it('default branch follows {ensemble}/{playerName} convention', function () {
-      // The createWorktree function defaults to `${ensemble}/${playerName}`
-      // We test the convention here without invoking git
       const ensemble = 'my-ensemble';
       const playerName = 'soloist';
       const defaultBranch = `${ensemble}/${playerName}`;
@@ -48,7 +57,6 @@ describe('worktree helpers', function () {
 
     it('custom branch overrides the default', function () {
       const customBranch = 'feat/custom-branch';
-      // When branch is provided, it should be used as-is
       expect(customBranch).to.equal('feat/custom-branch');
     });
 
@@ -80,6 +88,176 @@ describe('worktree helpers', function () {
       const gitRoot = path.resolve('/repos/project');
       const basePath = worktreeBasePath(gitRoot, 'ens');
       expect(path.isAbsolute(basePath)).to.be.true;
+    });
+  });
+});
+
+describe('worktree workflow state', function () {
+  before(async function () {
+    this.timeout(60_000);
+    await setupTestEnv();
+  });
+
+  after(async function () {
+    await teardownTestEnv();
+  });
+
+  it('creates worktree entry on conductor via signal', async function () {
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: conductorMetadata({ playerId: 'conductor' }),
+      });
+
+      const entry: WorktreeEntry = {
+        player: 'soloist',
+        path: '/tmp/wt/soloist',
+        branch: 'test-ens/soloist',
+        gitRoot: '/repos/project',
+        createdAt: new Date().toISOString(),
+        createdBy: 'conductor',
+      };
+      await handle.signal(setWorktreeSignal, entry);
+
+      const worktrees: WorktreeEntry[] = await handle.query(worktreesQuery);
+      expect(worktrees).to.have.length(1);
+      expect(worktrees[0].player).to.equal('soloist');
+      expect(worktrees[0].path).to.equal('/tmp/wt/soloist');
+      expect(worktrees[0].branch).to.equal('test-ens/soloist');
+      expect(worktrees[0].gitRoot).to.equal('/repos/project');
+      expect(worktrees[0].createdBy).to.equal('conductor');
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('removes worktree entry by player name', async function () {
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: conductorMetadata({ playerId: 'conductor' }),
+      });
+
+      await handle.signal(setWorktreeSignal, {
+        player: 'engineer',
+        path: '/tmp/wt/engineer',
+        branch: 'ens/engineer',
+        gitRoot: '/repos/project',
+        createdAt: new Date().toISOString(),
+        createdBy: 'conductor',
+      });
+
+      let worktrees: WorktreeEntry[] = await handle.query(worktreesQuery);
+      expect(worktrees).to.have.length(1);
+
+      await handle.signal(removeWorktreeSignal, 'engineer');
+
+      worktrees = await handle.query(worktreesQuery);
+      expect(worktrees).to.have.length(0);
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('upserts worktree entry for same player', async function () {
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: conductorMetadata({ playerId: 'conductor' }),
+      });
+
+      await handle.signal(setWorktreeSignal, {
+        player: 'dev',
+        path: '/tmp/wt/dev-old',
+        branch: 'ens/dev',
+        gitRoot: '/repos/project',
+        createdAt: '2026-01-01T00:00:00Z',
+        createdBy: 'conductor',
+      });
+
+      // Upsert with new path
+      await handle.signal(setWorktreeSignal, {
+        player: 'dev',
+        path: '/tmp/wt/dev-new',
+        branch: 'ens/dev-v2',
+        gitRoot: '/repos/project',
+        createdAt: '2026-01-02T00:00:00Z',
+        createdBy: 'conductor',
+      });
+
+      const worktrees: WorktreeEntry[] = await handle.query(worktreesQuery);
+      expect(worktrees).to.have.length(1);
+      expect(worktrees[0].path).to.equal('/tmp/wt/dev-new');
+      expect(worktrees[0].branch).to.equal('ens/dev-v2');
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('non-conductor session does not have worktrees query', async function () {
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'player-no-wt' }),
+      });
+
+      try {
+        await handle.query(worktreesQuery);
+        expect.fail('Should have thrown for non-conductor');
+      } catch (err: any) {
+        expect(err.message).to.include('worktrees');
+      }
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('supports multiple worktrees simultaneously', async function () {
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: conductorMetadata({ playerId: 'conductor' }),
+      });
+
+      await handle.signal(setWorktreeSignal, {
+        player: 'alice',
+        path: '/tmp/wt/alice',
+        branch: 'ens/alice',
+        gitRoot: '/repos/project',
+        createdAt: new Date().toISOString(),
+        createdBy: 'conductor',
+      });
+      await handle.signal(setWorktreeSignal, {
+        player: 'bob',
+        path: '/tmp/wt/bob',
+        branch: 'ens/bob',
+        gitRoot: '/repos/project',
+        createdAt: new Date().toISOString(),
+        createdBy: 'conductor',
+      });
+
+      const worktrees: WorktreeEntry[] = await handle.query(worktreesQuery);
+      expect(worktrees).to.have.length(2);
+      expect(worktrees.map((w) => w.player)).to.include.members(['alice', 'bob']);
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('remove for non-existent player is a no-op', async function () {
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: conductorMetadata({ playerId: 'conductor' }),
+      });
+
+      // Remove a player that was never added — should not throw
+      await handle.signal(removeWorktreeSignal, 'ghost');
+
+      const worktrees: WorktreeEntry[] = await handle.query(worktreesQuery);
+      expect(worktrees).to.have.length(0);
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
     });
   });
 });


### PR DESCRIPTION
## Summary
Replaces the lineup-based `isolation: worktree` approach (shipped in v0.14.0) with a proper standalone `worktree` MCP tool for conductors.

- **`worktree create`** — checks out a new branch in a sibling directory, installs dependencies, auto-cues the player with the worktree path
- **`worktree remove`** — cleans up the worktree after task completion, notifies the player
- **`worktree list`** — shows all active worktree assignments in the conductor

Worktree state is stored in the conductor workflow (`WorktreeEntry`) and survives `continueAsNew`. Lineups remain static team definitions — not the place for task isolation.

## Changes
- `src/tools/worktree.ts` (new) — `create`, `remove`, `list` subcommands
- `src/server.ts` — registers worktree tool
- `src/types.ts` — `WorktreeEntry` type
- `src/workflows/signals.ts` + `session.ts` — worktree state in conductor workflow
- `src/ensemble/schema.ts` + `loader.ts` — removes `isolation`/`branch` from player schema
- `src/tools/load-lineup.ts` — removes inline worktree creation (reverts to clean recruit)
- `test/helpers.ts` + `test/worktree.test.ts` — 267 tests total (QA verified)
- `docs/WIRE-PROTOCOL.md`, `CLAUDE.md`, `README.md`, `examples/agents/tempo-conductor.md` — updated docs

## Test Plan
- [x] 267 tests passing (QA verified)
- [x] Build clean
- [x] Type check clean

## Issues Closed
- Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)