### PR TITLE
fix(lifecycle): close #99 and #102 with processingStart/End + destroy verb + runId pinning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ---
 
+## [0.24.1] - Unreleased
+
+### Fixed
+
+- **#99** — long tool calls no longer trigger false-stale: new `processingStart` / `processingEnd` Temporal updates (with required `messageId` for idempotency) suppress stale detection while an adapter is mid-`sendAndWait`; 15-minute safety timer ejects wedged entries
+- **#102** — graceful stop no longer resurrects sessions: new `destroy` update + `isDestroyed` query, with runId pinning in the Copilot bridge so a destroyed-then-recreated workflow cannot silently attach to the new run
+
+---
+
 ## [0.24.0] - 2026-04-12
 
 ### Added

--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -49,6 +49,8 @@ Queries on a `claudeSessionWorkflow` instance (synchronous, read-only).
 | `allSentMessages` | `SentMessage[]` | Returns the session's sent-message history (last 50 entries carried across `continueAsNew`). |
 | `outboxLocked` | `boolean` | Returns `true` if the session's outbox is currently locked (held at startup, awaiting `releaseHeld`). Returns `false` once the session is running normally. |
 | `paused` | `boolean` | Returns `true` if the session's outbox dispatch is currently paused via `setPaused`. |
+| `inFlightMessages` | `string[]` | Returns the IDs of messages currently being processed by a blocking adapter (see `processingStart`/`processingEnd` updates). While this set is non-empty, stale detection is suppressed. Used by Copilot-bridge-style adapters that call a long-running LLM API and cannot mark the message delivered until it returns. |
+| `isDestroyed` | `boolean` | Returns `true` if the session has been permanently destroyed via the `destroy` update. Adapters should check this before attempting reconnection — a destroyed session must not be resurrected. |
 
 ---
 
@@ -60,6 +62,9 @@ Workflow updates on a `claudeSessionWorkflow` instance (transactional, returns a
 |-------------|-------|--------|-------------|
 | `submitOutbox` | `OutboxEntryInput` | `string` (entry ID) | Appends an outbox entry (cue, report, stop, recruit, or encore) to the session's outbox queue and returns its generated UUID. The workflow's dispatch loop processes entries asynchronously via activities. This is the sole write path for all outbound operations. **Encore entries** (`type: 'encore'`) re-engage a player in a new session context; fields: `targetPlayerId: string`, `targetHostname?: string`, `contextMessageCount?: number`. |
 | `checkAndSetStatus` | `{ expectedStatus: string; newStatus: string }` | `boolean` | Atomically transitions the session's status from `expectedStatus` to `newStatus`. Returns `true` on success, `false` if the current status did not match `expectedStatus`. Used internally to guard state transitions (e.g., prevent double-encore, validate active/stale preconditions). |
+| `processingStart` | `{ messageId: string }` | *(void)* | Marks `messageId` as being actively processed by a blocking adapter (e.g. Copilot-bridge's `sendAndWait`). While any messageId is in-flight, stale detection is suppressed — fixes #99 where long LLM tool calls were misclassified as stale. `messageId` is required for idempotency under at-least-once update retries. The validator rejects the update if the session has been destroyed. A 15-minute safety timer in the workflow ejects wedged entries so a session cannot be pinned alive forever. |
+| `processingEnd` | `{ messageId: string }` | *(void)* | Marks `messageId` as done. Once the in-flight set is empty, stale detection resumes on the next main-loop iteration. Callers should run this in a `try/finally` around the blocking call so that a thrown error still releases the marker. |
+| `destroy` | `{ reason?: string }` | *(void)* | Permanently destroys the session. Sets `isDestroyed = true`, transitions status to `terminated`, pushes a system message recording the reason, and lets the main loop exit. The workflow drains its outbox with a 10-second cap (vs. the 2-minute cap for regular terminate) because a destroyed session typically has no remaining adapter to deliver messages. Fixes #102 — adapters (e.g. Copilot bridge's `recreateSession()`) must query `isDestroyed` before attempting reconnect; a destroyed workflow must not be resurrected as a zombie. |
 
 ---
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -32,6 +32,7 @@ interface ParsedArgs {
   type?: string;
   includeStale: boolean;
   host?: string;
+  terminate: boolean;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -49,6 +50,7 @@ function parseArgs(argv: string[]): ParsedArgs {
     replace: false,
     resume: false,
     includeStale: false,
+    terminate: false,
   };
 
   let i = 0;
@@ -96,6 +98,8 @@ function parseArgs(argv: string[]): ParsedArgs {
       result.includeStale = true;
     } else if (arg === '--host' && i + 1 < argv.length) {
       result.host = argv[++i];
+    } else if (arg === '--terminate') {
+      result.terminate = true;
     } else if (arg === '--agent' && i + 1 < argv.length) {
       const val = argv[++i];
       if (val !== 'claude' && val !== 'copilot') {
@@ -188,6 +192,7 @@ async function main() {
         name: args.name,
         ensemble: args.positional[1],
         all: args.all || undefined,
+        hardTerminate: args.terminate,
         ...overrides,
       });
       break;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -9,7 +9,7 @@ import { spawnInTerminal, spawnCopilotBridge, resolveClaudePath } from '../spawn
 import { conductorWorkflowId, sessionWorkflowId, schedulerWorkflowId, maestroWorkflowId, GLOBAL_MAESTRO_WORKFLOW_ID, ENV, getConfig, Config, CliOverrides, CLAUDE_TEMPO_HOME } from '../config';
 import { getGitInfo } from '../git-info';
 import { createTemporalConnection } from '../connection';
-import { playerReportSignal, updateMetadataSignal, releaseHeldSignal, outboxLockedQuery, setPausedSignal } from '../workflows/signals';
+import { playerReportSignal, updateMetadataSignal, releaseHeldSignal, outboxLockedQuery, setPausedSignal, destroyUpdate } from '../workflows/signals';
 import { addScheduleSignal, setSchedulerPausedSignal } from '../workflows/scheduler-signals';
 import { maestroSetPausedSignal } from '../workflows/maestro-signals';
 import { AgentType, ScheduleEntry, SessionInput, SessionMetadata } from '../types';
@@ -1413,6 +1413,8 @@ interface StopOpts extends CliOverrides {
   ensemble?: string;
   /** Stop every session across all ensembles. */
   all?: boolean;
+  /** Use hard terminate instead of destroy (escape hatch — destroy is preferred). */
+  hardTerminate?: boolean;
 }
 
 export async function stop(opts: StopOpts) {
@@ -1442,7 +1444,7 @@ export async function stop(opts: StopOpts) {
 
   if (opts.name) {
     // Stop a specific player by name (optionally scoped to ensemble)
-    await stopByName(client, opts.name, config, opts.ensemble);
+    await stopByName(client, opts.name, config, opts.ensemble, opts.hardTerminate);
   } else {
     // Stop multiple sessions (--ensemble or --all)
     const query = 'WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running"';
@@ -1462,7 +1464,18 @@ export async function stop(opts: StopOpts) {
           }
         }
 
-        await handle.signal(updateMetadataSignal, { status: 'terminated' });
+        if (opts.hardTerminate) {
+          await handle.signal(updateMetadataSignal, { status: 'terminated' });
+        } else {
+          // Prefer destroy — sets the isDestroyed flag so adapter recovery (bridge
+          // recreateSession) sees "no" and exits cleanly instead of zombie-rejoining.
+          // Falls back to terminate if the workflow is older and doesn't support destroy.
+          try {
+            await handle.executeUpdate(destroyUpdate, { args: [{ reason: 'stop via CLI' }] });
+          } catch {
+            await handle.signal(updateMetadataSignal, { status: 'terminated' });
+          }
+        }
         stopped++;
         out.log(`  ${out.dim('stopped')} ${wf.workflowId}`);
       } catch {
@@ -1487,7 +1500,7 @@ export async function stop(opts: StopOpts) {
   await connection.close();
 }
 
-async function stopByName(client: Client, name: string, config: Config, ensemble?: string) {
+async function stopByName(client: Client, name: string, config: Config, ensemble?: string, hardTerminate = false) {
   // Find the workflow by player name using metadata queries (not search attributes).
   const query = `WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running"`;
   let found = false;
@@ -1526,9 +1539,19 @@ async function stopByName(client: Client, name: string, config: Config, ensemble
       }
     }
 
-    // Send termination status update (graceful)
+    // Send destroy (preferred) or hard terminate (escape hatch).
+    // Destroy sets isDestroyed so adapter recovery (e.g. copilot-bridge's
+    // recreateSession) stops instead of rejoining as a zombie (#102).
     try {
-      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      if (hardTerminate) {
+        await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      } else {
+        try {
+          await handle.executeUpdate(destroyUpdate, { args: [{ reason: 'stop via CLI' }] });
+        } catch {
+          await handle.signal(updateMetadataSignal, { status: 'terminated' });
+        }
+      }
       out.success(`Stopped "${name}"`);
     } catch {
       out.warn(`Could not signal "${name}" — it may have already exited`);

--- a/src/copilot-bridge.ts
+++ b/src/copilot-bridge.ts
@@ -252,14 +252,16 @@ async function main() {
   // We know the exact workflow ID because we pass CLAUDE_TEMPO_PLAYER_NAME to the
   // MCP server — no need for a time-window heuristic that could misidentify workflows.
   log(`Waiting for workflow ${expectedWorkflowId} to register...`);
-  const handle = client.workflow.getHandle(expectedWorkflowId);
+  let handle = client.workflow.getHandle(expectedWorkflowId);
 
   let workflowReady = false;
+  let pinnedRunId: string | undefined;
   for (let attempt = 0; attempt < 30; attempt++) {
     try {
       const desc = await handle.describe();
       if (desc.status.name === 'RUNNING') {
         workflowReady = true;
+        pinnedRunId = desc.runId;
         break;
       }
     } catch {
@@ -278,7 +280,13 @@ async function main() {
     process.exit(1);
   }
 
-  log(`Workflow ready: ${expectedWorkflowId}`);
+  // Pin all subsequent interactions to the runId we observed — prevents the
+  // zombie-resurrection hazard from #102. If this run completes (e.g. destroy),
+  // a later USE_EXISTING start would spawn a new run with the same workflow ID;
+  // an unpinned handle would silently attach to the new run, but a pinned handle
+  // returns WorkflowNotFound and lets the bridge exit cleanly.
+  handle = client.workflow.getHandle(expectedWorkflowId, pinnedRunId);
+  log(`Workflow ready: ${expectedWorkflowId} (pinned runId ${pinnedRunId})`);
 
   // Store sessionId in workflow metadata for future encore/resume
   try {
@@ -342,6 +350,27 @@ async function main() {
 
   /** Attempt to recreate the Copilot session after repeated failures. */
   async function recreateSession(): Promise<boolean> {
+    // Fixes #102: before recreating, check whether the pinned-runId workflow has
+    // been destroyed. If so, the user explicitly stopped this session — do NOT
+    // bring it back as a zombie. This also covers WorkflowNotFound (the pinned
+    // run has completed/terminated) since the query throws cleanly.
+    try {
+      const isDestroyed: boolean = await handle.query('isDestroyed');
+      if (isDestroyed) {
+        log('Workflow is destroyed — not reconnecting (session was intentionally stopped)');
+        return false;
+      }
+    } catch (err: any) {
+      const errName = err?.name || '';
+      const errMsg = err?.message || '';
+      if (errName.includes('WorkflowNotFound') || errMsg.includes('NOT_FOUND')) {
+        log('Workflow not found (likely terminated) — not reconnecting');
+        return false;
+      }
+      // Query failed for another reason — log and continue with recreation.
+      log(`isDestroyed query failed (${errMsg}), continuing with recreation`);
+    }
+
     sessionRecreations++;
     if (sessionRecreations > MAX_SESSION_RECREATIONS) {
       log(`ERROR: Exceeded max session recreations (${MAX_SESSION_RECREATIONS}). Giving up.`);
@@ -397,6 +426,17 @@ async function main() {
           await cleanup(false); // workflow already gone, don't signal
           process.exit(0);
         }
+        // Also check the in-workflow destroy flag — the workflow may still be RUNNING
+        // (draining) but has been destroyed. Exit cleanly without attempting signals
+        // that would be rejected.
+        try {
+          const isDestroyed: boolean = await handle.query('isDestroyed');
+          if (isDestroyed) {
+            log('Workflow destroyed — exiting cleanly');
+            await cleanup(false);
+            process.exit(0);
+          }
+        } catch { /* isDestroyed query unavailable pre-upgrade — safe to ignore */ }
       } catch (err: any) {
         // If we can't describe (e.g., workflow not found), it was likely terminated
         log(`Workflow describe failed: ${err?.message} — treating as terminated`);
@@ -451,8 +491,23 @@ async function main() {
         log('WARNING: session appears dead, sendAndWait may hang');
       }
 
+      // Fixes #99: mark these messages as in-flight before the blocking LLM call so
+      // the workflow's stale detection doesn't misclassify a long tool call as dead.
+      // Fire-and-logged — don't block sendAndWait on the update roundtrip.
+      const processingMarkerId = ids[0]; // representative for the batch
+      handle.executeUpdate('processingStart', { args: [{ messageId: processingMarkerId }] })
+        .catch((err: any) => log(`processingStart update failed (non-fatal): ${err?.message}`));
+
       const t0 = Date.now();
-      const result = await session.sendAndWait({ prompt }, 300_000); // 5 min timeout
+      let result: any;
+      try {
+        result = await session.sendAndWait({ prompt }, 300_000); // 5 min timeout
+      } finally {
+        // Always release the in-flight marker — a thrown error from sendAndWait
+        // must not leave the workflow pinned as "processing".
+        handle.executeUpdate('processingEnd', { args: [{ messageId: processingMarkerId }] })
+          .catch((err: any) => log(`processingEnd update failed (non-fatal): ${err?.message}`));
+      }
       const elapsed = Date.now() - t0;
 
       log(`sendAndWait completed in ${elapsed}ms`);

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,12 @@ export interface SessionInput {
   heldMessage?: string;
   /** When true, outbox dispatch is paused ensemble-wide (pause/resume). */
   paused?: boolean;
+  /** Restored from continue-as-new: message IDs currently being processed (blocks stale detection). */
+  inFlightMessageIds?: string[];
+  /** Restored from continue-as-new: timestamp when in-flight set became non-empty. */
+  processingSince?: number;
+  /** Restored from continue-as-new: workflow has been destroyed (terminal). */
+  destroyed?: boolean;
   /** Temporal config passed through for outbox activities (non-secret fields only). */
   temporalConfig?: {
     temporalAddress: string;

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -9,6 +9,7 @@ import {
   uuid4,
   proxyActivities,
   patched,
+  log as workflowLog,
 } from '@temporalio/workflow';
 
 import type { OutboxActivities } from '../activities/outbox';
@@ -758,9 +759,10 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
       // Safety timer: if a messageId stays in-flight past PROCESSING_STUCK_MS, eject it
       // so a runaway wedge doesn't keep the session pinned alive forever.
       if (processingSince !== null && now - processingSince > PROCESSING_STUCK_MS) {
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[claude-tempo:workflow] processing stuck for ${Math.round((now - processingSince) / 1000)}s — ` +
+        // workflow.log.* is replay-safe (SDK dedupes by event time); console.warn would
+        // fire on every replay and pollute logs.
+        workflowLog.warn(
+          `processing stuck for ${Math.round((now - processingSince) / 1000)}s — ` +
           `ejecting ${inFlightMessages.size} in-flight message(s): ${[...inFlightMessages].join(', ')}`,
         );
         inFlightMessages.clear();

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -56,6 +56,11 @@ import {
   outboxLockedQuery,
   setPausedSignal,
   pausedQuery,
+  processingStartUpdate,
+  processingEndUpdate,
+  inFlightMessagesQuery,
+  destroyUpdate,
+  isDestroyedQuery,
 } from './signals';
 
 // ── Outbox Activity Proxies ──
@@ -117,6 +122,19 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
   let outboxLocked = input.outboxLocked ?? false;
   let heldMessage: string | undefined = input.heldMessage;
   let paused = input.paused ?? false;
+
+  // ── Processing Lifecycle State (fixes #99) ──
+  // Tracks messages currently being processed by a blocking adapter (e.g. copilot-bridge
+  // LLM tool call). While non-empty, stale detection is suppressed.
+  const inFlightMessages = new Set<string>(input.inFlightMessageIds ?? []);
+  let processingSince: number | null = input.processingSince ?? (inFlightMessages.size > 0 ? Date.now() : null);
+  /** Safety cap: if a messageId stays in-flight longer than this, eject it with a warning. */
+  const PROCESSING_STUCK_MS = 15 * 60 * 1000; // 15 minutes
+
+  // ── Destroy State (fixes #102) ──
+  // Once true, the workflow refuses all attach-adjacent operations and terminates cleanly.
+  let destroyed = input.destroyed ?? false;
+  let destroyRequested = destroyed;
 
   // ── Outbox Update + Query Handlers ──
 
@@ -287,6 +305,62 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
   });
 
   setHandler(pausedQuery, () => paused);
+
+  // ── Processing Lifecycle Handlers (fixes #99) ──
+
+  setHandler(processingStartUpdate, ({ messageId }) => {
+    const wasEmpty = inFlightMessages.size === 0;
+    inFlightMessages.add(messageId);
+    if (wasEmpty) {
+      processingSince = Date.now();
+    }
+    lastActivityTime = Date.now();
+  }, {
+    validator: ({ messageId }) => {
+      if (!messageId || typeof messageId !== 'string') {
+        throw new Error('processingStart requires a non-empty messageId');
+      }
+      if (destroyed || destroyRequested) {
+        throw new Error('Cannot start processing on destroyed session');
+      }
+    },
+  });
+
+  setHandler(processingEndUpdate, ({ messageId }) => {
+    inFlightMessages.delete(messageId);
+    if (inFlightMessages.size === 0) {
+      processingSince = null;
+    }
+    lastActivityTime = Date.now();
+  }, {
+    validator: ({ messageId }) => {
+      if (!messageId || typeof messageId !== 'string') {
+        throw new Error('processingEnd requires a non-empty messageId');
+      }
+    },
+  });
+
+  setHandler(inFlightMessagesQuery, () => [...inFlightMessages]);
+
+  // ── Destroy Handlers (fixes #102) ──
+
+  setHandler(destroyUpdate, ({ reason }) => {
+    destroyRequested = true;
+    // Graceful destroy: mark as terminated so the main loop drains & exits.
+    // The status change triggers the same path as updateMetadataSignal with status=terminated.
+    input.metadata.status = 'terminated';
+    upsertSearchAttributes({ ClaudeTempoStatus: ['terminated'] });
+    messages.push({
+      id: uuid4(),
+      from: 'system',
+      text: `Session destroyed${reason ? `: ${reason}` : ''}.`,
+      timestamp: new Date().toISOString(),
+      delivered: false,
+    });
+    lastActivityTime = Date.now();
+  });
+
+  setHandler(isDestroyedQuery, () => destroyed || destroyRequested);
 
   // ── Conductor State ──
 
@@ -678,11 +752,27 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
     // Mark as stale so the workflow stays alive and can be reconnected later.
     if (!input.disableStaleDetection) {
       const now = Date.now();
+
+      // Fixes #99: suppress stale detection while the adapter reports an in-flight
+      // blocking operation (e.g. copilot-bridge sendAndWait on a long tool call).
+      // Safety timer: if a messageId stays in-flight past PROCESSING_STUCK_MS, eject it
+      // so a runaway wedge doesn't keep the session pinned alive forever.
+      if (processingSince !== null && now - processingSince > PROCESSING_STUCK_MS) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[claude-tempo:workflow] processing stuck for ${Math.round((now - processingSince) / 1000)}s — ` +
+          `ejecting ${inFlightMessages.size} in-flight message(s): ${[...inFlightMessages].join(', ')}`,
+        );
+        inFlightMessages.clear();
+        processingSince = null;
+      }
+      const processingInFlight = inFlightMessages.size > 0;
+
       const staleMessages = messages.filter(
         (m) => !m.delivered && now - new Date(m.timestamp).getTime() > STALE_MESSAGE_MS,
       );
       const stuckPending = input.metadata.status === 'pending' && now - lastActivityTime > STALE_MESSAGE_MS;
-      if ((staleMessages.length > 0 || stuckPending) && input.metadata.status !== 'stale') {
+      if (!processingInFlight && (staleMessages.length > 0 || stuckPending) && input.metadata.status !== 'stale') {
         input.metadata.status = 'stale';
         upsertSearchAttributes({ ClaudeTempoStatus: ['stale'] });
       }
@@ -732,6 +822,9 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
         outboxLocked,
         heldMessage,
         paused,
+        inFlightMessageIds: [...inFlightMessages],
+        processingSince: processingSince ?? undefined,
+        destroyed: destroyed || destroyRequested,
         ...(input.metadata.isConductor ? { commandHistory, reportHistory, qualityGates, worktrees, stages } : {}),
       });
     }
@@ -740,10 +833,18 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
   // Graceful shutdown — wait for in-flight handlers
   await condition(allHandlersFinished);
 
+  // Finalize destroy: mark destroyed so isDestroyedQuery returns true before workflow completes.
+  if (destroyRequested) {
+    destroyed = true;
+  }
+
   // If terminated, wait for the termination message to be delivered.
   // Skip in test mode (disableStaleDetection) since there's no message poller.
+  // Skip when destroyed: the adapter is expected to see isDestroyed and exit; no poller will deliver.
+  // Drain window for destroy: cap at 10 seconds (outbox + pending message delivery).
   if (input.metadata.status === 'terminated' && !input.disableStaleDetection) {
     const allDelivered = () => messages.every((m) => m.delivered);
-    await condition(allDelivered, '2 minutes');
+    const drainTimeout = destroyRequested ? '10 seconds' : '2 minutes';
+    await condition(allDelivered, drainTimeout);
   }
 }

--- a/src/workflows/signals.ts
+++ b/src/workflows/signals.ts
@@ -79,6 +79,26 @@ export const historyQuery = defineQuery<HistoryEntry[]>('history');
 /** Atomically transition status from expectedStatus to newStatus. Returns true on success, false if current status didn't match. */
 export const checkAndSetStatusUpdate = defineUpdate<boolean, [{ expectedStatus: string; newStatus: string }]>('checkAndSetStatus');
 
+// ── Processing Lifecycle (fixes #99) ──
+// Suppress stale detection while the adapter is in a blocking operation (e.g. LLM tool call).
+// `messageId` is required for idempotency — at-least-once update retries otherwise corrupt the set.
+
+/** Signal that the adapter has started processing an inbound message (blocking LLM/tool call). */
+export const processingStartUpdate = defineUpdate<void, [{ messageId: string }]>('processingStart');
+/** Signal that the adapter has finished processing an inbound message. */
+export const processingEndUpdate = defineUpdate<void, [{ messageId: string }]>('processingEnd');
+/** Query currently in-flight message IDs. */
+export const inFlightMessagesQuery = defineQuery<string[]>('inFlightMessages');
+
+// ── Destroy Verb (fixes #102) ──
+// Permanent, terminal teardown. Once destroyed, the workflow refuses all attach-adjacent ops
+// and adapters (bridge) must exit cleanly instead of reconnecting.
+
+/** Destroy the session: drain outbox briefly then terminate. No re-attachment possible. */
+export const destroyUpdate = defineUpdate<void, [{ reason?: string }]>('destroy');
+/** Query whether the session has been destroyed. */
+export const isDestroyedQuery = defineQuery<boolean>('isDestroyed');
+
 // ── Outbox Update + Query ──
 
 export const submitOutboxUpdate = defineUpdate<string, [OutboxEntryInput]>('submitOutbox');

--- a/test/destroy.test.ts
+++ b/test/destroy.test.ts
@@ -1,0 +1,135 @@
+import { expect } from 'chai';
+import { WorkflowIdConflictPolicy } from '@temporalio/client';
+import {
+  setupTestEnv,
+  teardownTestEnv,
+  withWorker,
+  startSession,
+  playerMetadata,
+  getMetadataQuery,
+  destroyUpdate,
+  isDestroyedQuery,
+  processingStartUpdate,
+  getClient,
+  TASK_QUEUE,
+} from './helpers';
+
+describe('destroy verb — fixes #102 (graceful stop → resurrection loop)', function () {
+  before(async function () {
+    this.timeout(60_000);
+    await setupTestEnv();
+  });
+
+  after(async function () {
+    await teardownTestEnv();
+  });
+
+  it('marks the workflow destroyed and transitions to terminated status', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const ensemble = `destroy-${Date.now()}`;
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'destroy-bob', ensemble }),
+      });
+
+      // Pre-destroy: not destroyed
+      expect(await handle.query(isDestroyedQuery)).to.equal(false);
+
+      await handle.executeUpdate(destroyUpdate, { args: [{ reason: 'user requested stop' }] });
+
+      // Post-destroy: query returns true, metadata status is terminated
+      expect(await handle.query(isDestroyedQuery)).to.equal(true);
+      const meta = await handle.query(getMetadataQuery);
+      expect(meta.status).to.equal('terminated');
+
+      // Workflow drains and completes on its own
+      await handle.result();
+    });
+  });
+
+  it('refuses processingStart once destroyRequested is set (in-workflow guard)', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const ensemble = `destroy-attach-${Date.now()}`;
+      // Start a session pre-marked as destroyed via input state (simulates continue-as-new
+      // of a destroyed workflow) — this keeps the workflow alive long enough for us to
+      // observe the in-workflow guard without racing workflow completion.
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'destroy-attach', ensemble, status: 'pending' }),
+        destroyed: true,
+      });
+
+      expect(await handle.query(isDestroyedQuery)).to.equal(true);
+
+      let rejected = false;
+      try {
+        await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: 'late-msg' }] });
+      } catch {
+        rejected = true;
+      }
+      expect(rejected).to.equal(true, 'expected processingStart to be rejected on destroyed session');
+
+      // Force-terminate rather than waiting — the workflow's main loop is still running
+      // with status=pending since we bypassed the normal destroy flow.
+      await handle.terminate('test cleanup');
+      await handle.result().catch(() => {});
+    });
+  });
+
+  it('second start with USE_EXISTING on a destroyed workflow gets a NEW run; old handle sees terminated', async function () {
+    this.timeout(20_000);
+    await withWorker(async () => {
+      const ensemble = `destroy-resurrect-${Date.now()}`;
+      const metadata = playerMetadata({ playerId: 'resurrect-bob', ensemble });
+      const wfId = `claude-session-${ensemble}-resurrect-bob`;
+      const client = getClient();
+
+      const input = {
+        metadata,
+        autoSummary: `Session in test`,
+        disableStaleDetection: true,
+      };
+
+      // Initial run — pin runId
+      const handle1 = await client.workflow.start('claudeSessionWorkflow', {
+        workflowId: wfId,
+        taskQueue: TASK_QUEUE,
+        args: [input],
+      });
+      const runId1 = handle1.firstExecutionRunId;
+      expect(runId1).to.be.a('string');
+
+      // Destroy the first run
+      await handle1.executeUpdate(destroyUpdate, { args: [{ reason: 'stop' }] });
+      await handle1.result();
+
+      // Simulate the adapter-recovery misbehavior: call start() again with USE_EXISTING.
+      // Temporal reuses the old workflowId but (since it completed) allows a new run.
+      const handle2 = await client.workflow.start('claudeSessionWorkflow', {
+        workflowId: wfId,
+        taskQueue: TASK_QUEUE,
+        args: [input],
+        workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+      });
+      const runId2 = handle2.firstExecutionRunId;
+
+      // The second start returned a fresh run — that's the resurrection hazard.
+      // But a correctly-written adapter would have pinned to runId1, and a query
+      // against the runId1-pinned handle should not silently attach to run 2.
+      expect(runId2).to.not.equal(runId1, 'USE_EXISTING on completed workflow should start a new run');
+
+      // Confirm: the runId1-pinned handle reports the OLD run as closed.
+      const pinnedToOld = client.workflow.getHandle(wfId, runId1!);
+      const descOld = await pinnedToOld.describe();
+      expect(['COMPLETED', 'TERMINATED', 'FAILED']).to.include(descOld.status.name);
+
+      // The pinned-old isDestroyed query still succeeds against the historical run
+      // (queries against closed workflows work in Temporal), returning true.
+      expect(await pinnedToOld.query(isDestroyedQuery)).to.equal(true);
+
+      // Clean up the second run
+      await handle2.executeUpdate(destroyUpdate, { args: [{}] });
+      await handle2.result();
+    });
+  });
+});

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -33,6 +33,11 @@ import {
   setWorktreeSignal,
   removeWorktreeSignal,
   worktreesQuery,
+  processingStartUpdate,
+  processingEndUpdate,
+  inFlightMessagesQuery,
+  destroyUpdate,
+  isDestroyedQuery,
 } from '../src/workflows/signals';
 
 // Re-export signals/queries for convenience in test files
@@ -59,6 +64,11 @@ export {
   setWorktreeSignal,
   removeWorktreeSignal,
   worktreesQuery,
+  processingStartUpdate,
+  processingEndUpdate,
+  inFlightMessagesQuery,
+  destroyUpdate,
+  isDestroyedQuery,
 };
 
 let testEnv: TestWorkflowEnvironment;

--- a/test/processing-lifecycle.test.ts
+++ b/test/processing-lifecycle.test.ts
@@ -1,0 +1,178 @@
+import { expect } from 'chai';
+import { OutboxEntry, Message, SessionMetadata } from '../src/types';
+import {
+  setupTestEnv,
+  teardownTestEnv,
+  withWorker,
+  withWorkerAndOutboxActivities,
+  startSession,
+  playerMetadata,
+  getMetadataQuery,
+  pendingMessagesQuery,
+  markDeliveredSignal,
+  processingStartUpdate,
+  processingEndUpdate,
+  inFlightMessagesQuery,
+  destroyUpdate,
+  updateMetadataSignal,
+  submitOutboxUpdate,
+} from './helpers';
+
+/** Outbox seed — wakes the main loop so stale detection runs an iteration. */
+function seedOutbox(): OutboxEntry[] {
+  return [{
+    id: 'seed-probe',
+    type: 'cue',
+    targetPlayerId: '_probe',
+    message: '_wake',
+    createdAt: new Date().toISOString(),
+    status: 'pending',
+  }];
+}
+
+/** Deliver all pending messages so the workflow can exit cleanly. */
+async function deliverAll(handle: any): Promise<void> {
+  const msgs = await handle.query(pendingMessagesQuery);
+  const ids = (msgs as Message[]).filter((m) => !m.delivered).map((m) => m.id);
+  if (ids.length > 0) await handle.signal(markDeliveredSignal, ids);
+}
+
+describe('processing lifecycle — fixes #99 (long tool calls misclassified as stale)', function () {
+  before(async function () {
+    this.timeout(60_000);
+    await setupTestEnv();
+  });
+
+  after(async function () {
+    await teardownTestEnv();
+  });
+
+  it('tracks in-flight messages via processingStart/End', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'proc-track' }),
+      });
+
+      await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: 'msg-1' }] });
+      expect(await handle.query(inFlightMessagesQuery)).to.deep.equal(['msg-1']);
+
+      await handle.executeUpdate(processingEndUpdate, { args: [{ messageId: 'msg-1' }] });
+      expect(await handle.query(inFlightMessagesQuery)).to.be.empty;
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('processingStart/End are idempotent — duplicate messageIds do not corrupt state', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'proc-idem' }),
+      });
+
+      await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: 'msg-a' }] });
+      await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: 'msg-a' }] }); // retry
+      expect(await handle.query(inFlightMessagesQuery)).to.deep.equal(['msg-a']); // set dedupes
+
+      await handle.executeUpdate(processingEndUpdate, { args: [{ messageId: 'msg-a' }] });
+      await handle.executeUpdate(processingEndUpdate, { args: [{ messageId: 'msg-a' }] }); // idempotent
+      expect(await handle.query(inFlightMessagesQuery)).to.be.empty;
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('rejects processingStart with missing messageId (validator)', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'proc-val' }),
+      });
+
+      let rejected = false;
+      try {
+        await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: '' }] });
+      } catch {
+        rejected = true;
+      }
+      expect(rejected).to.equal(true, 'expected validator rejection for empty messageId');
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('tracks multiple concurrent in-flight messages', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'proc-multi' }),
+      });
+
+      await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: 'a' }] });
+      await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: 'b' }] });
+      await handle.executeUpdate(processingStartUpdate, { args: [{ messageId: 'c' }] });
+
+      expect(await handle.query(inFlightMessagesQuery)).to.have.members(['a', 'b', 'c']);
+
+      await handle.executeUpdate(processingEndUpdate, { args: [{ messageId: 'b' }] });
+      expect(await handle.query(inFlightMessagesQuery)).to.have.members(['a', 'c']);
+
+      await handle.signal(updateMetadataSignal, { status: 'terminated' });
+      await handle.result();
+    });
+  });
+
+  it('suppresses stale detection while a message is in-flight, then resumes once released (#99)', async function () {
+    this.timeout(30_000);
+    await withWorkerAndOutboxActivities(async () => {
+      const now = Date.now();
+      // Pre-seed a 5-minute-old undelivered message (would normally trigger stale detection,
+      // since the threshold is 3 minutes) and pre-populate inFlightMessageIds so the very
+      // first main-loop iteration treats the adapter as processing.
+      const oldMsg: Message = {
+        id: 'msg-1',
+        from: 'conductor',
+        text: 'Do a long task',
+        timestamp: new Date(now - 5 * 60 * 1000).toISOString(),
+        delivered: false,
+      };
+
+      const handle = await startSession({
+        metadata: playerMetadata({ playerId: 'proc-stale', status: 'active' }),
+        disableStaleDetection: false,
+        messages: [oldMsg],
+        inFlightMessageIds: ['msg-1'],
+        processingSince: now - 5 * 60 * 1000,
+        // Seed the outbox so the main loop wakes on first iteration and runs stale check.
+        outbox: seedOutbox(),
+      });
+
+      // Give the workflow a beat to run its first main-loop iteration.
+      await new Promise((r) => setTimeout(r, 2000));
+      const meta1: SessionMetadata = await handle.query(getMetadataQuery);
+      expect(meta1.status).to.not.equal('stale');
+      expect(await handle.query(inFlightMessagesQuery)).to.deep.equal(['msg-1']);
+
+      // End processing — next iteration should let stale detection fire.
+      await handle.executeUpdate(processingEndUpdate, { args: [{ messageId: 'msg-1' }] });
+      // Submit another outbox seed to wake the loop again.
+      await handle.executeUpdate(submitOutboxUpdate, {
+        args: [{ type: 'cue', targetPlayerId: '_probe2', message: '_wake2' }],
+      });
+      await new Promise((r) => setTimeout(r, 2000));
+
+      const meta2: SessionMetadata = await handle.query(getMetadataQuery);
+      expect(meta2.status).to.equal('stale');
+
+      // Cleanup: deliver all pending messages then destroy.
+      await deliverAll(handle);
+      await handle.executeUpdate(destroyUpdate, { args: [{}] });
+      await deliverAll(handle);
+      await handle.result().catch(() => {});
+    });
+  });
+});

--- a/test/runid-pinning.test.ts
+++ b/test/runid-pinning.test.ts
@@ -1,0 +1,133 @@
+import { expect } from 'chai';
+import { WorkflowIdConflictPolicy, WorkflowNotFoundError } from '@temporalio/client';
+import {
+  setupTestEnv,
+  teardownTestEnv,
+  withWorker,
+  playerMetadata,
+  getMetadataQuery,
+  updateMetadataSignal,
+  getClient,
+  TASK_QUEUE,
+} from './helpers';
+
+describe('runId pinning — prevents zombie-resurrection via unpinned handles', function () {
+  before(async function () {
+    this.timeout(60_000);
+    await setupTestEnv();
+  });
+
+  after(async function () {
+    await teardownTestEnv();
+  });
+
+  it('unpinned getHandle silently attaches to a new run with same workflowId (illustrates the hazard)', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const ensemble = `pin-hazard-${Date.now()}`;
+      const wfId = `claude-session-${ensemble}-pin-bot`;
+      const client = getClient();
+      const input = {
+        metadata: playerMetadata({ playerId: 'pin-bot', ensemble }),
+        autoSummary: `Session in test`,
+        disableStaleDetection: true,
+      };
+
+      // Start run 1, capture runId
+      const h1 = await client.workflow.start('claudeSessionWorkflow', {
+        workflowId: wfId,
+        taskQueue: TASK_QUEUE,
+        args: [input],
+      });
+      const runId1 = h1.firstExecutionRunId!;
+
+      // Complete run 1
+      await h1.signal(updateMetadataSignal, { status: 'terminated' });
+      await h1.result();
+
+      // Start run 2 with USE_EXISTING (completed run allows this) — fresh runId
+      const h2 = await client.workflow.start('claudeSessionWorkflow', {
+        workflowId: wfId,
+        taskQueue: TASK_QUEUE,
+        args: [input],
+        workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+      });
+      const runId2 = h2.firstExecutionRunId!;
+      expect(runId2).to.not.equal(runId1);
+
+      // HAZARD demonstration: unpinned getHandle attaches to the CURRENT run (run 2),
+      // silently. A caller expecting run 1 would not get an error.
+      const unpinned = client.workflow.getHandle(wfId);
+      const descUnpinned = await unpinned.describe();
+      expect(descUnpinned.runId).to.equal(runId2, 'unpinned handle tracks current run');
+
+      // Cleanup
+      await h2.signal(updateMetadataSignal, { status: 'terminated' });
+      await h2.result();
+    });
+  });
+
+  it('pinned getHandle(wfId, runId) returns WorkflowNotFound if the pinned run is gone', async function () {
+    this.timeout(15_000);
+    await withWorker(async () => {
+      const ensemble = `pin-safe-${Date.now()}`;
+      const wfId = `claude-session-${ensemble}-pin-safe`;
+      const client = getClient();
+      const input = {
+        metadata: playerMetadata({ playerId: 'pin-safe', ensemble }),
+        autoSummary: `Session in test`,
+        disableStaleDetection: true,
+      };
+
+      // Start + terminate run 1
+      const h1 = await client.workflow.start('claudeSessionWorkflow', {
+        workflowId: wfId,
+        taskQueue: TASK_QUEUE,
+        args: [input],
+      });
+      const runId1 = h1.firstExecutionRunId!;
+      await h1.signal(updateMetadataSignal, { status: 'terminated' });
+      await h1.result();
+
+      // The runId1-pinned handle can still query the historical run (queries against
+      // closed workflows work in Temporal).
+      const pinned1 = client.workflow.getHandle(wfId, runId1);
+      const pinnedDesc = await pinned1.describe();
+      expect(pinnedDesc.runId).to.equal(runId1);
+      // Historical metadata still queryable
+      const meta = await pinned1.query(getMetadataQuery);
+      expect(meta.status).to.equal('terminated');
+
+      // Start run 2 (fresh)
+      const h2 = await client.workflow.start('claudeSessionWorkflow', {
+        workflowId: wfId,
+        taskQueue: TASK_QUEUE,
+        args: [input],
+        workflowIdConflictPolicy: WorkflowIdConflictPolicy.USE_EXISTING,
+      });
+
+      // The runId1-pinned handle is STILL pinned to run 1 — never silently attaches
+      // to run 2 even though it's now the current run for this workflow ID.
+      const pinnedAgain = await pinned1.describe();
+      expect(pinnedAgain.runId).to.equal(runId1);
+      expect(pinnedAgain.runId).to.not.equal(h2.firstExecutionRunId);
+
+      // A signal attempt against the pinned-closed run throws — protects callers from
+      // silently mutating a resurrected workflow.
+      let threw = false;
+      try {
+        await pinned1.signal(updateMetadataSignal, { status: 'terminated' });
+      } catch (err) {
+        threw = true;
+        // Could be WorkflowNotFoundError or a workflow-execution-already-completed error;
+        // either way, it did NOT silently attach to run 2.
+        expect(err instanceof WorkflowNotFoundError || String(err).toLowerCase().includes('completed')).to.equal(true);
+      }
+      expect(threw).to.equal(true, 'signal against pinned-closed run must fail, not attach to current');
+
+      // Cleanup run 2
+      await h2.signal(updateMetadataSignal, { status: 'terminated' });
+      await h2.result();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Tactical MVP to close the two most painful session-lifecycle bugs in production.
Uses the correct mechanisms from the upcoming Design B v2 (full rebuild) but
scoped tight — does NOT implement the full 7-phase lifecycle, attachment leases,
or adapter refactor. Those come later.

**Closes #99** — long tool calls in the Copilot bridge no longer get
misclassified as stale.
**Closes #102** — graceful stop no longer triggers a resurrection loop.

Parent: #106

## The four pieces

### 1. `processingStart` / `processingEnd` updates (fixes #99)

Two new Temporal updates on `claudeSessionWorkflow`:

- `processingStart({ messageId })` — marks the messageId as being actively
  processed by a blocking adapter. `messageId` is required for idempotency
  under at-least-once update retries.
- `processingEnd({ messageId })` — removes it.

While any messageId is in-flight, **stale detection is suppressed** — an adapter
mid-tool-call no longer flips to `stale`. A 15-minute safety timer logs a warning
and ejects wedged entries so the workflow cannot be pinned alive forever.

The Copilot bridge wraps `sendAndWait()` in `try/finally` with these updates
around it. Fire-and-logged: the update round-trip never blocks the LLM call,
but exceptions are logged.

### 2. `destroy` verb (fixes #102 primary)

New update `destroy({ reason? })` + query `isDestroyed()` on `claudeSessionWorkflow`:

- `destroy` sets `destroyed = true`, transitions status to `terminated`, records
  a system message with the reason, and lets the main loop exit.
- The final drain window is capped at 10 seconds (vs. 2 minutes for regular
  terminate) because a destroyed session has no adapter to deliver messages.
- The `processingStart` validator rejects on destroyed workflows — late messages
  from a recovery-looping bridge cannot re-attach.

The Copilot bridge's `recreateSession()` now queries `isDestroyed` **before**
spawning a new Copilot session. On true (or `WorkflowNotFound` from a pinned
handle), it returns `false` — no zombie rejoin.

`claude-tempo stop` uses the destroy update. `--terminate` flag restored as an
escape hatch for hard-terminate.

### 3. RunId pinning (belt-and-suspenders for #102)

Current bug: `client.workflow.getHandle(workflowId)` returns an unpinned handle.
If the workflow completes and `USE_EXISTING` starts a fresh run with the same ID,
the unpinned handle silently tracks the new run. Signals go to the wrong run.

Fix: in the Copilot bridge, after the initial workflow-ready `describe()`,
re-get the handle with the observed runId — `getHandle(wfId, runId)` — and use
that pinned handle for every subsequent signal/query/update. A destroyed-and-
resurrected workflow now throws `WorkflowNotFound` instead of letting the bridge
mutate a new run.

### 4. Dead-code removal from fd00e83

**Already done.** The `describe() → TERMINATE_EXISTING` branches were reverted
in `dfebc95` (hold/pause feature) along with the describe-guard in the bridge.
Confirmed via grep — no dead code remaining.

## Tests

New test files:

- `test/processing-lifecycle.test.ts` — 5 tests: tracking, idempotency,
  validator rejection on empty messageId, concurrent in-flight messages, and
  the #99 repro (old undelivered message + inFlight suppresses stale; after
  processingEnd, next iteration flips stale).
- `test/destroy.test.ts` — 3 tests: destroy → isDestroyed=true + status=terminated,
  destroy validator rejects processingStart, #102 repro (destroy → USE_EXISTING
  starts fresh run; pinned-old-runId handle reports terminated, `isDestroyed`
  query against historical run still returns true).
- `test/runid-pinning.test.ts` — 2 tests: illustrates the hazard of unpinned
  handles, verifies pinned handles throw rather than silently attach.

**Full suite: 611 passing, 0 failing** (up from 601 baseline + 10 new).

## Test plan

- [x] `npm run build` succeeds (workflow bundle rebuilt)
- [x] `npm test` — 611 passing
- [ ] Manual validation: spawn Copilot player, trigger a long (>3min) tool call,
  verify session does NOT go stale
- [ ] Manual validation: `claude-tempo stop copilot-bob`, verify no zombie rejoin

🤖 Generated with [Claude Code](https://claude.com/claude-code)