### PR TITLE
feat(config): add custom claude executable alias (#87)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [0.21.0] - 2026-04-08
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Added
+
+- Custom claude executable alias: `CLAUDE_TEMPO_CLAUDE_BIN` env var and `claude-tempo config set claude-bin` (#87)
+
 ## [0.20.1] - 2026-04-08
 
 ### Fixed

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,6 +21,7 @@ Settings are stored in `~/.claude-tempo/config.json`. You can also set values no
 claude-tempo config set temporalAddress my-ns.tmprl.cloud:7233
 claude-tempo config set temporalNamespace my-ns.abc123
 claude-tempo config set temporalApiKey tcl_...
+claude-tempo config set claude-bin /usr/local/bin/claude-nightly
 claude-tempo config show
 ```
 
@@ -48,6 +49,23 @@ Settings are resolved in this order (first match wins):
 | `CLAUDE_TEMPO_CONDUCTOR` | `false` | Enable conductor mode |
 | `CLAUDE_TEMPO_PLAYER_NAME` | *(random hex)* | Player name on startup |
 | `CLAUDE_TEMPO_DEFAULT_AGENT` | `claude` | Default agent type (`claude` or `copilot`) |
+| `CLAUDE_TEMPO_CLAUDE_BIN` | *(auto-detected)* | Path to a custom `claude` executable. Takes precedence over the config file setting and `which`/`where` auto-detection. Useful when multiple Claude versions are installed or the binary is not on `PATH`. |
+
+## Custom Claude Executable
+
+By default, claude-tempo auto-detects the `claude` binary using `which` (POSIX) or `where` (Windows). To use a different binary:
+
+```bash
+# Set via env var (takes highest precedence)
+export CLAUDE_TEMPO_CLAUDE_BIN=/usr/local/bin/claude-nightly
+
+# Or persist in config file
+claude-tempo config set claude-bin /usr/local/bin/claude-nightly
+```
+
+**Resolution order:** `CLAUDE_TEMPO_CLAUDE_BIN` env var → config file → `which`/`where` → bare `claude` fallback.
+
+Paths with spaces are handled correctly on both Windows and POSIX.
 
 ## Temporal Cloud
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.21.0",
+  "version": "0.20.1",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.20.1",
+  "version": "0.21.0",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -132,6 +132,7 @@ export async function start(opts: StartOpts) {
   if (config.temporalApiKey) temporalEnvVars[ENV.TEMPORAL_API_KEY] = config.temporalApiKey;
   if (config.temporalTlsCertPath) temporalEnvVars[ENV.TEMPORAL_TLS_CERT_PATH] = config.temporalTlsCertPath;
   if (config.temporalTlsKeyPath) temporalEnvVars[ENV.TEMPORAL_TLS_KEY_PATH] = config.temporalTlsKeyPath;
+  if (config.claudeBin) temporalEnvVars[ENV.CLAUDE_BIN] = config.claudeBin;
 
   if (opts.agent === 'copilot') {
     const { pid } = spawnCopilotBridge({
@@ -168,7 +169,7 @@ export async function start(opts: StartOpts) {
       [ENV.PLAYER_NAME]: sessionName || '',
     };
 
-    const { pid } = spawnInTerminal(claudeArgs, workDir, envVars);
+    const { pid } = spawnInTerminal(claudeArgs, workDir, envVars, { claudeBin: config.claudeBin });
     out.success(`Launched ${role} session${sessionName ? ` "${sessionName}"` : ''} (pid ${pid ?? 'unknown'})`);
   }
   out.log(`  Ensemble: ${opts.ensemble}`);
@@ -875,7 +876,7 @@ export async function up(opts: UpOpts) {
       conductorEnvVars[ENV.PLAYER_TYPE] = resolvedConductorType?.name || conductorTypeName || '';
     }
 
-    ({ pid } = spawnInTerminal(claudeArgs, process.cwd(), conductorEnvVars));
+    ({ pid } = spawnInTerminal(claudeArgs, process.cwd(), conductorEnvVars, { claudeBin: config.claudeBin }));
   }
 
   out.success(`Conductor launched (pid ${pid ?? 'unknown'})`);
@@ -987,7 +988,7 @@ export async function up(opts: UpOpts) {
             if (resolvedPlayerType) {
               playerEnvVars[ENV.PLAYER_TYPE] = resolvedPlayerType.name;
             }
-            spawnInTerminal(claudeArgs, playerWorkDir, playerEnvVars);
+            spawnInTerminal(claudeArgs, playerWorkDir, playerEnvVars, { claudeBin: config.claudeBin });
           }
           out.log(`  ${out.green('ok')} ${out.bold(player.name)} in ${playerWorkDir}`);
         } catch (err) {
@@ -1865,8 +1866,9 @@ export async function encore(opts: EncoreOpts) {
   if (config.temporalApiKey) envVars[ENV.TEMPORAL_API_KEY] = config.temporalApiKey;
   if (config.temporalTlsCertPath) envVars[ENV.TEMPORAL_TLS_CERT_PATH] = config.temporalTlsCertPath;
   if (config.temporalTlsKeyPath) envVars[ENV.TEMPORAL_TLS_KEY_PATH] = config.temporalTlsKeyPath;
+  if (config.claudeBin) envVars[ENV.CLAUDE_BIN] = config.claudeBin;
 
-  const { pid } = spawnInTerminal(spawnArgs, targetMeta.workDir, envVars);
+  const { pid } = spawnInTerminal(spawnArgs, targetMeta.workDir, envVars, { claudeBin: config.claudeBin });
   out.success(`Encore! "${opts.name}" revived (pid ${pid})`);
 
   await connection.close();

--- a/src/cli/config-command.ts
+++ b/src/cli/config-command.ts
@@ -150,6 +150,8 @@ export function configSet(key: string, value: string): void {
     'temporal-tls-key-path': 'temporalTlsKeyPath',
     defaultAgent: 'defaultAgent',
     'default-agent': 'defaultAgent',
+    claudeBin: 'claudeBin',
+    'claude-bin': 'claudeBin',
   };
 
   const configKey = keyMap[key];
@@ -183,6 +185,7 @@ export function configShow(): void {
     { key: 'temporalTlsCertPath', configKey: 'temporalTlsCertPath' },
     { key: 'temporalTlsKeyPath', configKey: 'temporalTlsKeyPath' },
     { key: 'defaultAgent', configKey: 'defaultAgent' },
+    { key: 'claudeBin', configKey: 'claudeBin' },
   ];
 
   out.log(`  Config file: ${out.dim(CONFIG_FILE_PATH)}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -25,6 +25,7 @@ export const ENV = {
   TEMPORAL_TLS_KEY_PATH: 'TEMPORAL_TLS_KEY_PATH',
   DEFAULT_AGENT: 'CLAUDE_TEMPO_DEFAULT_AGENT',
   PLAYER_TYPE: 'CLAUDE_TEMPO_PLAYER_TYPE',
+  CLAUDE_BIN: 'CLAUDE_TEMPO_CLAUDE_BIN',
 } as const;
 
 export interface Config {
@@ -34,6 +35,7 @@ export interface Config {
   temporalTlsCertPath?: string;
   temporalTlsKeyPath?: string;
   defaultAgent: AgentType;
+  claudeBin?: string;
   taskQueue: string;
   ensemble: string;
 }
@@ -46,6 +48,7 @@ export interface PersistedConfig {
   temporalTlsCertPath?: string;
   temporalTlsKeyPath?: string;
   defaultAgent?: AgentType;
+  claudeBin?: string;
 }
 
 export const CLAUDE_TEMPO_HOME = join(homedir(), '.claude-tempo');
@@ -241,6 +244,7 @@ export function getConfig(overrides: CliOverrides = {}): Config {
     defaultAgent: validAgent(overrides.defaultAgent
       || process.env[ENV.DEFAULT_AGENT]
       || configFile.defaultAgent),
+    claudeBin: process.env[ENV.CLAUDE_BIN] || configFile.claudeBin || undefined,
     taskQueue: process.env[ENV.TASK_QUEUE] ?? 'claude-tempo',
     ensemble: process.env[ENV.ENSEMBLE] ?? 'default',
   };
@@ -290,6 +294,7 @@ export function getConfigWithSources(overrides: CliOverrides = {}): ConfigWithSo
   const tlsCert = resolveWithSource('temporalTlsCertPath', overrides.temporalTlsCertPath, ENV.TEMPORAL_TLS_CERT_PATH, configFile.temporalTlsCertPath, temporalCli.temporalTlsCertPath);
   const tlsKey = resolveWithSource('temporalTlsKeyPath', overrides.temporalTlsKeyPath, ENV.TEMPORAL_TLS_KEY_PATH, configFile.temporalTlsKeyPath, temporalCli.temporalTlsKeyPath);
   const defaultAgent = resolveWithSource('defaultAgent', overrides.defaultAgent, ENV.DEFAULT_AGENT, configFile.defaultAgent, undefined, 'claude');
+  const claudeBin = resolveWithSource('claudeBin', undefined, ENV.CLAUDE_BIN, configFile.claudeBin, undefined);
 
   return {
     config: {
@@ -299,6 +304,7 @@ export function getConfigWithSources(overrides: CliOverrides = {}): ConfigWithSo
       temporalTlsCertPath: tlsCert.value,
       temporalTlsKeyPath: tlsKey.value,
       defaultAgent: validAgent(defaultAgent.value),
+      claudeBin: claudeBin.value,
       taskQueue: process.env[ENV.TASK_QUEUE] ?? 'claude-tempo',
       ensemble: process.env[ENV.ENSEMBLE] ?? 'default',
     },
@@ -309,6 +315,7 @@ export function getConfigWithSources(overrides: CliOverrides = {}): ConfigWithSo
       temporalTlsCertPath: tlsCert.source,
       temporalTlsKeyPath: tlsKey.source,
       defaultAgent: defaultAgent.source,
+      claudeBin: claudeBin.source,
     },
   };
 }

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -129,8 +129,25 @@ export function shellQuote(s: string): string {
   return `'${s.replace(/'/g, "'\\''")}'`;
 }
 
-/** Resolve the absolute path to the `claude` binary */
-export function resolveClaudePath(): string {
+/**
+ * Resolve the path to the `claude` binary.
+ *
+ * Resolution order:
+ *  1. `configBin` parameter (from Config.claudeBin — env var or config file)
+ *  2. `CLAUDE_TEMPO_CLAUDE_BIN` env var (checked directly for spawned processes that
+ *     may not have full config resolution, e.g., activities)
+ *  3. `which claude` / `where claude` lookup
+ *  4. Bare `claude` fallback
+ */
+export function resolveClaudePath(configBin?: string): string {
+  // Priority 1: explicit config value
+  if (configBin) return configBin;
+
+  // Priority 2: env var (may be set by parent process)
+  const envBin = process.env.CLAUDE_TEMPO_CLAUDE_BIN;
+  if (envBin) return envBin;
+
+  // Priority 3: which/where lookup
   const cmd = process.platform === 'win32' ? 'where' : 'which';
   try {
     return execFileSync(cmd, ['claude'], { encoding: 'utf8' }).trim().split('\n')[0];
@@ -203,8 +220,10 @@ export function buildClaudeCommand(
   const envInline = Object.entries(envVars)
     .map(([k, v]) => `${k}=${shellQuote(v)}`)
     .join(' ');
+  // Quote the binary path if it contains spaces (e.g., "C:\Program Files\...")
+  const quotedBin = claudeBin.includes(' ') ? shellQuote(claudeBin) : claudeBin;
   const args = claudeArgs.map(a => shellQuote(a)).join(' ');
-  return envInline ? `${envInline} ${claudeBin} ${args}` : `${claudeBin} ${args}`;
+  return envInline ? `${envInline} ${quotedBin} ${args}` : `${quotedBin} ${args}`;
 }
 
 /**
@@ -221,8 +240,9 @@ export function spawnInTerminal(
   claudeArgs: string[],
   workDir: string,
   envVars: Record<string, string>,
+  options?: { claudeBin?: string },
 ): { pid: number | undefined } {
-  const claudeBin = resolveClaudePath();
+  const claudeBin = resolveClaudePath(options?.claudeBin);
   const claudeInvocation = buildClaudeCommand(claudeBin, claudeArgs, envVars);
 
   if (process.platform === 'darwin') {
@@ -318,7 +338,9 @@ export function spawnInTerminal(
       const setCmds = Object.entries(envVars)
         .map(([k, v]) => `set "${k}=${cmdEscape(v)}"`)
         .join(' && ');
-      const claudeCmd = `${cmdEscape(claudeBin)} ${claudeArgs.map(a => `"${cmdEscape(a)}"`).join(' ')}`;
+      // Quote the binary path if it contains spaces (e.g., "C:\Program Files\...")
+      const quotedWinBin = claudeBin.includes(' ') ? `"${cmdEscape(claudeBin)}"` : cmdEscape(claudeBin);
+      const claudeCmd = `${quotedWinBin} ${claudeArgs.map(a => `"${cmdEscape(a)}"`).join(' ')}`;
       const innerCmd = setCmds
         ? `${setCmds} && ${claudeCmd}`
         : claudeCmd;


### PR DESCRIPTION
## Summary
- Adds `CLAUDE_TEMPO_CLAUDE_BIN` env var and `claude-tempo config set claude-bin` to configure a custom claude executable path/command
- Resolution order: env var → config file → `which`/`where` → bare `claude` fallback
- Cross-platform: handles paths with spaces on Windows (cmd.exe escaping) and POSIX (shell quoting)

## Changes
- **`src/config.ts`**: `CLAUDE_BIN` env constant, `claudeBin` field in `Config`/`PersistedConfig`, wired into `getConfig()` and `getConfigWithSources()`
- **`src/spawn.ts`**: `resolveClaudePath(configBin?)` checks configBin → env → which/where → fallback; `spawnInTerminal()` accepts `{ claudeBin }` option; `buildClaudeCommand()` quotes paths with spaces
- **`src/cli/commands.ts`**: All `spawnInTerminal` call sites pass `config.claudeBin`; env var propagated to child processes
- **`src/cli/config-command.ts`**: `claude-bin` added to config set/show

## Test plan
- [ ] `CLAUDE_TEMPO_CLAUDE_BIN=echo claude-tempo up test` uses `echo` instead of `claude`
- [ ] `claude-tempo config set claude-bin /usr/local/bin/my-claude` persists
- [ ] `claude-tempo config show` displays claude-bin and its source
- [ ] Env var takes precedence over config file
- [ ] Paths with spaces work on Windows
- [ ] Falls back to current behavior when neither is set
- [ ] `npm test` passes (371 tests)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)