### PR TITLE
chore(ci): bump actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,10 +18,10 @@ jobs:
         node-version: [18, 20, 22]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node-version }}
           cache: npm
@@ -42,7 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,10 +22,10 @@ jobs:
       contents: write  # needed to create GitHub Releases
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Use Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm
@@ -61,7 +61,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         env:
           CHANGELOG_NOTES: ${{ steps.changelog.outputs.notes }}
         with:


### PR DESCRIPTION
## Summary

- `actions/checkout` v4 → v6 (Node.js 24 runtime)
- `actions/setup-node` v4 → v6 (Node.js 24 runtime)
- `actions/github-script` v7 → v8 (Node.js 24 runtime)

## Why

GitHub Actions is deprecating the Node.js 20 runtime for actions on June 2, 2026. CI has been emitting deprecation warnings on every run since these actions shipped with Node.js 24 support.

## Test plan

- [ ] CI green on Node 18, 20, 22 with updated action versions (no more Node.js 20 deprecation warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)