### PR TITLE
fix(types): reconcile DetachReason enum with design spec (#116)

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -51,15 +51,27 @@ export interface AdapterDescriptor {
   heartbeatMs: number;
 }
 
-/** Reason an attachment detached or was detached. Used for audit and UX messaging. */
+/**
+ * Reason an attachment detached or was detached. Used for audit and UX messaging.
+ *
+ * Canonical values per design §3.1 (`docs/design/session-lifecycle-rebuild-v2.md`):
+ *   `user-stop` | `restart` | `heartbeat-timeout` | `superseded` | `agent-exited` | `spawn-failed` | `destroy`
+ *
+ * `force` is a PR-A implementation extension used by the main loop's `drainingDeadline`
+ * fire path (§9.5.c) when the adapter never sent `adapterExited` after `requestDetach`.
+ * Kept alongside the spec values so the workflow has a non-empty reason to record even
+ * when the graceful drain path never acked. Safe to merge into `heartbeat-timeout` in a
+ * future cleanup if the semantics converge.
+ */
 export type DetachReason =
-  | 'requested'
+  | 'user-stop'
   | 'restart'
   | 'heartbeat-timeout'
-  | 'destroy'
+  | 'superseded'
+  | 'agent-exited'
   | 'spawn-failed'
-  | 'force'
-  | 'idle';
+  | 'destroy'
+  | 'force';
 
 /**
  * Workflow-emitted directive to the attached adapter. Delivered via {@link AttachmentInfo}

--- a/test/session-phase-machine.test.ts
+++ b/test/session-phase-machine.test.ts
@@ -215,7 +215,7 @@ describe('session phase machine (v0.25 PR-A)', function () {
         args: [{ host: 'host-A', adapterId: 'claude-code', adapterClass: 'interactive', leaseMs: 60_000 }],
       });
 
-      await handle.signal(requestDetachSignal, { reason: 'requested', deadlineMs: 5_000 });
+      await handle.signal(requestDetachSignal, { reason: 'user-stop', deadlineMs: 5_000 });
       // Poll attachmentInfo briefly — phase should hit 'draining'.
       let info: AttachmentInfo = await handle.query(attachmentInfoQuery);
       // The requestDetach signal may not have been processed yet at first query; loop with tiny wait.
@@ -225,7 +225,7 @@ describe('session phase machine (v0.25 PR-A)', function () {
       }
       expect(info.phase).to.equal('draining');
 
-      await handle.signal(adapterExitedSignal, { attachmentId: token.attachmentId, reason: 'requested' });
+      await handle.signal(adapterExitedSignal, { attachmentId: token.attachmentId, reason: 'agent-exited' });
       for (let i = 0; i < 10 && info.phase !== 'detached'; i++) {
         await new Promise((r) => setTimeout(r, 100));
         info = await handle.query(attachmentInfoQuery);
@@ -343,11 +343,11 @@ describe('session phase machine (v0.25 PR-A)', function () {
         args: [{ host: 'host-A', adapterId: 'claude-code', adapterClass: 'interactive', leaseMs: 60_000 }],
       });
       await handle.executeUpdate(setPreferredHostUpdate, { args: [{ host: 'host-preferred' }] });
-      await handle.executeUpdate(forceDetachUpdate, { args: [{ reason: 'requested', gracePeriodMs: 0 }] });
+      await handle.executeUpdate(forceDetachUpdate, { args: [{ reason: 'user-stop', gracePeriodMs: 0 }] });
 
       const summary: OrphanSummary = await handle.query(orphanSummaryQuery);
       expect(summary.preferredHost).to.equal('host-preferred');
-      expect(summary.reason).to.equal('requested');
+      expect(summary.reason).to.equal('user-stop');
       expect(summary.detachedSince).to.be.a('string');
       expect(summary.lastAdapter?.hostname).to.equal('host-A');
       expect(summary.lastAdapter?.adapterId).to.equal('claude-code');


### PR DESCRIPTION
## Summary

Reconciles `DetachReason` in `src/types.ts` with the canonical definition in
`docs/design/session-lifecycle-rebuild-v2.md` §3.1. Must land before PR-C since
that PR wires adapters to emit these values directly — mismatched values would
be silently ignored by the phase-machine handlers.

## Before / after

| Previous           | Updated             | Rationale                                    |
|--------------------|---------------------|----------------------------------------------|
| `requested`        | `user-stop`         | rename to match spec wording                 |
| `restart`          | `restart`           | unchanged (in spec)                          |
| `heartbeat-timeout`| `heartbeat-timeout` | unchanged (in spec)                          |
| `destroy`          | `destroy`           | unchanged (in spec)                          |
| `spawn-failed`     | `spawn-failed`      | unchanged — **in spec, issue summary was off** |
| `force`            | `force`             | kept as extension w/ doc note (§9.5.c)       |
| `idle`             | *(removed)*         | unused in code, not in spec                  |
| *(missing)*        | `superseded`        | added — for new-claim eviction in PR-C/F     |
| *(missing)*        | `agent-exited`      | added — `adapterExited` signal sets this     |

Final enum (spec order, `force` last as the documented extension):

```ts
type DetachReason =
  | 'user-stop'
  | 'restart'
  | 'heartbeat-timeout'
  | 'superseded'
  | 'agent-exited'
  | 'spawn-failed'
  | 'destroy'
  | 'force';
```

## Callers updated

Only test files used the old `'requested'` value — no production code touched
beyond the type definition.

- `test/session-phase-machine.test.ts`:
  - `requestDetach({ reason: 'requested' })` → `'user-stop'`
  - `adapterExited({ reason: 'requested' })` → `'agent-exited'` (more accurate semantics)
  - `forceDetach({ reason: 'requested' })` + orphanSummary assertion → `'user-stop'`

`src/workflows/session.ts` line 1107 drainingDeadline fallback keeps `'force'`
(spec doesn't offer a clean substitute; doc comment on the type explains).

## Wire-protocol impact

**None.** `DetachReason` appears in signal/update payloads abstractly
(`reason: DetachReason`) in `docs/WIRE-PROTOCOL.md`, not as an enumerated set.
No doc changes beyond the type definition.

## Test plan

- [x] `npm run build` green
- [x] `npm test` — 628 passing, 0 failing (no regressions vs. PR-A baseline)
- [x] All call sites of `'requested'` updated
- [x] `'idle'` removal verified — `grep -r "'idle'" src/ test/` shows no hits

Design ref: `docs/design/session-lifecycle-rebuild-v2.md` §3.1.
Closes #116.

🤖 Generated with [Claude Code](https://claude.com/claude-code)