### PR TITLE
fix(test): stabilize ensemble-listing race in integration.test.ts (latent flake)

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -70,7 +70,7 @@ describe('multi-session integration', function () {
           metadata: playerMetadata({ playerId: 'out-scope', ensemble: 'ens-B' }),
         });
 
-        const members = await listEnsemble(getClient(), 'ens-A');
+        const members = await waitForEnsembleMembers(getClient(), 'ens-A', 1);
         expect(members).to.have.lengthOf(1);
         expect(members[0].playerId).to.equal('in-scope');
 


### PR DESCRIPTION
## Summary

- Wraps the bare `listEnsemble(getClient(), 'ens-A')` call at line 64 in `waitForEnsembleMembers(getClient(), 'ens-A', 1)` to match the polling pattern used by the two sibling tests at lines 43 and 83.

## Root cause

`listEnsemble` queries Temporal's visibility store directly with no retry. The visibility store is eventually consistent — a workflow started moments earlier may not yet be visible. The sibling tests already work around this with `waitForEnsembleMembers`, but this test was missed. The race is latent and only manifests reliably under Node 22's scheduler cadence.

## Test plan

- [x] `npm test` — 628 mocha + 69 vitest passing, 0 failing
- [x] One-line change; no logic, no API surface, no wire protocol impact
- [x] Dual QA optional per conductor guidance — de-risking only

🤖 Generated with [Claude Code](https://claude.com/claude-code)