### PR TITLE
fix(recruit): thread claudeBin config through recruit and encore pipelines (#90)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.21.1] - 2026-04-08
+
+### Fixed
+
+- Recruit and encore tools now use the configured `claudeBin` setting when spawning new player sessions. Previously, mid-session recruits ignored the custom binary path and fell back to the default `claude` command (#90)
+
 ## [0.21.0] - 2026-04-08
 
 ### Added

--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -49,6 +49,8 @@ export interface StartRecruitedSessionInput {
   agentDefinition?: string;
   agentDefinitionDescription?: string;
   allowedTools?: string[];
+  /** Custom claude binary path (from config.claudeBin). */
+  claudeBin?: string;
 }
 
 export interface SpawnProcessInput {
@@ -69,6 +71,8 @@ export interface SpawnProcessInput {
   claudeSessionId?: string;
   /** Tool restrictions from the agent definition frontmatter. */
   allowedTools?: string[];
+  /** Custom claude binary path (from config.claudeBin). */
+  claudeBin?: string;
 }
 
 export interface PerformEncoreInput {
@@ -91,6 +95,8 @@ export interface EncoreResult {
   claudeSessionId?: string;
   temporalAddress: string;
   temporalNamespace: string;
+  /** Custom claude binary path (from config.claudeBin). */
+  claudeBin?: string;
 }
 
 // ── Activity result type ──
@@ -237,7 +243,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
     },
 
     async spawnProcess(input: SpawnProcessInput): Promise<OutboxActivityResult> {
-      const { targetName, workDir, isConductor, agent, systemPrompt, ensemble, temporalAddress, temporalNamespace, agentDefinition, agentDefinitionPath, nativeResolvable, resume, claudeSessionId, allowedTools } = input;
+      const { targetName, workDir, isConductor, agent, systemPrompt, ensemble, temporalAddress, temporalNamespace, agentDefinition, agentDefinitionPath, nativeResolvable, resume, claudeSessionId, allowedTools, claudeBin } = input;
       // Read secrets from the worker's config closure — never from workflow state
       const { temporalApiKey, temporalTlsCertPath, temporalTlsKeyPath } = config;
       try {
@@ -298,7 +304,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
           if (temporalApiKey) envVars[ENV.TEMPORAL_API_KEY] = temporalApiKey;
           if (temporalTlsCertPath) envVars[ENV.TEMPORAL_TLS_CERT_PATH] = temporalTlsCertPath;
           if (temporalTlsKeyPath) envVars[ENV.TEMPORAL_TLS_KEY_PATH] = temporalTlsKeyPath;
-          const { pid } = spawnInTerminal(spawnArgs, workDir, envVars);
+          const { pid } = spawnInTerminal(spawnArgs, workDir, envVars, { claudeBin });
           log(`Spawned claude process (pid ${pid}) in ${workDir} as "${targetName}" (resume=${!!resume})`);
         }
 
@@ -387,6 +393,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
           claudeSessionId: (metadata.claudeSessionId as string) || undefined,
           temporalAddress: config.temporalAddress,
           temporalNamespace: config.temporalNamespace,
+          claudeBin: config.claudeBin,
         };
       } catch (err) {
         if (err instanceof ApplicationFailure) throw err;

--- a/src/tools/encore.ts
+++ b/src/tools/encore.ts
@@ -67,6 +67,7 @@ export function registerEncoreTool(
           targetPlayerId: playerId,
           targetHostname: host,
           contextMessageCount: contextMessages,
+          claudeBin: config.claudeBin,
         } as OutboxEntryInput;
         const entryId = await handle.executeUpdate(submitOutboxUpdate, { args: [entry] });
 

--- a/src/tools/load-lineup.ts
+++ b/src/tools/load-lineup.ts
@@ -173,6 +173,7 @@ export function registerLoadLineupTool(
               agentDefinitionDescription: resolvedType?.description,
               nativeResolvable: resolvedType?.nativeResolvable,
               allowedTools: player.allowedTools,
+              claudeBin: config.claudeBin,
             } as OutboxEntryInput;
             await handle.executeUpdate(submitOutboxUpdate, { args: [entry] });
             recruited.push(playerName);

--- a/src/tools/recruit.ts
+++ b/src/tools/recruit.ts
@@ -143,6 +143,7 @@ export function registerRecruitTool(
           agentDefinitionDescription,
           nativeResolvable,
           allowedTools,
+          claudeBin: config.claudeBin,
         } as OutboxEntryInput;
         const entryId = await handle.executeUpdate(submitOutboxUpdate, { args: [entry] });
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -145,6 +145,8 @@ export interface RecruitOutboxEntry extends OutboxEntryBase {
   nativeResolvable?: boolean;
   /** Tool restrictions from the agent definition frontmatter. */
   allowedTools?: string[];
+  /** Custom claude binary path (from config.claudeBin). */
+  claudeBin?: string;
 }
 
 export interface ReportOutboxEntry extends OutboxEntryBase {
@@ -163,6 +165,8 @@ export interface EncoreOutboxEntry extends OutboxEntryBase {
   targetPlayerId: string;
   targetHostname?: string;
   contextMessageCount?: number;
+  /** Custom claude binary path (from config.claudeBin). */
+  claudeBin?: string;
 }
 
 export type OutboxEntry = CueOutboxEntry | RecruitOutboxEntry | ReportOutboxEntry | StopOutboxEntry | EncoreOutboxEntry;

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -530,6 +530,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
               agentDefinition: entry.agentDefinition,
               agentDefinitionDescription: entry.agentDefinitionDescription,
               allowedTools: entry.allowedTools,
+              claudeBin: entry.claudeBin,
             });
             const targetHost = entry.targetHostname || input.metadata.hostname;
             const spawnFn = getSpawnProxy(targetHost);
@@ -547,6 +548,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
               nativeResolvable: entry.nativeResolvable,
               claudeSessionId: recruitResult.claudeSessionId,
               allowedTools: entry.allowedTools,
+              claudeBin: entry.claudeBin,
             });
             break;
           }
@@ -574,6 +576,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
                 allowedTools: encoreResult.allowedTools,
                 claudeSessionId: encoreResult.claudeSessionId,
                 resume: true,
+                claudeBin: entry.claudeBin || encoreResult.claudeBin,
               });
             } catch (spawnErr) {
               // Spawn failed after status was reset to pending — revert to stale

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -408,7 +408,62 @@ export async function withWorkerAndRecruitActivities<T>(fn: () => Promise<T>): P
       return await fn();
     } finally {
       hostWorker.shutdown();
-      await hostWorkerPromise.catch(() => {});
+      await hostWorkerPromise.catch(() => { /* cleanup */ });
+    }
+  });
+}
+
+/**
+ * Like withWorkerAndRecruitActivities, but captures spawnProcess inputs
+ * so tests can verify arguments passed through the recruit pipeline.
+ */
+export async function withWorkerAndRecruitCapture<T>(
+  spawnInputs: Array<Record<string, unknown>>,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const { createScheduleActivities } = await import('../src/activities/schedule-fire');
+  const { createOutboxActivities } = await import('../src/activities/outbox');
+
+  const scheduleActivities = createScheduleActivities(testEnv.client);
+  const outboxActivities = createOutboxActivities(testEnv.client, {
+    temporalAddress: '',
+    temporalNamespace: 'default',
+    taskQueue: TASK_QUEUE,
+    ensemble: 'test-ensemble',
+    defaultAgent: 'claude',
+  });
+
+  const capturingSpawn = async (input: Record<string, unknown>) => {
+    spawnInputs.push(input);
+    return { success: true };
+  };
+
+  const mainWorker = await Worker.create({
+    connection: testEnv.nativeConnection,
+    taskQueue: TASK_QUEUE,
+    workflowBundle,
+    activities: {
+      ...scheduleActivities,
+      ...outboxActivities,
+      spawnProcess: capturingSpawn,
+    },
+  });
+
+  const hostWorker = await Worker.create({
+    connection: testEnv.nativeConnection,
+    taskQueue: `claude-tempo-test-host`,
+    activities: {
+      spawnProcess: capturingSpawn,
+    },
+  });
+
+  return mainWorker.runUntil(async () => {
+    const hostWorkerPromise = hostWorker.run();
+    try {
+      return await fn();
+    } finally {
+      hostWorker.shutdown();
+      await hostWorkerPromise.catch(() => { /* cleanup */ });
     }
   });
 }

--- a/test/outbox.test.ts
+++ b/test/outbox.test.ts
@@ -4,6 +4,7 @@ import {
   teardownTestEnv,
   withWorkerAndOutboxActivities,
   withWorkerAndRecruitActivities,
+  withWorkerAndRecruitCapture,
   startSession,
   playerMetadata,
   conductorMetadata,
@@ -392,6 +393,56 @@ describe('outbox', function () {
 
         await handle.signal(updateMetadataSignal, { status: 'terminated' });
         await handle.result();
+        await recruitedHandle.signal(updateMetadataSignal, { status: 'terminated' });
+        try { await recruitedHandle.result(); } catch { /* cleanup */ }
+      });
+    });
+
+    it('forwards claudeBin from outbox entry to spawnProcess', async function () {
+      this.timeout(30_000);
+      const spawnInputs: Array<Record<string, unknown>> = [];
+      await withWorkerAndRecruitCapture(spawnInputs, async () => {
+        const ensemble = `recruit-bin-${Date.now()}`;
+
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: 'recruiter-bin', ensemble }),
+          temporalConfig: {
+            temporalAddress: '',
+            temporalNamespace: 'default',
+            taskQueue: TASK_QUEUE,
+          },
+        });
+
+        await handle.executeUpdate(submitOutboxUpdate, {
+          args: [{
+            type: 'recruit',
+            targetName: 'bin-player',
+            workDir: '/tmp/test',
+            isConductor: false,
+            agent: 'claude',
+            claudeBin: '/custom/path/to/claude',
+          }],
+        });
+
+        // Wait for dispatch loop to process the recruit entry
+        await sleep(3000);
+
+        // Outbox entry should be delivered
+        const outboxEntries = await handle.query(outboxQuery);
+        const recruitEntry = outboxEntries.find((e) => e.type === 'recruit');
+        expect(recruitEntry).to.exist;
+        expect(recruitEntry!.status).to.equal('delivered');
+
+        // spawnProcess should have been called with claudeBin
+        expect(spawnInputs).to.have.lengthOf(1);
+        expect(spawnInputs[0].claudeBin).to.equal('/custom/path/to/claude');
+
+        // Cleanup
+        await handle.signal(updateMetadataSignal, { status: 'terminated' });
+        await handle.result();
+        const recruitedHandle = getClient().workflow.getHandle(
+          `claude-session-${ensemble}-bin-player`,
+        );
         await recruitedHandle.signal(updateMetadataSignal, { status: 'terminated' });
         try { await recruitedHandle.result(); } catch { /* cleanup */ }
       });


### PR DESCRIPTION
## Summary

- Threads `claudeBin` config setting through the full recruit and encore pipelines so mid-session recruits use the configured Claude binary instead of falling back to default
- Adds `claudeBin?: string` to `RecruitOutboxEntry` and `EncoreOutboxEntry`
- All three recruit entry points patched: `recruit.ts`, `load-lineup.ts`, `encore.ts`
- New regression test verifying claudeBin flows end-to-end through outbox dispatch

Fixes #90

## Test plan

- [x] New test: `claudeBin` flows from outbox entry to `spawnProcess` input
- [x] Full test suite passes (371+ tests)
- [x] Build passes clean
- [x] Wire protocol: additive optional fields only, no breaking changes
- [x] QA code review: APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)