### PR TITLE
test(tui): Phase 1 unit tests for reducer, slash parser, client fallbacks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-tempo",
-  "version": "0.20.1",
+  "version": "0.24.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-tempo",
-      "version": "0.20.1",
+      "version": "0.24.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.28.0",
@@ -27,6 +27,7 @@
         "claude-tempo-server": "dist/server.js"
       },
       "devDependencies": {
+        "@temporalio/common": "^1.15.0",
         "@temporalio/testing": "~1.15.0",
         "@types/chai": "^4.3.20",
         "@types/mocha": "^10.0.10",
@@ -36,7 +37,8 @@
         "mocha": "^11.7.5",
         "ts-node": "^10.9.0",
         "tsx": "^4.21.0",
-        "typescript": "^5.5.0"
+        "typescript": "^5.5.0",
+        "vitest": "^2.1.9"
       },
       "engines": {
         "node": ">=18"
@@ -1434,6 +1436,356 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@swc/core": {
       "version": "1.15.21",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.21.tgz",
@@ -1930,6 +2282,190 @@
         "csstype": "^3.2.2"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@vitest/expect/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vitest/expect/node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@webassemblyjs/ast": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
@@ -2369,6 +2905,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/call-bind-apply-helpers": {
@@ -3102,6 +3648,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3148,6 +3704,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -4058,6 +4624,16 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
@@ -4253,6 +4829,25 @@
         "node": ">=12.13"
       }
     },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
     "node_modules/negotiator": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
@@ -4443,6 +5038,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/pathval": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -4466,6 +5068,35 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.9",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
+      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/proto3-json-serializer": {
@@ -4653,6 +5284,51 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "license": "ISC"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -4908,6 +5584,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -5054,6 +5737,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -5062,6 +5752,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "4.2.3",
@@ -5272,6 +5969,50 @@
       },
       "peerDependencies": {
         "tslib": "^2"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -5511,6 +6252,656 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite-node/node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vite/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vite/node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/vitest/node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/vitest/node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/vitest/node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vitest/node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.1.tgz",
@@ -5610,6 +7001,23 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/widest-line": {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
     "dev": "ts-node src/server.ts",
     "copilot-bridge": "ts-node src/copilot-bridge.ts",
     "pretest": "tsc -p test/tsconfig.json",
-    "test": "mocha"
+    "test:tui": "vitest run",
+    "test": "mocha && vitest run"
   },
   "optionalDependencies": {
     "@github/copilot-sdk": "^0.2.0"
@@ -86,7 +87,8 @@
     "mocha": "^11.7.5",
     "ts-node": "^10.9.0",
     "tsx": "^4.21.0",
-    "typescript": "^5.5.0"
+    "typescript": "^5.5.0",
+    "vitest": "^2.1.9"
   },
   "typesVersions": {
     "*": {

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -1101,6 +1101,36 @@ export function formatHelpSummary(): string {
   return ['Available commands:', '', ...lines, '', 'Type /help <command> for details.'].join('\n');
 }
 
+/**
+ * Filter palette command entries by a typed prefix.
+ * Prefix may optionally include a leading '/' — it's stripped before matching.
+ * An empty prefix returns all commands in order.
+ *
+ * Pure function — safe to call from React render paths and unit tests.
+ */
+export function filterPaletteCommands<T extends { name: string }>(
+  commands: readonly T[],
+  filter: string,
+): T[] {
+  const prefix = filter.startsWith('/') ? filter.slice(1) : filter;
+  if (!prefix) return [...commands];
+  const lower = prefix.toLowerCase();
+  return commands.filter((c) => c.name.toLowerCase().startsWith(lower));
+}
+
+/**
+ * Resolve the target of a `/help <name>` invocation. Accepts either
+ * `recruit` or `/recruit` — both resolve to the same command def.
+ * Returns null if the command is unknown.
+ */
+export function resolveHelpTarget(raw: string): { name: string; def: CommandDef } | null {
+  const name = raw.replace(/^\//, '').trim().toLowerCase();
+  if (!name) return null;
+  const def = COMMANDS[name];
+  if (!def) return null;
+  return { name, def };
+}
+
 /** Commands that take a player name as their first parameter. */
 export const PLAYER_PARAM_COMMANDS = new Set(['stop', 'encore', 'worktree']);
 

--- a/src/tui/utils/format.ts
+++ b/src/tui/utils/format.ts
@@ -68,6 +68,20 @@ export function wordWrap(text: string, maxWidth: number): string[] {
   return result.length > 0 ? result : [''];
 }
 
+/**
+ * Format the "↑ N earlier message(s)" indicator shown above a truncated
+ * message list. Returns null when no indicator should render.
+ *
+ * - count <= 0          → null (no indicator)
+ * - count === 1         → "↑ 1 earlier message" (singular)
+ * - count >= 2          → "↑ N earlier messages" (plural)
+ */
+export function formatEarlierIndicator(count: number): string | null {
+  if (!Number.isFinite(count) || count <= 0) return null;
+  const label = count === 1 ? 'earlier message' : 'earlier messages';
+  return `\u2191 ${count} ${label}`;
+}
+
 /** Format an event type for display. */
 export function formatEventType(type: string): string {
   switch (type) {

--- a/tests/client/fallback.test.ts
+++ b/tests/client/fallback.test.ts
@@ -1,0 +1,332 @@
+/**
+ * Unit tests for TempoClient query fallback precedence.
+ * See src/client/index.ts. Issue #105, Phase 1.
+ *
+ * The client tries, in order:
+ *   1. Global Maestro workflow query
+ *   2. Per-ensemble Maestro workflow query
+ *   3. Direct workflow-list scan
+ * These tests mock the Temporal Client to exercise each fallback level
+ * deterministically without spinning up a Temporal test env.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createTempoClient } from '../../src/client';
+import type { MaestroPlayerInfo } from '../../src/types';
+
+// ── Helpers ──
+
+/** Build a minimal fake Temporal Client. */
+function makeFakeClient(opts: {
+  /** Map of workflowId → query handler (name → result or error fn). */
+  handlers: Record<string, Record<string, (...args: unknown[]) => unknown>>;
+  /** Async iterator of workflow descriptions for `workflow.list`. */
+  listItems?: Array<{ workflowId: string; searchAttributes?: Record<string, unknown[]> }>;
+  /** If set, workflow.list throws this error instead of yielding. */
+  listError?: Error;
+}): any {
+  return {
+    workflow: {
+      getHandle(workflowId: string) {
+        return {
+          workflowId,
+          async query(name: string, ...args: unknown[]) {
+            const wf = opts.handlers[workflowId];
+            if (!wf || !wf[name]) {
+              throw new Error(`No handler for ${workflowId}.query(${name})`);
+            }
+            const result = wf[name](...args);
+            if (result instanceof Error) throw result;
+            return result;
+          },
+          async executeUpdate(name: string, ...args: unknown[]) {
+            const wf = opts.handlers[workflowId];
+            if (!wf || !wf[name]) {
+              throw new Error(`No handler for ${workflowId}.executeUpdate(${name})`);
+            }
+            const result = wf[name](...args);
+            if (result instanceof Error) throw result;
+            return result;
+          },
+          async signal() { /* noop */ },
+          async describe() { return { status: { name: 'RUNNING' } }; },
+        };
+      },
+      async *list() {
+        if (opts.listError) throw opts.listError;
+        for (const item of opts.listItems ?? []) {
+          yield item;
+        }
+      },
+    },
+  };
+}
+
+function p(id: string, ensemble = 'demo', status = 'active'): MaestroPlayerInfo {
+  return {
+    playerId: id,
+    ensemble,
+    part: '',
+    hostname: 'test-host',
+    workDir: '/tmp',
+    isConductor: false,
+    agentType: 'claude',
+    status,
+  };
+}
+
+// ── getPlayers fallback precedence ──
+
+describe('TempoClient.getPlayers — fallback precedence', () => {
+  it('uses Global Maestro first when available', async () => {
+    const globalResult = { demo: [p('alice'), p('bob')] };
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroPlayersByEnsemble: () => globalResult,
+        },
+      },
+    });
+    const spy = vi.spyOn(fake.workflow, 'getHandle');
+    const client = createTempoClient(fake);
+
+    const players = await client.getPlayers('demo');
+
+    expect(players.map((x) => x.playerId)).toEqual(['alice', 'bob']);
+    // Should have hit the global maestro handle
+    expect(spy).toHaveBeenCalledWith('claude-maestro-global');
+  });
+
+  it('falls back to per-ensemble Maestro when Global Maestro fails', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroPlayersByEnsemble: () => new Error('global maestro unavailable'),
+        },
+        'claude-maestro-demo': {
+          maestroPlayers: () => [p('carol')],
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+
+    const players = await client.getPlayers('demo');
+    expect(players.map((x) => x.playerId)).toEqual(['carol']);
+  });
+
+  it('falls back to direct workflow-list scan when both Maestro tiers fail', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroPlayersByEnsemble: () => new Error('unavailable'),
+        },
+        'claude-maestro-demo': {
+          maestroPlayers: () => new Error('unavailable'),
+        },
+      },
+      listItems: [
+        {
+          workflowId: 'claude-session-demo-dave',
+          searchAttributes: {
+            ClaudeTempoEnsemble: ['demo'],
+            ClaudeTempoPlayerId: ['dave'],
+            ClaudeTempoHostname: ['host-1'],
+            ClaudeTempoStatus: ['active'],
+          },
+        },
+      ],
+    });
+    const client = createTempoClient(fake);
+
+    const players = await client.getPlayers('demo');
+    expect(players).toHaveLength(1);
+    expect(players[0].playerId).toBe('dave');
+    expect(players[0].status).toBe('active');
+  });
+
+  it('returns empty array when all three tiers fail', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': { maestroPlayersByEnsemble: () => new Error('x') },
+        'claude-maestro-demo': { maestroPlayers: () => new Error('x') },
+      },
+      listError: new Error('list failed'),
+    });
+    const client = createTempoClient(fake);
+    expect(await client.getPlayers('demo')).toEqual([]);
+  });
+
+  it('uses per-ensemble Maestro when global has no entry for the ensemble', async () => {
+    // Global Maestro is alive but doesn't know about "demo" yet
+    // (maestroPlayersByEnsemble returns an empty record for demo).
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroPlayersByEnsemble: () => ({ /* no demo key */ }),
+        },
+        'claude-maestro-demo': {
+          maestroPlayers: () => [p('eve')],
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+    const players = await client.getPlayers('demo');
+    expect(players.map((x) => x.playerId)).toEqual(['eve']);
+  });
+});
+
+// ── discoverEnsembles fallback ──
+
+describe('TempoClient.discoverEnsembles — fallback precedence', () => {
+  it('prefers Global Maestro and returns all ensembles it knows', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroPlayersByEnsemble: () => ({
+            demo: [p('alice'), { ...p('conductor'), isConductor: true }],
+            other: [p('bob')],
+          }),
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+    const ensembles = await client.discoverEnsembles();
+    expect(ensembles.map((e) => e.name).sort()).toEqual(['demo', 'other']);
+    const demo = ensembles.find((e) => e.name === 'demo')!;
+    expect(demo.playerCount).toBe(2);
+    expect(demo.hasConductor).toBe(true);
+    const other = ensembles.find((e) => e.name === 'other')!;
+    expect(other.hasConductor).toBe(false);
+  });
+
+  it('falls through to workflow list when Global Maestro returns empty', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroPlayersByEnsemble: () => ({}),
+        },
+      },
+      listItems: [
+        {
+          workflowId: 'claude-session-mine-conductor',
+          searchAttributes: {
+            ClaudeTempoEnsemble: ['mine'],
+            ClaudeTempoIsConductor: [true],
+            ClaudeTempoStatus: ['active'],
+          },
+        },
+        {
+          workflowId: 'claude-session-mine-alice',
+          searchAttributes: {
+            ClaudeTempoEnsemble: ['mine'],
+            ClaudeTempoIsConductor: [false],
+          },
+        },
+      ],
+    });
+    const client = createTempoClient(fake);
+    const ensembles = await client.discoverEnsembles();
+    expect(ensembles).toHaveLength(1);
+    expect(ensembles[0].name).toBe('mine');
+    expect(ensembles[0].playerCount).toBe(2);
+    expect(ensembles[0].hasConductor).toBe(true);
+    expect(ensembles[0].conductorStatus).toBe('active');
+  });
+
+  it('returns empty array when both Global Maestro and workflow list fail', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroPlayersByEnsemble: () => new Error('down'),
+        },
+      },
+      listError: new Error('list failed'),
+    });
+    const client = createTempoClient(fake);
+    expect(await client.discoverEnsembles()).toEqual([]);
+  });
+});
+
+// ── getMessages (Global Maestro only, no fallback) ──
+
+describe('TempoClient.getMessages', () => {
+  it('filters ring-buffer messages by ensemble', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroRecentMessages: () => [
+            { id: 'a', ensemble: 'demo', from: 'alice', to: 'maestro', text: 'hi', timestamp: '', direction: 'inbound' },
+            { id: 'b', ensemble: 'other', from: 'bob', to: 'maestro', text: 'other', timestamp: '', direction: 'inbound' },
+            { id: 'c', ensemble: 'demo', from: 'carol', to: 'maestro', text: 'hi2', timestamp: '', direction: 'inbound' },
+          ],
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+    const msgs = await client.getMessages('demo');
+    expect(msgs.map((m) => m.id)).toEqual(['a', 'c']);
+  });
+
+  it('applies limit as a tail slice', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroRecentMessages: () => Array.from({ length: 5 }, (_, i) => ({
+            id: `m${i}`, ensemble: 'demo', from: 'alice', to: 'maestro',
+            text: '', timestamp: '', direction: 'inbound' as const,
+          })),
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+    const msgs = await client.getMessages('demo', 2);
+    expect(msgs.map((m) => m.id)).toEqual(['m3', 'm4']);
+  });
+
+  it('returns empty array when Global Maestro query fails', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-global': {
+          maestroRecentMessages: () => new Error('x'),
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+    expect(await client.getMessages('demo')).toEqual([]);
+  });
+});
+
+// ── getEnsembleChat (per-ensemble Maestro only) ──
+
+describe('TempoClient.getEnsembleChat', () => {
+  it('returns chat from per-ensemble Maestro', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-demo': {
+          maestroEnsembleChat: () => ({
+            messages: [{ id: '1', from: 'alice', to: 'conductor', text: 'hi', timestamp: '', role: 'conductor-in' }],
+            total: 1,
+            hasMore: false,
+            hasConductor: true,
+          }),
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+    const chat = await client.getEnsembleChat('demo');
+    expect(chat.total).toBe(1);
+    expect(chat.hasConductor).toBe(true);
+  });
+
+  it('returns empty result when Maestro is unavailable', async () => {
+    const fake = makeFakeClient({
+      handlers: {
+        'claude-maestro-demo': {
+          maestroEnsembleChat: () => new Error('down'),
+        },
+      },
+    });
+    const client = createTempoClient(fake);
+    const chat = await client.getEnsembleChat('demo');
+    expect(chat).toEqual({ messages: [], total: 0, hasMore: false, hasConductor: false });
+  });
+});

--- a/tests/tui/chat-cap.test.ts
+++ b/tests/tui/chat-cap.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Unit tests for the "↑ N earlier messages" chat-cap indicator formatting.
+ * See src/tui/utils/format.ts → formatEarlierIndicator.
+ *
+ * Issue #105, Phase 1. No Ink — pure-function tests only.
+ *
+ * ── Finding ──
+ * The inline formatter in src/tui/components/PlayerDetailView.tsx always
+ * emits plural "earlier messages", even for count === 1. The
+ * formatEarlierIndicator helper tested here implements the correct
+ * singular/plural behavior. Wiring PlayerDetailView to use this helper is
+ * a follow-up (minor presentation fix, out of scope for Phase 1 per the
+ * test plan's "flag findings, don't fix" rule).
+ */
+import { describe, it, expect } from 'vitest';
+import { formatEarlierIndicator } from '../../src/tui/utils/format';
+
+describe('formatEarlierIndicator', () => {
+  it('returns null when count is 0 (no indicator)', () => {
+    expect(formatEarlierIndicator(0)).toBeNull();
+  });
+
+  it('returns null for negative counts (defensive)', () => {
+    expect(formatEarlierIndicator(-1)).toBeNull();
+    expect(formatEarlierIndicator(-100)).toBeNull();
+  });
+
+  it('uses singular form for exactly 1 earlier message', () => {
+    expect(formatEarlierIndicator(1)).toBe('\u2191 1 earlier message');
+  });
+
+  it('uses plural form for 2+ earlier messages', () => {
+    expect(formatEarlierIndicator(2)).toBe('\u2191 2 earlier messages');
+    expect(formatEarlierIndicator(5)).toBe('\u2191 5 earlier messages');
+    expect(formatEarlierIndicator(42)).toBe('\u2191 42 earlier messages');
+  });
+
+  it('uses plural form for large counts', () => {
+    expect(formatEarlierIndicator(1000)).toBe('\u2191 1000 earlier messages');
+  });
+
+  it('handles cap-boundary: 20 visible messages → no earlier indicator', () => {
+    // The PlayerDetailView/ChatView caps at 20 visible; if exactly 20 fit,
+    // earlierCount is 0 and no indicator should render.
+    expect(formatEarlierIndicator(0)).toBeNull();
+  });
+
+  it('defends against non-finite input', () => {
+    expect(formatEarlierIndicator(NaN)).toBeNull();
+    expect(formatEarlierIndicator(Infinity)).toBeNull();
+    expect(formatEarlierIndicator(-Infinity)).toBeNull();
+  });
+
+  it('always starts with the up-arrow glyph', () => {
+    const out = formatEarlierIndicator(3);
+    expect(out).not.toBeNull();
+    expect(out!.startsWith('\u2191')).toBe(true);
+  });
+});

--- a/tests/tui/commands.test.ts
+++ b/tests/tui/commands.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Unit tests for the slash-command parser and command registry.
+ * See src/tui/commands.ts. Issue #105, Phase 1.
+ *
+ * These tests cover pure-logic behavior: parsing, registry lookups, and
+ * help-target resolution. UI/dispatch concerns (App.tsx) are out of scope.
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  parseCommand,
+  isValidCommand,
+  getCommandNames,
+  resolveHelpTarget,
+  COMMANDS,
+} from '../../src/tui/commands';
+
+describe('parseCommand', () => {
+  it('returns null for bare text (non-slash input)', () => {
+    // Bare text routes to the conductor via sendCommand — not parsed as a command.
+    expect(parseCommand('hello world')).toBeNull();
+    expect(parseCommand('alice can you review?')).toBeNull();
+    expect(parseCommand('@alice ping')).toBeNull();
+  });
+
+  it('returns null for empty or whitespace-only input', () => {
+    expect(parseCommand('')).toBeNull();
+    expect(parseCommand('   ')).toBeNull();
+    expect(parseCommand('\t\n')).toBeNull();
+  });
+
+  it('returns null for lone "/" with no command name', () => {
+    expect(parseCommand('/')).toBeNull();
+    expect(parseCommand('/   ')).toBeNull();
+  });
+
+  it('parses a simple command with no args', () => {
+    const p = parseCommand('/status');
+    expect(p).not.toBeNull();
+    expect(p!.name).toBe('status');
+    expect(p!.args).toEqual([]);
+    expect(p!.raw).toBe('/status');
+  });
+
+  it('lowercases the command name', () => {
+    expect(parseCommand('/STATUS')!.name).toBe('status');
+    expect(parseCommand('/Recruit')!.name).toBe('recruit');
+  });
+
+  it('parses positional args separated by whitespace', () => {
+    const p = parseCommand('/stop alice');
+    expect(p!.name).toBe('stop');
+    expect(p!.args).toEqual(['alice']);
+  });
+
+  it('collapses runs of whitespace between args', () => {
+    const p = parseCommand('/recruit   alice    bob   carol');
+    expect(p!.args).toEqual(['alice', 'bob', 'carol']);
+  });
+
+  it('trims leading/trailing whitespace before parsing', () => {
+    expect(parseCommand('  /status  ')!.name).toBe('status');
+    expect(parseCommand('\n/stop alice\t')!.args).toEqual(['alice']);
+  });
+
+  it('does not crash on malformed input with embedded quote characters', () => {
+    // Current parser does not interpret quotes — it treats them as literal chars.
+    // This test guards against a future regression that might choke on them.
+    const malformed = parseCommand('/schedule create foo cron "0 * * * *');
+    expect(malformed).not.toBeNull();
+    expect(malformed!.name).toBe('schedule');
+    // The quote characters remain embedded in the tokens — parser is quote-naive.
+    expect(malformed!.args.length).toBeGreaterThan(0);
+  });
+
+  // ── KNOWN LIMITATION / Finding for follow-up ──
+  // The current parser splits on whitespace without honoring quoted strings.
+  // Per #105 Phase 1 review: commands like
+  //     /schedule create foo cron "0 * * * *"
+  // should treat the cron expression as a single arg. Today they don't.
+  // Flagged as a follow-up; no behavior change in this PR.
+  it.todo(
+    'TODO: /schedule create foo cron "0 * * * *" should bind the cron expression as one arg (quoted-string support)',
+  );
+});
+
+describe('command registry', () => {
+  it('isValidCommand returns true for registered commands', () => {
+    expect(isValidCommand('status')).toBe(true);
+    expect(isValidCommand('stop')).toBe(true);
+    expect(isValidCommand('recruit')).toBe(true);
+    expect(isValidCommand('help')).toBe(true);
+  });
+
+  it('isValidCommand returns false for unknown commands', () => {
+    // App.tsx uses !isValidCommand(name) to emit the "Unknown command: /foo" error.
+    expect(isValidCommand('foobar')).toBe(false);
+    expect(isValidCommand('')).toBe(false);
+    expect(isValidCommand('nope')).toBe(false);
+  });
+
+  it('isValidCommand rejects removed aliases (regression for /home, /maestro, etc.)', () => {
+    // Per CLAUDE.md: /home, /maestro, /dashboard, /exit, /unschedule are NOT registered.
+    expect(isValidCommand('home')).toBe(false);
+    expect(isValidCommand('maestro')).toBe(false);
+    expect(isValidCommand('dashboard')).toBe(false);
+    expect(isValidCommand('exit')).toBe(false);
+    expect(isValidCommand('unschedule')).toBe(false);
+  });
+
+  it('getCommandNames returns a sorted list', () => {
+    const names = getCommandNames();
+    const sorted = [...names].sort();
+    expect(names).toEqual(sorted);
+    // Spot-check a few well-known commands are present.
+    expect(names).toContain('status');
+    expect(names).toContain('help');
+    expect(names).toContain('recruit');
+  });
+
+  it('every COMMANDS entry has description and usage strings', () => {
+    for (const [name, def] of Object.entries(COMMANDS)) {
+      expect(def.description, `${name}.description`).toBeTypeOf('string');
+      expect(def.description.length, `${name}.description length`).toBeGreaterThan(0);
+      expect(def.usage, `${name}.usage`).toBeTypeOf('string');
+      expect(def.usage.length, `${name}.usage length`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('resolveHelpTarget', () => {
+  it('resolves "/help recruit" and "/help /recruit" to the same target', () => {
+    const a = resolveHelpTarget('recruit');
+    const b = resolveHelpTarget('/recruit');
+    expect(a).not.toBeNull();
+    expect(b).not.toBeNull();
+    expect(a!.name).toBe('recruit');
+    expect(b!.name).toBe('recruit');
+    expect(a!.def).toBe(b!.def);
+    expect(a!.def).toBe(COMMANDS.recruit);
+  });
+
+  it('is case-insensitive', () => {
+    expect(resolveHelpTarget('RECRUIT')!.name).toBe('recruit');
+    expect(resolveHelpTarget('/Recruit')!.name).toBe('recruit');
+  });
+
+  it('trims whitespace', () => {
+    expect(resolveHelpTarget('  recruit  ')!.name).toBe('recruit');
+  });
+
+  it('returns null for unknown commands', () => {
+    expect(resolveHelpTarget('nope')).toBeNull();
+    expect(resolveHelpTarget('/nope')).toBeNull();
+  });
+
+  it('returns null for empty or slash-only input', () => {
+    expect(resolveHelpTarget('')).toBeNull();
+    expect(resolveHelpTarget('/')).toBeNull();
+    expect(resolveHelpTarget('   ')).toBeNull();
+  });
+});

--- a/tests/tui/palette.test.ts
+++ b/tests/tui/palette.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Unit tests for command palette autocomplete — filter logic and reducer
+ * index transitions. See src/tui/commands.ts filterPaletteCommands and
+ * src/tui/store.ts (PALETTE_UP / PALETTE_DOWN / PALETTE_SET_INDEX).
+ *
+ * Issue #105, Phase 1. No Ink — pure-logic tests only.
+ */
+import { describe, it, expect } from 'vitest';
+import { filterPaletteCommands } from '../../src/tui/commands';
+import { initialState, tuiReducer, type TuiState } from '../../src/tui/store';
+
+interface PCmd { name: string; usage: string; description: string }
+
+const commands: PCmd[] = [
+  { name: 'recruit', usage: '/recruit', description: 'Spawn a new player' },
+  { name: 'recall',  usage: '/recall',  description: "Read a player's history" },
+  { name: 'resume',  usage: '/resume',  description: 'Resume a paused ensemble' },
+  { name: 'pause',   usage: '/pause',   description: 'Pause the ensemble' },
+  { name: 'stop',    usage: '/stop',    description: 'Stop a player' },
+  { name: 'help',    usage: '/help',    description: 'Show available commands' },
+];
+
+describe('filterPaletteCommands', () => {
+  it('empty filter returns all commands in original order (copy, not same ref)', () => {
+    const out = filterPaletteCommands(commands, '');
+    expect(out).toEqual(commands);
+    expect(out).not.toBe(commands); // caller should get a fresh array
+  });
+
+  it('bare prefix narrows options (no leading slash)', () => {
+    const out = filterPaletteCommands(commands, 're');
+    expect(out.map((c) => c.name)).toEqual(['recruit', 'recall', 'resume']);
+  });
+
+  it('prefix with leading slash is equivalent', () => {
+    const bare = filterPaletteCommands(commands, 're');
+    const slash = filterPaletteCommands(commands, '/re');
+    expect(slash).toEqual(bare);
+  });
+
+  it('prefix longer than any command returns empty', () => {
+    expect(filterPaletteCommands(commands, 'nomatch')).toEqual([]);
+  });
+
+  it('is case-insensitive', () => {
+    expect(filterPaletteCommands(commands, 'RE').map((c) => c.name))
+      .toEqual(['recruit', 'recall', 'resume']);
+    expect(filterPaletteCommands(commands, '/Pause').map((c) => c.name))
+      .toEqual(['pause']);
+  });
+
+  it('exact match returns exactly one entry', () => {
+    expect(filterPaletteCommands(commands, 'help').map((c) => c.name)).toEqual(['help']);
+  });
+
+  it('does not mutate the input array', () => {
+    const snapshot = commands.map((c) => c.name);
+    filterPaletteCommands(commands, 're');
+    expect(commands.map((c) => c.name)).toEqual(snapshot);
+  });
+
+  it('works on readonly input', () => {
+    const readonly: readonly PCmd[] = commands;
+    const out = filterPaletteCommands(readonly, 'p');
+    expect(out.map((c) => c.name)).toEqual(['pause']);
+  });
+});
+
+describe('tuiReducer — palette index transitions', () => {
+  function stateWithPalette(index: number): TuiState {
+    return { ...initialState('demo'), paletteVisible: true, paletteIndex: index };
+  }
+
+  it('PALETTE_UP at index 0 stays clamped to 0', () => {
+    const s = stateWithPalette(0);
+    const out = tuiReducer(s, { type: 'PALETTE_UP' });
+    expect(out.paletteIndex).toBe(0);
+  });
+
+  it('PALETTE_UP decrements index by 1 when > 0', () => {
+    const s = stateWithPalette(3);
+    const out = tuiReducer(s, { type: 'PALETTE_UP' });
+    expect(out.paletteIndex).toBe(2);
+  });
+
+  it('PALETTE_DOWN increments without a max', () => {
+    const s = stateWithPalette(0);
+    const out = tuiReducer(s, { type: 'PALETTE_DOWN' });
+    expect(out.paletteIndex).toBe(1);
+  });
+
+  it('PALETTE_DOWN clamps to max when provided', () => {
+    const s = stateWithPalette(4);
+    const out = tuiReducer(s, { type: 'PALETTE_DOWN', max: 4 });
+    expect(out.paletteIndex).toBe(4); // stays at max
+    const out2 = tuiReducer(out, { type: 'PALETTE_DOWN', max: 4 });
+    expect(out2.paletteIndex).toBe(4);
+  });
+
+  it('PALETTE_SET_INDEX jumps directly', () => {
+    const s = stateWithPalette(0);
+    const out = tuiReducer(s, { type: 'PALETTE_SET_INDEX', index: 5 });
+    expect(out.paletteIndex).toBe(5);
+  });
+
+  // Wrap-around is NOT currently supported; PALETTE_UP/_DOWN clamp at 0/max.
+  // Documenting the current behavior (not wrapping) locks in the contract.
+  it('PALETTE_UP at 0 does not wrap around to the end', () => {
+    const s = stateWithPalette(0);
+    const out = tuiReducer(s, { type: 'PALETTE_UP' });
+    expect(out.paletteIndex).toBe(0);
+    expect(out.paletteIndex).not.toBe(-1);
+  });
+});

--- a/tests/tui/store.test.ts
+++ b/tests/tui/store.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Unit tests for the TUI reducer — state-identity and transition correctness.
+ * See src/tui/store.ts. Issue #105, Phase 1.
+ *
+ * Per CLAUDE.md's "Reducer state identity matters" rule:
+ * returning `{ ...state, field: sameValue }` creates a new object reference
+ * and triggers a re-render even when nothing changed. These tests lock in
+ * no-op identity for the transitions that have been hardened.
+ */
+import { describe, it, expect } from 'vitest';
+import { initialState, tuiReducer, type TuiAction, type TuiState } from '../../src/tui/store';
+import type { MaestroPlayerInfo } from '../../src/types';
+
+function s0(): TuiState {
+  return initialState('demo');
+}
+
+describe('tuiReducer — no-op identity', () => {
+  it('unknown action returns the same state reference', () => {
+    const s = s0();
+    const out = tuiReducer(s, { type: 'NOT_A_REAL_ACTION' } as unknown as TuiAction);
+    expect(out).toBe(s);
+  });
+
+  it('HIDE_OVERLAY returns same reference when already hidden', () => {
+    const s = s0();
+    expect(s.overlay).toBeNull();
+    const out = tuiReducer(s, { type: 'HIDE_OVERLAY' });
+    expect(out).toBe(s);
+  });
+
+  it('OVERLAY_SELECT returns same reference when selection cannot change', () => {
+    // Overlay with a single item — up/down cycling lands on the same index.
+    const s: TuiState = {
+      ...s0(),
+      overlay: {
+        type: 'command',
+        title: 'Test',
+        items: [{ id: '1', label: 'only' }],
+        selectedIndex: 0,
+        hint: 'esc',
+      },
+    };
+    const out = tuiReducer(s, { type: 'OVERLAY_SELECT', direction: 'down' });
+    expect(out).toBe(s);
+  });
+
+  it('PLAYER_SCROLL_UP at offset 0 returns same reference', () => {
+    const s: TuiState = { ...s0(), playerScrollOffset: 0 };
+    const out = tuiReducer(s, { type: 'PLAYER_SCROLL_UP' });
+    expect(out).toBe(s);
+  });
+
+  it('PLAYER_SCROLL_DOWN at max returns same reference', () => {
+    // With no player messages, maxScroll = 0, offset can't advance.
+    const s: TuiState = { ...s0(), playerMessages: [], playerScrollOffset: 0 };
+    const out = tuiReducer(s, { type: 'PLAYER_SCROLL_DOWN' });
+    expect(out).toBe(s);
+  });
+
+  it('SHOW_PALETTE when already visible at index 0 returns same reference', () => {
+    const s: TuiState = { ...s0(), paletteVisible: true, paletteIndex: 0 };
+    const out = tuiReducer(s, { type: 'SHOW_PALETTE' });
+    expect(out).toBe(s);
+  });
+
+  it('HIDE_PALETTE when already hidden at index 0 returns same reference', () => {
+    const s = s0();
+    expect(s.paletteVisible).toBe(false);
+    expect(s.paletteIndex).toBe(0);
+    const out = tuiReducer(s, { type: 'HIDE_PALETTE' });
+    expect(out).toBe(s);
+  });
+
+  // ── KNOWN-FAILING / Finding for follow-up ──
+  // PALETTE_UP currently does `{ ...state, paletteIndex: Math.max(0, state.paletteIndex - 1) }`
+  // which creates a new state object even when the value is unchanged.
+  // Per CLAUDE.md "Reducer state identity matters", this forces a re-render
+  // on every arrow-up at the top. OVERLAY_SELECT (line ~568) already does the
+  // right thing — fix PALETTE_UP/PALETTE_DOWN the same way in a follow-up PR.
+  it.todo(
+    'TODO: PALETTE_UP at index 0 should return same reference (currently returns new object — see CLAUDE.md identity rule)',
+  );
+  it.todo(
+    'TODO: PALETTE_DOWN at clamped max should return same reference (same fix)',
+  );
+});
+
+describe('tuiReducer — state transitions', () => {
+  it('SET_PHASE updates phase and clears error when omitted', () => {
+    const s = { ...s0(), error: 'old error' };
+    const out = tuiReducer(s, { type: 'SET_PHASE', phase: 'main' });
+    expect(out.phase).toBe('main');
+    expect(out.error).toBeUndefined();
+  });
+
+  it('REFRESH_ENSEMBLE_DATA populates players without re-ordering subsequent actions', () => {
+    // Calling REFRESH_ENSEMBLE_DATA twice with the same order should preserve player order.
+    const players: MaestroPlayerInfo[] = [
+      { playerId: 'alice', ensemble: 'demo', part: '', hostname: '', workDir: '', isConductor: false, agentType: 'claude' },
+      { playerId: 'bob', ensemble: 'demo', part: '', hostname: '', workDir: '', isConductor: false, agentType: 'claude' },
+    ];
+    const s1 = tuiReducer(s0(), {
+      type: 'REFRESH_ENSEMBLE_DATA',
+      players,
+      messages: [],
+      history: [],
+    });
+    expect(s1.players.map((p) => p.playerId)).toEqual(['alice', 'bob']);
+    expect(s1.playersLoaded).toBe(true);
+
+    const s2 = tuiReducer(s1, {
+      type: 'REFRESH_ENSEMBLE_DATA',
+      players,
+      messages: [],
+      history: [],
+    });
+    expect(s2.players.map((p) => p.playerId)).toEqual(['alice', 'bob']);
+  });
+
+  it('REFRESH_ENSEMBLE_DATA clamps selectedPlayerIndex when player count shrinks', () => {
+    // Start with 3 players and selection at index 2
+    const three: MaestroPlayerInfo[] = ['a', 'b', 'c'].map((id) => ({
+      playerId: id, ensemble: 'demo', part: '', hostname: '', workDir: '', isConductor: false, agentType: 'claude',
+    }));
+    const s1 = tuiReducer({ ...s0(), selectedPlayerIndex: 2 }, {
+      type: 'REFRESH_ENSEMBLE_DATA',
+      players: three,
+      messages: [],
+      history: [],
+    });
+    expect(s1.selectedPlayerIndex).toBe(2);
+
+    // Next refresh has only 1 player — selection should clamp to 0
+    const one = three.slice(0, 1);
+    const s2 = tuiReducer(s1, {
+      type: 'REFRESH_ENSEMBLE_DATA',
+      players: one,
+      messages: [],
+      history: [],
+    });
+    expect(s2.selectedPlayerIndex).toBe(0);
+  });
+
+  it('REFRESH_ENSEMBLES clamps selectedEnsembleIndex when list shrinks', () => {
+    const s1 = tuiReducer({ ...s0(), selectedEnsembleIndex: 5 }, {
+      type: 'REFRESH_ENSEMBLES',
+      ensembles: [
+        { name: 'a', playerCount: 1, hasConductor: false },
+        { name: 'b', playerCount: 1, hasConductor: false },
+      ],
+    });
+    expect(s1.selectedEnsembleIndex).toBe(1);
+
+    // Empty list → index 0
+    const s2 = tuiReducer(s1, { type: 'REFRESH_ENSEMBLES', ensembles: [] });
+    expect(s2.selectedEnsembleIndex).toBe(0);
+  });
+
+  it('ENTER_CHAT / EXIT_CHAT round-trip preserves prior chat target handling', () => {
+    const s1 = tuiReducer(s0(), { type: 'ENTER_CHAT', target: 'alice' });
+    expect(s1.phase).toBe('chat');
+    expect(s1.chatTarget).toBe('alice');
+    const s2 = tuiReducer(s1, { type: 'EXIT_CHAT' });
+    expect(s2.phase).toBe('main');
+    expect(s2.chatTarget).toBeUndefined();
+  });
+
+  it('HYDRATE_SENT_MESSAGES dedupes the same message and returns same reference on no-op', () => {
+    const msg = { to: 'alice', text: 'hi', timestamp: '2026-01-01T00:00:00.000Z' };
+    const s1 = tuiReducer(s0(), { type: 'HYDRATE_SENT_MESSAGES', messages: [msg] });
+    expect(s1.sentMessages).toHaveLength(1);
+
+    // Re-hydrating the same message should NOT duplicate — and should return same reference.
+    const s2 = tuiReducer(s1, { type: 'HYDRATE_SENT_MESSAGES', messages: [msg] });
+    expect(s2).toBe(s1);
+    expect(s2.sentMessages).toHaveLength(1);
+  });
+
+  it('APPEND_SENT_MESSAGE caps the sentMessages buffer at 200', () => {
+    let s: TuiState = s0();
+    for (let i = 0; i < 205; i++) {
+      s = tuiReducer(s, { type: 'APPEND_SENT_MESSAGE', to: 'alice', text: `msg-${i}` });
+    }
+    expect(s.sentMessages.length).toBe(200);
+    // Oldest messages dropped; the last one is present.
+    expect(s.sentMessages[s.sentMessages.length - 1].text).toBe('msg-204');
+  });
+
+  it('COMMIT_STATIC caps the staticItems buffer at 500', () => {
+    let s: TuiState = s0();
+    for (let i = 0; i < 505; i++) {
+      s = tuiReducer(s, {
+        type: 'COMMIT_STATIC',
+        item: { id: `i-${i}`, type: 'info', content: `entry-${i}`, timestamp: i },
+      });
+    }
+    expect(s.staticItems.length).toBe(500);
+    expect(s.staticItems[s.staticItems.length - 1].content).toBe('entry-504');
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,20 @@
+import { defineConfig } from 'vitest/config';
+
+/**
+ * Vitest configuration for TUI/client pure-logic unit tests.
+ *
+ * Phase 1 unit tests live under `tests/tui/` and `tests/client/`.
+ * Temporal workflow/activity tests continue to run under Mocha via
+ * the `test` script — this config targets ONLY the pure-logic layer.
+ *
+ * See issue #105 for the testing strategy breakdown.
+ */
+export default defineConfig({
+  test: {
+    include: ['tests/tui/**/*.test.ts', 'tests/client/**/*.test.ts'],
+    environment: 'node',
+    globals: false,
+    // Keep these tests fast — no Ink, no Temporal, no I/O beyond mocks.
+    testTimeout: 5000,
+  },
+});


### PR DESCRIPTION
## Summary

Phase 1 of the TUI testability plan (issue #105): add Vitest alongside Mocha for pure-logic unit tests, and lock in regression coverage for the highest-leverage / lowest-risk layers before larger refactoring (#106) lands.

- **69 passing vitest tests** across 5 files (commands parser, reducer, palette filter/index, chat-cap indicator, TempoClient fallback precedence)
- **3 `it.todo` findings** flagged for follow-up — bugs discovered while writing tests, not fixed in this PR per plan
- **No Ink, no Temporal** — pure-function/mock-only
- Existing 601 Mocha tests untouched; `npm test` now chains `mocha && vitest run`
- No behavior changes in production code paths; three small helpers extracted for testability (`filterPaletteCommands`, `resolveHelpTarget`, `formatEarlierIndicator`)

## What's tested

| File | Coverage |
|---|---|
| `tests/tui/commands.test.ts` | `parseCommand`, `isValidCommand`, `getCommandNames`, `resolveHelpTarget` (help alias normalization, unknown-command detection, case/whitespace handling, malformed-quote tolerance) |
| `tests/tui/store.test.ts` | Reducer state-identity on no-op transitions (`HIDE_OVERLAY`, `OVERLAY_SELECT`, `PLAYER_SCROLL_*`, `SHOW/HIDE_PALETTE`, `HYDRATE_SENT_MESSAGES`), clamp logic on list shrinkage, buffer caps (sent 200, static 500), chat enter/exit round-trip |
| `tests/tui/palette.test.ts` | `filterPaletteCommands` (empty, prefix, slash-prefix, case-insensitive, no-match, readonly input, no mutation) + reducer index clamping/jumping/no-wrap contract |
| `tests/tui/chat-cap.test.ts` | `formatEarlierIndicator` singular/plural, 0/negative/NaN/Infinity defensive cases, cap boundary (20 visible → no indicator) |
| `tests/client/fallback.test.ts` | `getPlayers` / `discoverEnsembles` / `getMessages` / `getEnsembleChat` fallback precedence — Global Maestro → per-ensemble Maestro → workflow list → empty, with deterministic Temporal Client mocks |

## Findings for follow-up

Writing the tests surfaced three small bugs that I **did not** fix here (per plan: "flag it as a finding rather than fixing it in this PR"). All are marked as `it.todo` in the test files so they show up in test output.

1. **Palette reducer violates state-identity rule.** `PALETTE_UP` / `PALETTE_DOWN` in `src/tui/store.ts` return `{ ...state, paletteIndex: ... }` even when the value is unchanged, which triggers unnecessary re-renders. `OVERLAY_SELECT` (line ~568) already has the correct `if (idx === state.overlay.selectedIndex) return state;` pattern — apply the same fix. See CLAUDE.md "Reducer state identity matters".
2. **Slash-command parser is quote-naive.** `parseCommand` splits on whitespace, so `/schedule create foo cron "0 * * * *"` treats the cron fragments as four separate args. Needs a quote-aware tokenizer.
3. **Plural-only "earlier messages" indicator.** `PlayerDetailView.tsx` hardcodes plural, even for count === 1. The new `formatEarlierIndicator` helper does the right singular/plural choice — wiring `PlayerDetailView` to it is a one-line change.

None of these are regressions from this PR — they're pre-existing. Happy to file separate tickets once the conductor confirms scope.

## Scope constraints honored

- [x] No Ink in tests (Phase 2 / ink-testing-library is a separate ticket)
- [x] No Temporal test env spin-up (TempoClient tests use lightweight mock client)
- [x] No changes to `src/server.ts`, `src/workflows/`, `src/activities/`, `src/copilot-bridge.ts` (tempo-eng's territory)
- [x] Minimal behavior-preserving refactors only (three pure-function extractions — existing call sites unchanged)

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes — Mocha: 601 passing / Vitest: 69 passing, 3 todo
- [x] `npx tsc --noEmit` clean
- [x] CI already picks up both runners via `test` script chain (no workflow file changes needed)
- [x] Each new vitest test file can also run standalone via `npm run test:tui`

## References

- Parent research: issue #105 (TUI testability)
- Rebuild campaign: issue #106 (orthogonal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)