### PR TITLE
fix(cli): auto-detect ensemble on down, warn about npx cache (#63)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ src/
 │   ├── index.ts       # Workflow exports (re-exports for worker bundle)
 │   ├── session.ts     # claude-session workflow
 │   ├── scheduler.ts   # durable scheduler workflow (one per ensemble)
-│   ├── maestro.ts     # Maestro ensemble hub workflow (one per ensemble)
+│   ├── maestro.ts     # Maestro workflows — per-ensemble hub (one per ensemble) and global hub (one instance spanning all ensembles)
 │   ├── maestro-signals.ts # Maestro signal/query/update type definitions
 │   ├── scheduler-signals.ts # Scheduler signal/query type definitions
 │   └── signals.ts     # Session signal/query type definitions
@@ -76,6 +76,18 @@ src/
 │   ├── stages.ts      # List stages and their status (conductor only)
 │   ├── cancel-stage.ts # Cancel an active stage (conductor only)
 │   └── helpers.ts     # Zod/MCP tool registration wrapper
+├── tui/
+│   ├── index.ts       # TUI entry point — connects to Temporal and renders the Ink app
+│   ├── App.tsx        # Root TUI component — routes between splash, dashboard, and error states
+│   ├── store.ts       # TUI state reducer (phase, players, events, conductor history)
+│   ├── core-api.ts    # TUI API layer — wraps Temporal queries via the Maestro workflow
+│   ├── ink-loader.ts  # Dynamic ESM loader for Ink (avoids CJS/ESM conflicts)
+│   ├── ink-context.tsx # React context for injected Ink primitives
+│   ├── components/
+│   │   └── Splash.tsx # Splash/connecting screen component
+│   └── utils/
+│       ├── format.ts  # Display formatting helpers
+│       └── platform.ts # Terminal size detection helpers
 ├── utils/
 │   ├── validation.ts  # Shared validation constants (name/message/path limits, encore defaults) and helpers
 │   ├── worktree.ts    # Git worktree create/remove helpers (cross-platform)

--- a/README.md
+++ b/README.md
@@ -95,6 +95,60 @@ claude-tempo conduct
 claude-tempo start
 ```
 
+## Upgrading
+
+### Upgrading to 0.19.0
+
+v0.19.0 introduces the **worker daemon** — a single background process that runs all Temporal workers instead of each session running its own. Old sessions running in-process workers will compete on the same task queue as the daemon, causing errors. A clean restart is required.
+
+1. **Stop everything:**
+
+   ```bash
+   claude-tempo down --all
+   ```
+
+2. **Install the new version:**
+
+   ```bash
+   npm install -g claude-tempo@latest
+   ```
+
+3. **Fix MCP registration (if you previously used `npx`):**
+
+   If you registered with `npx` (e.g. via `claude-tempo init` before v0.19.0):
+
+   ```bash
+   # Remove old registration
+   claude mcp remove claude-tempo -s user
+
+   # Re-register with the direct binary
+   claude mcp add claude-tempo -s user -- claude-tempo-server
+   ```
+
+   If you have a project-level `.mcp.json` with `"command": "npx"`, either delete it or change the entry:
+
+   ```json
+   { "command": "claude-tempo-server", "args": [] }
+   ```
+
+4. **Start fresh:**
+
+   ```bash
+   claude-tempo up <ensemble>
+   ```
+
+   The daemon starts automatically — no manual daemon management needed.
+
+### Troubleshooting
+
+| Symptom | Fix |
+|---------|-----|
+| `workflow execution not found` errors | Restart the daemon: `claude-tempo daemon stop && claude-tempo daemon start` |
+| Sessions not responding to messages | Run `claude-tempo daemon status` — ensure the daemon is running |
+| `.mcp.json` keeps being recreated with `npx` | Delete `.mcp.json` and use user-level registration: `claude-tempo init` |
+
+---
+
 ## Core concepts
 
 - **Player** — A Claude Code session registered as a Temporal workflow
@@ -510,6 +564,7 @@ claude-tempo <command> [options]
 | `ensemble <sub>` | Manage saved lineups (`save`, `list`, `show`) |
 | `agent-types <sub>` | Manage player types (`list`, `show <name>`, `init`) |
 | `daemon <sub>` | Manage the worker daemon (`start`, `stop`, `status`, `logs`) |
+| `tui [ensemble]` | Launch the terminal UI dashboard — shows players, status, and recent activity (experimental) |
 | `version` | Print the installed version |
 | `help` | Show usage info |
 

--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -25,7 +25,7 @@ Signals sent **to** a `claudeSessionWorkflow` instance.
 
 | Signal Name | Payload | Description |
 |-------------|---------|-------------|
-| `receiveMessage` | `{ from: string; text: string; isMaestro?: boolean }` | Delivers an inbound message from another player (or Maestro) into the session's inbox. The session's poller consumes pending messages and forwards them to Claude. |
+| `receiveMessage` | `{ from: string; text: string; isMaestro?: boolean; isScheduled?: boolean; scheduleName?: string }` | Delivers an inbound message from another player (or Maestro) into the session's inbox. The session's poller consumes pending messages and forwards them to Claude. `isScheduled: true` and `scheduleName` are set when the message was fired by the scheduler workflow — useful for dashboard integrations that want to distinguish scheduled messages from direct cues. |
 | `recordSentMessage` | `{ to: string; text: string }` | Records an outbound message in the session's sent-message history without triggering any delivery. Used for audit/history continuity. |
 | `setPart` | `string` | Updates the player's current "part" — a short description of what the session is working on, visible to other players via `ensemble`. |
 | `markDelivered` | `string[]` | Marks one or more messages (by ID) as delivered. Resets stale-detection timer; any delivery proves the session is alive. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -186,7 +186,7 @@ async function main() {
 
     case 'down':
       await down({
-        ensemble,
+        ensemble: args.ensemble || args.positional[1] || process.env[ENV.ENSEMBLE],
         all: args.all,
         removeMcp: !args.keepMcp,
         dir: args.dir,

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -4,7 +4,7 @@ import { execFileSync, spawn as cpSpawn } from 'child_process';
 import { homedir } from 'os';
 import { Client, Connection, WorkflowIdConflictPolicy } from '@temporalio/client';
 import { spawnInTerminal, spawnCopilotBridge, resolveClaudePath } from '../spawn';
-import { conductorWorkflowId, schedulerWorkflowId, maestroWorkflowId, ENV, getConfig, Config, CliOverrides, CLAUDE_TEMPO_HOME } from '../config';
+import { conductorWorkflowId, schedulerWorkflowId, maestroWorkflowId, GLOBAL_MAESTRO_WORKFLOW_ID, ENV, getConfig, Config, CliOverrides, CLAUDE_TEMPO_HOME } from '../config';
 import { createTemporalConnection } from '../connection';
 import { playerReportSignal, updateMetadataSignal } from '../workflows/signals';
 import { addScheduleSignal } from '../workflows/scheduler-signals';
@@ -984,7 +984,8 @@ function parseDuration(s: string): number {
 // --- Teardown: `down` command ---
 
 interface DownOpts extends CliOverrides {
-  ensemble: string;
+  /** Explicitly specified ensemble name. If undefined, auto-detect from running workflows. */
+  ensemble?: string;
   all: boolean;
   removeMcp: boolean;
   dir: string;
@@ -992,16 +993,68 @@ interface DownOpts extends CliOverrides {
 
 export async function down(opts: DownOpts) {
   const config = getConfig(opts);
-  const ensembleName = opts.ensemble;
+  let ensembleName = opts.ensemble;
+
+  // Auto-detect ensemble if not explicitly specified
+  if (!ensembleName && !opts.all) {
+    const temporalUp = await isTemporalReachable(config);
+    if (!temporalUp) {
+      out.error('No ensembles running (Temporal is not reachable).');
+      process.exit(1);
+    }
+    let connection: Connection | undefined;
+    try {
+      connection = await createTemporalConnection(config);
+      const client = new Client({ connection, namespace: config.temporalNamespace });
+      const runningEnsembles = new Set<string>();
+      const query = 'WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running"';
+      for await (const wf of client.workflow.list({ query })) {
+        const vals = wf.searchAttributes?.ClaudeTempoEnsemble;
+        if (Array.isArray(vals) && vals.length > 0) {
+          runningEnsembles.add(String(vals[0]));
+        }
+      }
+
+      if (runningEnsembles.size === 0) {
+        out.error('No ensembles running.');
+        process.exit(1);
+      } else if (runningEnsembles.size === 1) {
+        ensembleName = [...runningEnsembles][0];
+      } else {
+        out.error(`Multiple ensembles running. Please specify which one to tear down:`);
+        for (const name of [...runningEnsembles].sort()) {
+          out.log(`  - claude-tempo down ${name}`);
+        }
+        out.log(`  - claude-tempo down --all`);
+        process.exit(1);
+      }
+    } catch (err) {
+      out.error(`Could not detect running ensembles: ${(err as Error).message}`);
+      process.exit(1);
+    } finally {
+      await connection?.close();
+    }
+  }
+
+  // When --all is set without a specific ensemble, we terminate everything
+  if (!ensembleName && opts.all) {
+    ensembleName = undefined;
+  }
 
   // Validate ensemble name before interpolating into query strings
-  const nameErr = validateEnsembleName(ensembleName);
-  if (nameErr) { out.error(nameErr); process.exit(1); }
+  if (ensembleName) {
+    const nameErr = validateEnsembleName(ensembleName);
+    if (nameErr) { out.error(nameErr); process.exit(1); }
+  }
 
   out.heading('claude-tempo teardown');
-  out.log(`  Ensemble: ${out.bold(ensembleName)}${opts.all ? ' (--all: will also stop Temporal server)' : ''}`);
+  if (ensembleName) {
+    out.log(`  Ensemble: ${out.bold(ensembleName)}${opts.all ? ' (--all: will also stop Temporal server)' : ''}`);
+  } else {
+    out.log(`  ${out.bold('Tearing down all ensembles')} (--all)`);
+  }
 
-  // Step 1: Terminate workflows for the target ensemble
+  // Step 1: Terminate workflows for the target ensemble (or all ensembles)
   const temporalUp = await isTemporalReachable(config);
   let hasRemainingWorkflows = false;
   if (temporalUp) {
@@ -1009,10 +1062,20 @@ export async function down(opts: DownOpts) {
       const connection = await createTemporalConnection(config);
       const client = new Client({ connection, namespace: config.temporalNamespace });
 
-      // Terminate session workflows scoped to this ensemble
-      const sessionQuery = `WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running" AND ClaudeTempoEnsemble = "${ensembleName}"`;
+      // Terminate session workflows — scoped to ensemble if specified, otherwise all
+      const sessionQuery = ensembleName
+        ? `WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running" AND ClaudeTempoEnsemble = "${ensembleName}"`
+        : `WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running"`;
       let terminated = 0;
+      const discoveredEnsembles = new Set<string>();
       for await (const wf of client.workflow.list({ query: sessionQuery })) {
+        // Track ensemble names for scheduler/maestro cleanup in --all mode
+        if (!ensembleName) {
+          const vals = wf.searchAttributes?.ClaudeTempoEnsemble;
+          if (Array.isArray(vals) && vals.length > 0) {
+            discoveredEnsembles.add(String(vals[0]));
+          }
+        }
         try {
           const handle = client.workflow.getHandle(wf.workflowId);
           await handle.terminate('claude-tempo down');
@@ -1020,25 +1083,47 @@ export async function down(opts: DownOpts) {
         } catch { /* already closed */ }
       }
 
-      // Also terminate the ensemble's scheduler workflow
-      try {
-        const schedulerHandle = client.workflow.getHandle(schedulerWorkflowId(ensembleName));
-        await schedulerHandle.terminate('claude-tempo down');
-        terminated++;
-      } catch { /* no scheduler or already closed */ }
+      // Terminate scheduler and maestro workflows for each ensemble
+      const ensemblesToClean = ensembleName ? [ensembleName] : [...discoveredEnsembles];
+      for (const name of ensemblesToClean) {
+        // Scheduler
+        try {
+          const schedulerHandle = client.workflow.getHandle(schedulerWorkflowId(name));
+          await schedulerHandle.terminate('claude-tempo down');
+          terminated++;
+        } catch { /* no scheduler or already closed */ }
+        // Per-ensemble Maestro
+        try {
+          const maestroHandle = client.workflow.getHandle(maestroWorkflowId(name));
+          await maestroHandle.terminate('claude-tempo down');
+          terminated++;
+        } catch { /* no maestro or already closed */ }
+      }
+
+      // Terminate global Maestro when tearing down all ensembles
+      if (!ensembleName) {
+        try {
+          const globalMaestroHandle = client.workflow.getHandle(GLOBAL_MAESTRO_WORKFLOW_ID);
+          await globalMaestroHandle.terminate('claude-tempo down');
+          terminated++;
+        } catch { /* no global maestro or already closed */ }
+      }
 
       // Check if other workflows still running (to decide whether to kill Temporal)
-      const allRunningQuery = 'ExecutionStatus = "Running"';
-      for await (const _ of client.workflow.list({ query: allRunningQuery })) {
-        hasRemainingWorkflows = true;
-        break;
+      if (!opts.all) {
+        const allRunningQuery = 'ExecutionStatus = "Running"';
+        for await (const _ of client.workflow.list({ query: allRunningQuery })) {
+          hasRemainingWorkflows = true;
+          break;
+        }
       }
 
       await connection.close();
+      const scope = ensembleName ? `in ensemble "${ensembleName}"` : 'across all ensembles';
       if (terminated > 0) {
-        out.success(`Terminated ${terminated} workflow${terminated !== 1 ? 's' : ''} in ensemble "${ensembleName}"`);
+        out.success(`Terminated ${terminated} workflow${terminated !== 1 ? 's' : ''} ${scope}`);
       } else {
-        out.warn(`No active workflows found for ensemble "${ensembleName}"`);
+        out.warn(`No active workflows found ${scope}`);
       }
     } catch {
       out.warn('Could not terminate active sessions');
@@ -1078,7 +1163,26 @@ export async function down(opts: DownOpts) {
     out.log(`  ${out.dim('Temporal not running')}`);
   }
 
-  // Step 4: Remove MCP config (global + project-level)
+  // Step 4: Check for npx usage, then remove MCP config
+  // npx check must happen BEFORE removal since step 4 deletes the entry
+  let hasNpxWarning = false;
+  const projectMcpPath = join(opts.dir, '.mcp.json');
+  if (existsSync(projectMcpPath)) {
+    try {
+      const mcpContent = JSON.parse(readFileSync(projectMcpPath, 'utf8'));
+      const tempoEntry = mcpContent?.mcpServers?.['claude-tempo'];
+      if (tempoEntry) {
+        const cmd = tempoEntry.command ?? '';
+        const entryArgs: string[] = tempoEntry.args ?? [];
+        if (cmd === 'npx' || entryArgs.some((a: string) => a === 'npx')) {
+          hasNpxWarning = true;
+        }
+      }
+    } catch {
+      // Corrupt .mcp.json — ignore
+    }
+  }
+
   if (opts.removeMcp) {
     // Remove global registration
     if (isGlobalMcpRegistered()) {
@@ -1090,24 +1194,30 @@ export async function down(opts: DownOpts) {
     }
 
     // Also remove project-level .mcp.json entry if present
-    const mcpPath = join(opts.dir, '.mcp.json');
-    if (existsSync(mcpPath)) {
+    if (existsSync(projectMcpPath)) {
       try {
-        const existing = JSON.parse(readFileSync(mcpPath, 'utf8'));
+        const existing = JSON.parse(readFileSync(projectMcpPath, 'utf8'));
         if (existing?.mcpServers?.['claude-tempo']) {
           delete existing.mcpServers['claude-tempo'];
           if (Object.keys(existing.mcpServers).length === 0) {
-            unlinkSync(mcpPath);
+            unlinkSync(projectMcpPath);
             out.success('Removed .mcp.json (no other servers configured)');
           } else {
-            writeFileSync(mcpPath, JSON.stringify(existing, null, 2) + '\n');
+            writeFileSync(projectMcpPath, JSON.stringify(existing, null, 2) + '\n');
             out.success('Removed claude-tempo from .mcp.json');
           }
         }
       } catch {
-        out.warn(`Could not update ${mcpPath}`);
+        out.warn(`Could not update ${projectMcpPath}`);
       }
     }
+  }
+
+  if (hasNpxWarning) {
+    console.log();
+    out.warn('Your .mcp.json uses npx which may cache stale versions.');
+    out.log(`  ${out.dim('Consider removing it — user-level registration is preferred.')}`);
+    out.log(`  ${out.dim('Run: claude-tempo init')}`);
   }
 
   console.log();


### PR DESCRIPTION
## Summary
- `claude-tempo down` without ensemble name now auto-detects running ensembles (1→auto-select, 2+→list, 0→error)
- `--all` now terminates scheduler, per-ensemble Maestro, and global Maestro workflows (previously only terminated sessions)
- Warns if project `.mcp.json` uses npx (stale cache risk)
- Connection leak fix in auto-detect path (try/finally)
- TUI: auto-starts Maestro on connect; fixes ESM ink import in CJS compilation

## Test plan
- [ ] `npm run build` passes
- [ ] `claude-tempo down` with one ensemble running → auto-selects it
- [ ] `claude-tempo down --all` → terminates all sessions + schedulers + maestro
- [ ] `.mcp.json` with npx → warning displayed
- [ ] TUI opens without prior `claude-tempo up` (auto-starts Maestro)

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)