### PR TITLE
fix(tools): apply conductor section when loading lineup via MCP tool (#48)

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -259,7 +259,7 @@ async function main() {
   registerUnscheduleTool(mcpServer, client, config);
   registerSchedulesTool(mcpServer, client, config);
   registerSaveLineupTool(mcpServer, client, config, getPlayerId, isConductor);
-  registerLoadLineupTool(mcpServer, client, config, getPlayerId, isBridgeMode ? 'copilot' : 'claude');
+  registerLoadLineupTool(mcpServer, client, config, getPlayerId, isBridgeMode ? 'copilot' : 'claude', handle, setPlayerId, isConductor);
   registerAgentTypesTool(mcpServer);
   registerWhoAmITool(mcpServer, handle, getPlayerId);
   registerBroadcastTool(mcpServer, client, config, getPlayerId, handle);

--- a/src/tools/load-lineup.ts
+++ b/src/tools/load-lineup.ts
@@ -3,7 +3,7 @@ import { existsSync } from 'fs';
 import { join } from 'path';
 import { Cron } from 'croner';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { Client, WorkflowIdConflictPolicy } from '@temporalio/client';
+import { Client, WorkflowHandle, WorkflowIdConflictPolicy } from '@temporalio/client';
 import { Config, CLAUDE_TEMPO_HOME, schedulerWorkflowId, ENV } from '../config';
 import { AgentType } from '../types';
 import { loadLineup } from '../ensemble/loader';
@@ -28,6 +28,9 @@ export function registerLoadLineupTool(
   config: Config,
   getPlayerId: () => string,
   ownAgentType: AgentType = 'claude',
+  handle?: WorkflowHandle,
+  setPlayerId?: (id: string) => void,
+  isConductor?: boolean,
 ) {
   defineTool(
     server,
@@ -93,6 +96,61 @@ export function registerLoadLineupTool(
         const lineup = loadAndResolveLineup(filePath);
         const recruited: string[] = [];
         const failed: string[] = [];
+        const conductorActions: string[] = [];
+
+        // Apply conductor section if present and this session is the conductor
+        if (lineup.conductor && isConductor && handle) {
+          // Apply conductor name
+          if (lineup.conductor.name && lineup.conductor.name !== getPlayerId()) {
+            try {
+              // Check if the name is already taken
+              const existing = await resolveSession(client, config.ensemble, lineup.conductor.name);
+              if (existing && existing.workflowId !== handle.workflowId) {
+                failed.push(`conductor name "${lineup.conductor.name}": already taken by another session`);
+              } else {
+                await handle.signal('setName', lineup.conductor.name);
+                if (setPlayerId) setPlayerId(lineup.conductor.name);
+                conductorActions.push(`name → ${lineup.conductor.name}`);
+                log(`Conductor name set to "${lineup.conductor.name}"`);
+              }
+            } catch (err) {
+              failed.push(`conductor name: ${err}`);
+            }
+          }
+
+          // Apply conductor type (update metadata)
+          if (lineup.conductor.type) {
+            try {
+              const typeInfo = resolveAgentType(lineup.conductor.type);
+              if (typeInfo) {
+                await handle.signal('updateMetadata', {
+                  playerType: typeInfo.name,
+                  playerTypeDescription: typeInfo.description || '',
+                });
+                conductorActions.push(`type → ${typeInfo.name}`);
+                log(`Conductor type set to "${typeInfo.name}"`);
+              } else {
+                failed.push(`conductor type "${lineup.conductor.type}": agent type not found`);
+              }
+            } catch (err) {
+              failed.push(`conductor type: ${err}`);
+            }
+          }
+
+          // Send conductor instructions
+          if (lineup.conductor.instructions) {
+            try {
+              await handle.signal('receiveMessage', {
+                from: 'lineup',
+                text: lineup.conductor.instructions,
+              });
+              conductorActions.push('instructions delivered');
+              log('Conductor instructions delivered');
+            } catch (err) {
+              failed.push(`conductor instructions: ${err}`);
+            }
+          }
+        }
 
         // Recruit players sequentially
         for (const player of lineup.players) {
@@ -308,6 +366,9 @@ export function registerLoadLineupTool(
 
         // Build summary
         const lines: string[] = [`Loaded lineup **${lineup.name}**.`];
+        if (conductorActions.length > 0) {
+          lines.push(`Conductor: ${conductorActions.join(', ')}`);
+        }
         if (recruited.length > 0) {
           lines.push(`Recruited: ${recruited.join(', ')}`);
         }

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -363,6 +363,116 @@ describe('load_lineup tool validation', function () {
   });
 });
 
+describe('load_lineup conductor section', function () {
+  const { writeFileSync, mkdirSync, rmSync } = require('fs');
+  const { join } = require('path');
+
+  // Use a subdir of cwd so safeLineupPath allows access
+  let tmpDir: string;
+
+  before(function () {
+    tmpDir = join(process.cwd(), `.test-lineup-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  after(function () {
+    try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
+  });
+
+  it('applies conductor name, type, and instructions from lineup', async function () {
+    // Write a lineup YAML with conductor section
+    const lineupPath = join(tmpDir, 'test-conductor.yaml');
+    writeFileSync(lineupPath, [
+      'name: test-conductor-lineup',
+      'conductor:',
+      '  name: my-conductor',
+      '  instructions: "You are the lead conductor."',
+      'players: []',
+    ].join('\n'));
+
+    // Track signals sent to the conductor handle
+    const signals: Array<{ name: string; args: any }> = [];
+    const conductorHandle = {
+      workflowId: `claude-session-${testConfig.ensemble}-conductor`,
+      executeUpdate: async () => 'fake-entry-id',
+      signal: async (name: string, ...args: any[]) => { signals.push({ name, args: args[0] }); },
+      describe: async () => ({ status: { name: 'RUNNING' } }),
+    } as unknown as WorkflowHandle;
+
+    // Fake client whose resolveSession returns null (name not taken)
+    const clientForConductor = {
+      workflow: {
+        getHandle: () => conductorHandle,
+        start: async () => ({ runId: 'fake' }),
+        list: async function* () { /* no workflows */ },
+      },
+    } as unknown as Client;
+
+    let updatedPlayerId = '';
+    const call = extractHandler((server) =>
+      registerLoadLineupTool(
+        server, clientForConductor, testConfig, getPlayerId, 'claude',
+        conductorHandle,
+        (id: string) => { updatedPlayerId = id; },
+        true, // isConductor
+      ),
+    );
+
+    const result = await call({ path: lineupPath });
+    expect(result.isError).to.be.undefined;
+    expect(result.content[0].text).to.include('test-conductor-lineup');
+    expect(result.content[0].text).to.include('Conductor:');
+    expect(result.content[0].text).to.include('my-conductor');
+    expect(result.content[0].text).to.include('instructions delivered');
+
+    // Verify setName signal was sent
+    const setNameSignal = signals.find(s => s.name === 'setName');
+    expect(setNameSignal).to.exist;
+    expect(setNameSignal!.args).to.equal('my-conductor');
+
+    // Verify setPlayerId was called
+    expect(updatedPlayerId).to.equal('my-conductor');
+
+    // Verify instructions were sent via receiveMessage
+    const msgSignal = signals.find(s => s.name === 'receiveMessage');
+    expect(msgSignal).to.exist;
+    expect(msgSignal!.args.text).to.equal('You are the lead conductor.');
+    expect(msgSignal!.args.from).to.equal('lineup');
+  });
+
+  it('skips conductor section for non-conductor sessions', async function () {
+    const lineupPath = join(tmpDir, 'test-skip.yaml');
+    writeFileSync(lineupPath, [
+      'name: test-skip-lineup',
+      'conductor:',
+      '  name: my-conductor',
+      '  instructions: "Hello"',
+      'players: []',
+    ].join('\n'));
+
+    const signals: Array<{ name: string; args: any }> = [];
+    const handle = {
+      executeUpdate: async () => 'fake-entry-id',
+      signal: async (name: string, ...args: any[]) => { signals.push({ name, args: args[0] }); },
+    } as unknown as WorkflowHandle;
+
+    const call = extractHandler((server) =>
+      registerLoadLineupTool(
+        server, makeTestClient(), testConfig, getPlayerId, 'claude',
+        handle,
+        () => {},
+        false, // NOT conductor
+      ),
+    );
+
+    const result = await call({ path: lineupPath });
+    expect(result.isError).to.be.undefined;
+    expect(result.content[0].text).to.not.include('Conductor:');
+    // No signals should have been sent for conductor section
+    expect(signals).to.have.length(0);
+  });
+});
+
 // ─────────────────────────────────────────────
 // broadcast tool
 // ─────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Fixes `load_lineup` MCP tool ignoring the `conductor` section of YAML lineups — the conductor player was not being recruited when loading a lineup through the MCP tool (only worked via CLI)
- `src/tools/load-lineup.ts`: Now applies the conductor section during lineup load
- `src/server.ts`: Related server-side fix
- `test/tools.test.ts`: Test coverage for the conductor section load path

## Test plan

- [x] Clean build passes
- [ ] CI green on Node 18, 20, 22
- [ ] Manual: load a lineup with a conductor section via `load_lineup` MCP tool, verify conductor is recruited

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)