### PR TITLE
fix: prevent terminated session resurrection cycling

### DIFF
--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -220,10 +220,10 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
           } : {}),
         };
 
-        await client.workflow.start('claudeSessionWorkflow', {
+        const startOpts = {
           workflowId,
           taskQueue,
-          args: [sessionInput],
+          args: [sessionInput] as [SessionInput],
           workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
           searchAttributes: {
             ...(gitRoot ? { ClaudeTempoGitRoot: [gitRoot] } : {}),
@@ -231,7 +231,20 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             ClaudeTempoEnsemble: [ensemble],
             ClaudeTempoPlayerId: [targetName],
           },
-        });
+        };
+
+        let handle = await client.workflow.start('claudeSessionWorkflow', startOpts);
+
+        // Check if the workflow is actually alive — USE_EXISTING returns handles
+        // to completed/terminated workflows, causing signals to be silently ignored
+        const desc = await handle.describe();
+        if (desc.status.name !== 'RUNNING') {
+          log(`Workflow ${workflowId} is ${desc.status.name} — force-starting a fresh instance`);
+          handle = await client.workflow.start('claudeSessionWorkflow', {
+            ...startOpts,
+            workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
+          });
+        }
 
         log(`Pre-created workflow ${workflowId} for recruit "${targetName}" (sessionId=${sessionId})`);
         return { success: true, sessionId };

--- a/src/copilot-bridge.ts
+++ b/src/copilot-bridge.ts
@@ -342,6 +342,19 @@ async function main() {
 
   /** Attempt to recreate the Copilot session after repeated failures. */
   async function recreateSession(): Promise<boolean> {
+    // Check if the workflow is still alive before attempting reconnection —
+    // prevents terminated sessions from entering a rapid rejoin loop
+    try {
+      const desc = await handle.describe();
+      if (desc.status.name !== 'RUNNING') {
+        log(`Workflow is ${desc.status.name} — not reconnecting (session was terminated)`);
+        return false;
+      }
+    } catch {
+      log('Workflow not found — not reconnecting');
+      return false;
+    }
+
     sessionRecreations++;
     if (sessionRecreations > MAX_SESSION_RECREATIONS) {
       log(`ERROR: Exceeded max session recreations (${MAX_SESSION_RECREATIONS}). Giving up.`);

--- a/src/server.ts
+++ b/src/server.ts
@@ -133,10 +133,10 @@ async function main() {
     },
   };
 
-  const handle = await client.workflow.start('claudeSessionWorkflow', {
+  const startOpts = {
     workflowId,
     taskQueue: config.taskQueue,
-    args: [sessionInput],
+    args: [sessionInput] as [SessionInput],
     workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
     // No execution timeout — workflows live until terminated status or stale detection.
     searchAttributes: {
@@ -145,7 +145,21 @@ async function main() {
       ClaudeTempoEnsemble: [config.ensemble],
       ClaudeTempoPlayerId: [playerId],
     },
-  });
+  };
+
+  let handle = await client.workflow.start('claudeSessionWorkflow', startOpts);
+
+  // Check if the workflow is actually alive — USE_EXISTING returns handles
+  // to completed/terminated workflows, causing signals to be silently ignored
+  const desc = await handle.describe();
+  if (desc.status.name !== 'RUNNING') {
+    log(`Workflow ${workflowId} is ${desc.status.name} — force-starting a fresh instance`);
+    handle = await client.workflow.start('claudeSessionWorkflow', {
+      ...startOpts,
+      workflowIdConflictPolicy: WorkflowIdConflictPolicy.TERMINATE_EXISTING,
+    });
+  }
+
   log(`Workflow ${workflowId} started (or reconnected)`);
 
   // Watch for workflow completion — exit the process when the workflow ends


### PR DESCRIPTION
## Problem
When a session is terminated, the \USE_EXISTING\ conflict policy returns the dead workflow handle. The bridge auto-reconnects, and if a conductor calls \ncore\, it creates an infinite resurrection cycle.

## Fix
- Add \handle.describe()\ check before returning existing handles
- Fall back to \TERMINATE_EXISTING\ when the existing workflow is not running
- Prevents zombie session cycling

## Related
Related to #99 — both discovered during long-running ensemble orchestration sessions.