### PR TITLE
fix(tools): validate schedule targets and track player renames (#74)

### DIFF
--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -103,6 +103,7 @@ Signals sent **to** a `claudeSchedulerWorkflow` instance.
 |-------------|---------|-------------|
 | `addSchedule` | `ScheduleEntry` | Registers a new named schedule. If a schedule with the same name already exists it is replaced. `ScheduleEntry.type` is `'once'`, `'interval'`, or `'cron'`. Cron schedules include `cronExpression` and optional `timezone`. |
 | `removeSchedule` | `string` (schedule name) | Cancels and removes a named schedule. No-op if the name is not found. |
+| `updateScheduleTarget` | `[string, string]` (oldName, newName) | Rewrites schedule `target` and `createdBy` fields from `oldName` to `newName`. Fired by `set_name` when a player renames. No-op if no entries match. |
 
 ---
 

--- a/src/tools/load-lineup.ts
+++ b/src/tools/load-lineup.ts
@@ -269,9 +269,22 @@ export function registerLoadLineupTool(
 
         // Create schedules
         const schedulesCreated: string[] = [];
+        const scheduleWarnings: string[] = [];
         if (lineup.schedules && lineup.schedules.length > 0) {
+          // Build valid target set from lineup player names + special values
+          const validTargets = new Set<string>(lineup.players.map((p) => p.name));
+          validTargets.add('conductor');
+          validTargets.add('all');
+
           for (const sched of lineup.schedules) {
             try {
+              // Validate schedule target against known player names
+              if (!validTargets.has(sched.target)) {
+                scheduleWarnings.push(
+                  `schedule "${sched.name}": target "${sched.target}" does not match any player in this lineup (known: ${[...validTargets].join(', ')})`
+                );
+              }
+
               const now = Date.now();
               let nextFireAt: number;
               let interval: number | undefined;
@@ -356,6 +369,9 @@ export function registerLoadLineupTool(
         }
         if (schedulesCreated.length > 0) {
           lines.push(`Schedules created: ${schedulesCreated.join(', ')}`);
+        }
+        if (scheduleWarnings.length > 0) {
+          lines.push(`⚠ Schedule target warnings:\n${scheduleWarnings.map(w => `  - ${w}`).join('\n')}`);
         }
         if (failed.length > 0) {
           lines.push(`Failures:\n${failed.map(f => `  - ${f}`).join('\n')}`);

--- a/src/tools/schedule.ts
+++ b/src/tools/schedule.ts
@@ -4,6 +4,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Client, WorkflowIdConflictPolicy } from '@temporalio/client';
 import { Config, schedulerWorkflowId } from '../config';
 import { parseDuration } from '../utils/duration';
+import { resolveSession } from './resolve';
 import { defineTool, ok, fail, formatError } from './helpers';
 import { SCHEDULE_NAME_MAX, SCHEDULE_MESSAGE_MAX, PLAYER_NAME_MAX, CRON_EXPRESSION_MAX } from '../utils/validation';
 
@@ -49,6 +50,19 @@ export function registerScheduleTool(
       // Resolve "self" to the current player name
       if (target === 'self') {
         target = getPlayerId();
+      }
+
+      // Validate target player exists (warn, don't block)
+      let targetWarning: string | undefined;
+      if (target !== 'all' && target !== 'conductor') {
+        try {
+          const targetHandle = await resolveSession(client, config.ensemble, target);
+          if (!targetHandle) {
+            targetWarning = `Warning: player "${target}" is not currently active. The schedule will be created but may fail to deliver until the player joins.`;
+          }
+        } catch {
+          // Resolution failed — don't block schedule creation
+        }
       }
 
       // Validate exactly one timing option
@@ -154,7 +168,8 @@ export function registerScheduleTool(
           : interval
             ? ` (repeating every ${every})`
             : ' (one-shot)';
-        return ok(`Schedule **${name}** created. Next fire: ${fireDate}${recur}. Target: ${target}.`);
+        const msg = `Schedule **${name}** created. Next fire: ${fireDate}${recur}. Target: ${target}.`;
+        return ok(targetWarning ? `${msg}\n\n⚠ ${targetWarning}` : msg);
       } catch (err) {
         return fail(`Failed to create schedule: ${formatError(err)}`);
       }

--- a/src/tools/set-name.ts
+++ b/src/tools/set-name.ts
@@ -1,10 +1,13 @@
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WorkflowHandle, Client } from '@temporalio/client';
-import { Config } from '../config';
+import { Config, schedulerWorkflowId } from '../config';
+import { updateScheduleTargetSignal } from '../workflows/scheduler-signals';
 import { resolveSession } from './resolve';
 import { defineTool, ok, fail, formatError } from './helpers';
 import { PLAYER_NAME_MAX, validatePlayerName } from '../utils/validation';
+
+const log = (...args: unknown[]) => console.error('[claude-tempo:set-name]', ...args);
 
 export function registerSetNameTool(
   server: McpServer,
@@ -37,8 +40,19 @@ export function registerSetNameTool(
       }
 
       try {
+        const oldName = getPlayerId();
         await handle.signal('setName', name);
         setPlayerId(name);
+
+        // Notify the scheduler to rewrite schedule targets from old name to new name
+        try {
+          const schedulerHandle = client.workflow.getHandle(schedulerWorkflowId(config.ensemble));
+          await schedulerHandle.signal(updateScheduleTargetSignal, oldName, name);
+        } catch {
+          // Scheduler may not be running — that's fine, no schedules to update
+          log(`No scheduler to notify about rename ${oldName} → ${name}`);
+        }
+
         return ok(`Session name set to **${name}**. Run \`/rename ${name}\` to match your Claude Code session name.`);
       } catch (err) {
         return fail(`Failed to set name: ${formatError(err)}`);

--- a/src/workflows/scheduler-signals.ts
+++ b/src/workflows/scheduler-signals.ts
@@ -8,6 +8,9 @@ export type { ScheduleEntry } from '../types';
 export const addScheduleSignal = defineSignal<[ScheduleEntry]>('addSchedule');
 export const removeScheduleSignal = defineSignal<[string]>('removeSchedule');
 
+/** Rewrite schedule targets from oldName to newName (fired on player rename). */
+export const updateScheduleTargetSignal = defineSignal<[string, string]>('updateScheduleTarget');
+
 // ── Scheduler Queries ──
 
 export const getSchedulesQuery = defineQuery<ScheduleEntry[]>('getSchedules');

--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -11,6 +11,7 @@ import {
 import {
   addScheduleSignal,
   removeScheduleSignal,
+  updateScheduleTargetSignal,
   getSchedulesQuery,
   getScheduleQuery,
 } from './scheduler-signals';
@@ -48,6 +49,18 @@ export async function claudeSchedulerWorkflow(input: SchedulerInput): Promise<vo
 
   setHandler(removeScheduleSignal, (name) => {
     entries = entries.filter((e) => e.name !== name);
+    dirty = true;
+  });
+
+  setHandler(updateScheduleTargetSignal, (oldName, newName) => {
+    for (const entry of entries) {
+      if (entry.target === oldName) {
+        entry.target = newName;
+      }
+      if (entry.createdBy === oldName) {
+        entry.createdBy = newName;
+      }
+    }
     dirty = true;
   });
 

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -16,6 +16,7 @@ import {
 import {
   addScheduleSignal,
   removeScheduleSignal,
+  updateScheduleTargetSignal,
   getSchedulesQuery,
   getScheduleQuery,
 } from '../src/workflows/scheduler-signals';
@@ -157,6 +158,83 @@ describe('claudeSchedulerWorkflow', function () {
         expect(schedules).to.have.lengthOf(0);
 
         // Should self-terminate since empty — cancel to not wait 30s
+        await handle.cancel();
+        try { await handle.result(); } catch { /* cancelled */ }
+      });
+    });
+
+    it('updates schedule targets on player rename via updateScheduleTarget signal', async function () {
+      await withWorkerAndActivities(async () => {
+        const handle = await startScheduler(getClient());
+
+        // Add two schedules targeting the same player, and one targeting a different player
+        const entry1 = makeEntry({
+          name: 'sched-a',
+          message: 'msg-a',
+          target: 'old-name',
+          createdBy: 'old-name',
+          nextFireAt: new Date(Date.now() + 60_000).toISOString(),
+        });
+        const entry2 = makeEntry({
+          name: 'sched-b',
+          message: 'msg-b',
+          target: 'old-name',
+          createdBy: 'someone-else',
+          nextFireAt: new Date(Date.now() + 60_000).toISOString(),
+        });
+        const entry3 = makeEntry({
+          name: 'sched-c',
+          message: 'msg-c',
+          target: 'other-player',
+          createdBy: 'old-name',
+          nextFireAt: new Date(Date.now() + 60_000).toISOString(),
+        });
+        await handle.signal(addScheduleSignal, entry1);
+        await handle.signal(addScheduleSignal, entry2);
+        await handle.signal(addScheduleSignal, entry3);
+
+        // Rename old-name → new-name
+        await handle.signal(updateScheduleTargetSignal, 'old-name', 'new-name');
+
+        const schedules = await handle.query(getSchedulesQuery);
+        expect(schedules).to.have.lengthOf(3);
+
+        const schedA = schedules.find(s => s.name === 'sched-a')!;
+        expect(schedA.target).to.equal('new-name');
+        expect(schedA.createdBy).to.equal('new-name');
+
+        const schedB = schedules.find(s => s.name === 'sched-b')!;
+        expect(schedB.target).to.equal('new-name');
+        expect(schedB.createdBy).to.equal('someone-else'); // unchanged — different creator
+
+        const schedC = schedules.find(s => s.name === 'sched-c')!;
+        expect(schedC.target).to.equal('other-player'); // unchanged — different target
+        expect(schedC.createdBy).to.equal('new-name'); // updated — was old-name
+
+        await handle.cancel();
+        try { await handle.result(); } catch { /* cancelled */ }
+      });
+    });
+
+    it('updateScheduleTarget is a no-op when no schedules match', async function () {
+      await withWorkerAndActivities(async () => {
+        const handle = await startScheduler(getClient());
+
+        const entry = makeEntry({
+          name: 'no-match',
+          message: 'msg',
+          target: 'player-x',
+          nextFireAt: new Date(Date.now() + 60_000).toISOString(),
+        });
+        await handle.signal(addScheduleSignal, entry);
+
+        // Rename a player that has no schedules
+        await handle.signal(updateScheduleTargetSignal, 'nonexistent', 'irrelevant');
+
+        const schedules = await handle.query(getSchedulesQuery);
+        expect(schedules).to.have.lengthOf(1);
+        expect(schedules[0].target).to.equal('player-x'); // unchanged
+
         await handle.cancel();
         try { await handle.result(); } catch { /* cancelled */ }
       });


### PR DESCRIPTION
## Summary
- Validate schedule targets against player names in `load-lineup` at load time (warn on mismatch)
- Add `updateScheduleTarget` scheduler signal so `set_name` renames propagate to existing schedules
- Validate target player exists in `schedule` tool at creation time (warn, don't block)

Closes #74

## Changes
- `src/workflows/scheduler-signals.ts` — new `updateScheduleTargetSignal` (additive, non-breaking)
- `src/workflows/scheduler.ts` — handler rewrites `target` and `createdBy` on matching entries
- `src/tools/set-name.ts` — signals scheduler after rename
- `src/tools/load-lineup.ts` — validates targets against lineup player names
- `src/tools/schedule.ts` — resolveSession check at creation time
- `docs/WIRE-PROTOCOL.md` — documents new signal
- `test/scheduler.test.ts` — 2 new tests (rename + no-op)

## Test plan
- [x] 357 tests passing (2 new)
- [x] `npm run build` passes
- [ ] Manual: create lineup with mismatched schedule target → should warn
- [ ] Manual: rename a player with active schedules → schedules should follow

🤖 Generated with [Claude Code](https://claude.com/claude-code)