### PR TITLE
fix(encore): use session UUID for deterministic --resume (#44)

### DIFF
--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -28,7 +28,7 @@ Signals sent **to** a `claudeSessionWorkflow` instance.
 | `setPart` | `string` | Updates the player's current "part" — a short description of what the session is working on, visible to other players via `ensemble`. |
 | `markDelivered` | `string[]` | Marks one or more messages (by ID) as delivered. Resets stale-detection timer; any delivery proves the session is alive. |
 | `setName` | `string` | Updates the player's human-readable ID (`ClaudeTempoPlayerId` search attribute). Called by the `set_name` MCP tool. |
-| `updateMetadata` | `{ hostname?, gitBranch?, gitRoot?, status?, terminatedBy?, enableStaleDetection?, playerType?, playerTypeDescription?, worktreePath? }` | Updates session metadata fields and syncs search attributes. Setting `status: 'terminated'` triggers graceful shutdown; `enableStaleDetection: true` re-arms stale detection after reconnect; `worktreePath` records the git worktree path when the session uses worktree isolation. |
+| `updateMetadata` | `{ hostname?, gitBranch?, gitRoot?, status?, terminatedBy?, enableStaleDetection?, playerType?, playerTypeDescription?, worktreePath?, claudeSessionId? }` | Updates session metadata fields and syncs search attributes. Setting `status: 'terminated'` triggers graceful shutdown; `enableStaleDetection: true` re-arms stale detection after reconnect; `worktreePath` records the git worktree path when the session uses worktree isolation; `claudeSessionId` stores the Claude Code session UUID for deterministic `--resume` on encore. |
 
 ---
 

--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -65,6 +65,8 @@ export interface SpawnProcessInput {
   nativeResolvable?: boolean;
   /** When true, use --resume instead of -n (reconnect to existing session). */
   resume?: boolean;
+  /** Claude Code session UUID for --session-id (new sessions) or --resume (encore). */
+  claudeSessionId?: string;
   /** Tool restrictions from the agent definition frontmatter. */
   allowedTools?: string[];
 }
@@ -85,6 +87,8 @@ export interface EncoreResult {
   agentDefinitionPath?: string;
   nativeResolvable?: boolean;
   allowedTools?: string[];
+  /** Claude Code session UUID for deterministic --resume. */
+  claudeSessionId?: string;
   temporalAddress: string;
   temporalNamespace: string;
 }
@@ -96,13 +100,18 @@ export interface OutboxActivityResult {
   error?: string;
 }
 
+export interface RecruitResult extends OutboxActivityResult {
+  /** Claude Code session UUID assigned at recruit time. */
+  claudeSessionId?: string;
+}
+
 // ── Activity interface ──
 
 export interface OutboxActivities {
   deliverCue(input: DeliverCueInput): Promise<OutboxActivityResult>;
   deliverReport(input: DeliverReportInput): Promise<OutboxActivityResult>;
   terminateSession(input: TerminateSessionInput): Promise<OutboxActivityResult>;
-  startRecruitedSession(input: StartRecruitedSessionInput): Promise<OutboxActivityResult>;
+  startRecruitedSession(input: StartRecruitedSessionInput): Promise<RecruitResult>;
   spawnProcess(input: SpawnProcessInput): Promise<OutboxActivityResult>;
   performEncore(input: PerformEncoreInput): Promise<EncoreResult>;
 }
@@ -155,7 +164,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
       return { success: true };
     },
 
-    async startRecruitedSession(input: StartRecruitedSessionInput): Promise<OutboxActivityResult> {
+    async startRecruitedSession(input: StartRecruitedSessionInput): Promise<RecruitResult> {
       const { ensemble, targetName, workDir, isConductor, initialMessage, fromPlayerId, agent, systemPrompt, taskQueue, agentDefinition, agentDefinitionDescription } = input;
       try {
         const workflowId = isConductor
@@ -163,6 +172,9 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
           : sessionWorkflowId(ensemble, targetName);
 
         const { gitRoot, gitBranch } = getGitInfo(workDir);
+
+        // Generate a UUID for the Claude Code session — used for deterministic --resume on encore
+        const claudeSessionId = crypto.randomUUID();
 
         const sessionInput: SessionInput = {
           metadata: {
@@ -175,6 +187,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             isConductor,
             agentType: agent,
             status: 'pending',
+            claudeSessionId,
             ...(agentDefinition ? { playerType: agentDefinition } : {}),
             ...(agentDefinitionDescription ? { playerTypeDescription: agentDefinitionDescription } : {}),
             recruitedBy: fromPlayerId,
@@ -205,8 +218,8 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
           },
         });
 
-        log(`Pre-created workflow ${workflowId} for recruit "${targetName}"`);
-        return { success: true };
+        log(`Pre-created workflow ${workflowId} for recruit "${targetName}" (sessionId=${claudeSessionId})`);
+        return { success: true, claudeSessionId };
       } catch (err) {
         throw ApplicationFailure.nonRetryable(
           `Failed to start recruited session "${targetName}": ${err instanceof Error ? err.message : String(err)}`,
@@ -215,7 +228,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
     },
 
     async spawnProcess(input: SpawnProcessInput): Promise<OutboxActivityResult> {
-      const { targetName, workDir, isConductor, agent, systemPrompt, ensemble, temporalAddress, temporalNamespace, agentDefinition, agentDefinitionPath, nativeResolvable, resume, allowedTools } = input;
+      const { targetName, workDir, isConductor, agent, systemPrompt, ensemble, temporalAddress, temporalNamespace, agentDefinition, agentDefinitionPath, nativeResolvable, resume, claudeSessionId, allowedTools } = input;
       // Read secrets from the worker's config closure — never from workflow state
       const { temporalApiKey, temporalTlsCertPath, temporalTlsKeyPath } = config;
       try {
@@ -246,8 +259,12 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             agentFlags = ['--system-prompt', systemPrompt];
           }
 
-          // Use --resume for encore (reconnect to existing session) or -n for new sessions
-          const nameArgs = resume ? ['--resume', targetName] : ['-n', targetName];
+          // Use --resume for encore (reconnect to existing session) or -n for new sessions.
+          // For encore: use UUID for deterministic --resume (no interactive picker).
+          // For new sessions: use --session-id to track the UUID for future encores.
+          const nameArgs = resume
+            ? ['--resume', claudeSessionId || targetName]
+            : ['-n', targetName, ...(claudeSessionId ? ['--session-id', claudeSessionId] : [])];
 
           // Build --allowedTools flag from agent definition frontmatter
           const allowedToolsFlags = allowedTools && allowedTools.length > 0
@@ -358,6 +375,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
           agentDefinitionPath,
           nativeResolvable,
           allowedTools,
+          claudeSessionId: (metadata.claudeSessionId as string) || undefined,
           temporalAddress: config.temporalAddress,
           temporalNamespace: config.temporalNamespace,
         };

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,8 @@ export interface SessionMetadata {
   recruitedBy?: string;
   /** Worktree path if this session was spawned in an isolated worktree. */
   worktreePath?: string;
+  /** Claude Code session UUID — used for deterministic --resume on encore. */
+  claudeSessionId?: string;
 }
 
 export interface AgentTypeInfo {

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -173,6 +173,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
     if (update.playerType != null) input.metadata.playerType = update.playerType;
     if (update.playerTypeDescription != null) input.metadata.playerTypeDescription = update.playerTypeDescription;
     if (update.worktreePath != null) input.metadata.worktreePath = update.worktreePath;
+    if (update.claudeSessionId != null) input.metadata.claudeSessionId = update.claudeSessionId;
     if (update.status != null) {
       input.metadata.status = update.status as SessionStatus;
       // Re-enable stale detection only when explicitly requested (server.ts sets this)
@@ -384,7 +385,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
             break;
           case 'recruit': {
             const tc = input.temporalConfig;
-            await startRecruitedSession({
+            const recruitResult = await startRecruitedSession({
               ensemble: input.metadata.ensemble,
               targetName: entry.targetName,
               workDir: entry.workDir,
@@ -412,6 +413,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
               agentDefinition: entry.agentDefinition,
               agentDefinitionPath: entry.agentDefinitionPath,
               nativeResolvable: entry.nativeResolvable,
+              claudeSessionId: recruitResult.claudeSessionId,
               allowedTools: entry.allowedTools,
             });
             break;
@@ -438,6 +440,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
                 agentDefinitionPath: encoreResult.agentDefinitionPath,
                 nativeResolvable: encoreResult.nativeResolvable,
                 allowedTools: encoreResult.allowedTools,
+                claudeSessionId: encoreResult.claudeSessionId,
                 resume: true,
               });
             } catch (spawnErr) {

--- a/src/workflows/signals.ts
+++ b/src/workflows/signals.ts
@@ -40,7 +40,7 @@ export const recordSentMessageSignal = defineSignal<[{ to: string; text: string 
 export const setPartSignal = defineSignal<[string]>('setPart');
 export const markDeliveredSignal = defineSignal<[string[]]>('markDelivered');
 export const setNameSignal = defineSignal<[string]>('setName');
-export const updateMetadataSignal = defineSignal<[{ hostname?: string; gitBranch?: string; gitRoot?: string; status?: string; terminatedBy?: string; enableStaleDetection?: boolean; playerType?: string; playerTypeDescription?: string; worktreePath?: string }]>('updateMetadata');
+export const updateMetadataSignal = defineSignal<[{ hostname?: string; gitBranch?: string; gitRoot?: string; status?: string; terminatedBy?: string; enableStaleDetection?: boolean; playerType?: string; playerTypeDescription?: string; worktreePath?: string; claudeSessionId?: string }]>('updateMetadata');
 
 // ── Player Queries ──
 

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -936,4 +936,44 @@ describe('claudeSessionWorkflow', function () {
       });
     });
   });
+
+  describe('claudeSessionId metadata', function () {
+    it('stores claudeSessionId via updateMetadata signal', async function () {
+      await withWorker(async () => {
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: 'uuid-test' }),
+        });
+
+        const testUuid = '550e8400-e29b-41d4-a716-446655440000';
+        await handle.signal(updateMetadataSignal, { claudeSessionId: testUuid });
+
+        const metadata = await handle.query(getMetadataQuery);
+        expect(metadata.claudeSessionId).to.equal(testUuid);
+
+        await handle.signal(updateMetadataSignal, { status: 'terminated' });
+        await handle.result();
+      });
+    });
+
+    it('preserves claudeSessionId from initial metadata', async function () {
+      await withWorker(async () => {
+        const testUuid = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890';
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: 'uuid-init', claudeSessionId: testUuid }),
+        });
+
+        const metadata = await handle.query(getMetadataQuery);
+        expect(metadata.claudeSessionId).to.equal(testUuid);
+
+        // Other metadata updates should not clear claudeSessionId
+        await handle.signal(updateMetadataSignal, { hostname: 'new-host' });
+        const updated = await handle.query(getMetadataQuery);
+        expect(updated.claudeSessionId).to.equal(testUuid);
+        expect(updated.hostname).to.equal('new-host');
+
+        await handle.signal(updateMetadataSignal, { status: 'terminated' });
+        await handle.result();
+      });
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Encore was passing the player name to `--resume`, which is ambiguous when multiple Claude Code sessions share a name (interactive picker appears)
- Now generates a UUID at recruit time via `--session-id` and stores it in session metadata (`claudeSessionId`)
- Encore uses the UUID for `--resume` when available, falling back to player name for legacy sessions with no stored UUID
- `claudeSessionId` flows through: `startRecruitedSession` result → `updateMetadata` signal → workflow metadata

## Changes
- `src/activities/outbox.ts` — generates `crypto.randomUUID()` at recruit, passes `--session-id`; uses `claudeSessionId` for `--resume` on encore
- `src/types.ts` — `claudeSessionId?` field on `SessionMetadata`
- `src/workflows/signals.ts` — `claudeSessionId?` in `updateMetadata` payload
- `src/workflows/session.ts` — stores `claudeSessionId` from recruit/encore result
- `docs/WIRE-PROTOCOL.md` — documents `claudeSessionId` in updateMetadata
- `test/workflow.test.ts` — 2 new tests

## Test Plan
- [x] Build clean
- [x] Type check clean
- [x] 2 new tests added (QA verified)

## Issues Closed
- Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)