### PR TITLE
fix(cli): detect existing conductor in up command (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.20.1] - 2026-04-08
+
+### Fixed
+
+- `claude-tempo up` now detects an existing running conductor and prompts with options: join as player, reconnect, tear down and start fresh, or cancel. Prevents two sessions from silently sharing the same Temporal workflow (#85)
+
 ## [0.20.0] - 2026-04-08
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -76,6 +76,8 @@ Launching conductor in ensemble myband...
   Or ask the conductor to recruit players for you
 ```
 
+If a conductor is already running in the target ensemble, `up` detects it and prompts with options: join as a player, reconnect to the existing conductor, tear down and start fresh, or cancel. This prevents two sessions from silently sharing the same Temporal workflow.
+
 ### `claude-tempo server`
 
 Starts the Temporal dev server with automatic search attribute registration:

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -762,19 +762,12 @@ export async function up(opts: UpOpts) {
           return;
 
         case '3':
-          // Tear down and start fresh
+          // Terminate existing workflows, then fall through to normal up flow
           console.log();
-          out.log('Tearing down...');
-          await down({
-            ensemble: opts.ensemble,
-            all: false,
-            removeMcp: false,
-            keepDaemon: true,
-            yes: true,
-            dir: process.cwd(),
-          });
-          console.log();
-          out.log('Starting fresh...');
+          try { await client.workflow.getHandle(conductorWfId).terminate('up: fresh start'); } catch { /* may not exist */ }
+          try { await client.workflow.getHandle(schedulerWorkflowId(opts.ensemble)).terminate('up: fresh start'); } catch { /* may not exist */ }
+          try { await client.workflow.getHandle(maestroWorkflowId(opts.ensemble)).terminate('up: fresh start'); } catch { /* may not exist */ }
+          out.success('Existing ensemble torn down');
           // Fall through to normal up flow below
           break;
 

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -696,15 +696,101 @@ export async function up(opts: UpOpts) {
   // Resolve conductor agent from lineup or CLI flags
   const conductorAgent: AgentType = lineup?.conductor?.agent === 'copilot' ? 'copilot' : opts.agent;
 
-  // Step 5: Connect to Temporal and pre-create conductor workflow before spawning
+  // Step 5: Connect to Temporal and check for existing conductor
   console.log();
-  out.log(`Launching conductor in ensemble ${out.cyan(opts.ensemble)}${conductorAgent === 'copilot' ? out.dim(' (copilot)') : ''}...`);
 
   const connection = await createTemporalConnection(config);
   const client = new Client({ connection, namespace: config.temporalNamespace });
 
-  const sessionName = opts.name || lineup?.conductor?.name || (conductorAgent === 'copilot' ? `${opts.ensemble}-conductor` : 'conductor');
   const conductorWfId = conductorWorkflowId(opts.ensemble);
+
+  // Check if a conductor is already running
+  try {
+    const existingHandle = client.workflow.getHandle(conductorWfId);
+    const desc = await existingHandle.describe();
+    if (desc.status.name === 'RUNNING') {
+      if (!process.stdin.isTTY) {
+        out.error(`A conductor is already running for ensemble "${opts.ensemble}".`);
+        out.log(`  Use ${out.dim('--resume')} to reconnect, or ${out.dim('claude-tempo start')} to join as a player.`);
+        process.exit(1);
+      }
+
+      out.warn(`A conductor is already running for ensemble "${opts.ensemble}".`);
+      console.log();
+      out.log(`  1) Join as a new player session`);
+      out.log(`  2) Reconnect to the existing conductor (--resume)`);
+      out.log(`  3) Tear down and start fresh`);
+      out.log(`  4) Cancel`);
+      console.log();
+
+      const choice = await new Promise<string>((res) => {
+        const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+        rl.question(`  ${out.cyan('?')} Choose an option [1-4]: `, (answer) => {
+          rl.close();
+          res(answer.trim());
+        });
+      });
+
+      switch (choice) {
+        case '1':
+          // Join as a player — delegate to start()
+          console.log();
+          out.log('Joining as a player session...');
+          await start({
+            ensemble: opts.ensemble,
+            conductor: false,
+            name: opts.name,
+            skipPreflight: true, // infrastructure already verified above
+            agent: opts.agent,
+            dir: process.cwd(),
+          });
+          return;
+
+        case '2':
+          // Reconnect to existing conductor
+          console.log();
+          out.log('Reconnecting to existing conductor...');
+          await start({
+            ensemble: opts.ensemble,
+            conductor: true,
+            resume: true,
+            name: opts.name,
+            skipPreflight: true,
+            agent: opts.agent,
+            dir: process.cwd(),
+          });
+          return;
+
+        case '3':
+          // Tear down and start fresh
+          console.log();
+          out.log('Tearing down...');
+          await down({
+            ensemble: opts.ensemble,
+            all: false,
+            removeMcp: false,
+            keepDaemon: true,
+            yes: true,
+            dir: process.cwd(),
+          });
+          console.log();
+          out.log('Starting fresh...');
+          // Fall through to normal up flow below
+          break;
+
+        case '4':
+        default:
+          out.log('Cancelled.');
+          process.exit(0);
+      }
+    }
+  } catch {
+    // No existing conductor — proceed normally
+  }
+
+  out.log(`Launching conductor in ensemble ${out.cyan(opts.ensemble)}${conductorAgent === 'copilot' ? out.dim(' (copilot)') : ''}...`);
+
+  const sessionName = opts.name || lineup?.conductor?.name || (conductorAgent === 'copilot' ? `${opts.ensemble}-conductor` : 'conductor');
 
   // Resolve conductor agent type from lineup
   const conductorType = lineup?.conductor?.agent && lineup.conductor.agent !== 'default' && lineup.conductor.agent !== 'copilot'


### PR DESCRIPTION
## Summary

- `claude-tempo up` now detects an existing running conductor and prompts with options instead of silently reusing the workflow
- TTY: 4-option prompt (join as player / reconnect / tear down + fresh / cancel)
- Non-TTY: exits code 1 with guidance
- Prevents two sessions from sharing the same Temporal workflow

Closes #85

## Test plan

- [x] 371 tests passing, build clean
- [x] Code reviewed and approved by QA
- [x] Wire protocol untouched
- [x] First `up` (no existing conductor) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)