### PR TITLE
docs(v0.25): scrub encore references, document new verb surface (#137)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -15,11 +15,14 @@ claude-tempo <command> [options]
 | `start [ensemble]` | Start a player session |
 | `status [ensemble]` | Show active sessions and Temporal health |
 | `config` | Configure Temporal connection settings (interactive or `set`/`show`) |
-| `stop [ensemble]` | Stop sessions only — recoverable via `encore`. Use `-n <name>` for one, `--all` for all. |
+| `stop [ensemble]` | Stop sessions only — recoverable via `restart`. Use `-n <name>` for one, `--all` for all. |
 | `init` | Register claude-tempo MCP server globally (`--project` for per-directory) |
 | `preflight` | Run environment checks |
 | `broadcast <msg>` | Send a message to all active players. Use `--type` to filter by player type, `--include-stale` to include stale sessions. |
-| `encore <name>` | Revive a stale player session by name. Use `--host` to target a remote machine. |
+| `restart <name>` | Restart a player session — detaches current adapter and re-spawns. Works from any non-`gone` attachment phase. Use `--host` to target a remote machine. |
+| `detach <name>` | Gracefully detach the adapter for a session — triggers draining and clean handoff. Use when migrating a session to another host. |
+| `destroy <name>` | Terminate a session's workflow — ordered shutdown via outbox drain. Use for permanent removal. |
+| `migrate <name>` | Move a session to a different host — sugar for `setPreferredHost` + `restart` on the target machine. Use `--to <hostname>`. |
 | `release [ensemble]` | Release all held players — unlocks outboxes and delivers deferred task messages. Use `-n <name>` to release one player. |
 | `pause [ensemble]` | Pause the ensemble — locks all session outbox dispatch and pauses the scheduler. |
 | `resume [ensemble]` | Resume a paused ensemble — unlocks outbox dispatch and restarts the scheduler. |
@@ -150,6 +153,47 @@ Graceful self-update — stops the daemon, installs the latest (or specified) ve
 claude-tempo upgrade            # install latest version
 claude-tempo upgrade 0.20.0     # install a specific version
 ```
+
+### `claude-tempo restart`
+
+Detaches the current adapter and re-spawns a fresh process — functionally replaces the retired `encore` command. Works from any non-`gone` attachment phase (including `attached`, `awaiting`, `processing`, and `detached`):
+
+```bash
+claude-tempo restart alice             # restart on same host
+claude-tempo restart alice --host bob-mac   # restart on remote host
+```
+
+The existing Temporal workflow is preserved — message history and metadata carry over.
+
+### `claude-tempo detach`
+
+Signals the adapter to drain and detach gracefully:
+
+```bash
+claude-tempo detach alice
+```
+
+Triggers the `requestDetach` signal → adapter enters `draining` → `detached`. Use before a planned `migrate` or host maintenance.
+
+### `claude-tempo destroy`
+
+Terminates a session's workflow via ordered shutdown (outbox drain):
+
+```bash
+claude-tempo destroy alice
+```
+
+Prefer `destroy` over `stop` for permanent removal — it respects the v0.25 outbox and attachment lifecycle rather than force-terminating.
+
+### `claude-tempo migrate`
+
+Moves a session to a different host — sets the preferred host then triggers `restart` on the target machine's task queue:
+
+```bash
+claude-tempo migrate alice --to build-server
+```
+
+Requires the target host to have an active claude-tempo daemon. See [PR-F multi-host docs](https://github.com/vinceblank/claude-tempo) for cross-host setup.
 
 ## Related
 

--- a/docs/dashboard.md
+++ b/docs/dashboard.md
@@ -51,8 +51,12 @@ Use `/players <name>` to open a scrollable message history for any player.
 | `/broadcast <message>` | Send a message to all active players in the current ensemble |
 | `/recruit [name] [--type <type>] [--dir <path>]` | Spawn a new player (launches wizard if args omitted) |
 | `/recruit-conductor` | Recruit a conductor for the current ensemble |
-| `/stop <player>` | Stop a player session (with confirmation) |
-| `/encore <player>` | Revive a stale player session |
+| `/stop <player>` | Hard-terminate a workflow — bypasses v0.25 outbox drain. Prefer `/destroy` for ordered shutdown. |
+| `/restart <player>` | Restart a player — detaches current adapter and re-spawns. Works from any non-`gone` phase. |
+| `/detach <player>` | Gracefully detach a player's adapter — triggers draining and clean handoff. |
+| `/destroy <player>` | Terminate a session via ordered shutdown (outbox drain). Use for permanent removal. |
+| `/migrate <player> --to <hostname>` | Move a session to a different host. Requires target host to have an active daemon. |
+| `/attachment-info <player>` | Show the current attachment phase, lease expiry, and in-flight count for a player. |
 | `/disband` | Tear down the current ensemble — all sessions, scheduler, and Maestro |
 | `/players [name]` | Show detailed player info; no args opens interactive picker |
 | `/ensemble [name]` | Switch active ensemble context; no args opens picker |
@@ -69,6 +73,14 @@ Use `/players <name>` to open a scrollable message history for any player.
 | `/quit` | Exit the TUI |
 
 Interactive overlays (`/schedule`, `/gates`, `/stages`, `/worktree`) support arrow-key navigation and action keys shown in the overlay hint bar (e.g. `n=new  d=delete  esc=close`).
+
+## v0.25 Changes
+
+> **Breaking change in v0.25.0-beta.1**: The wire protocol changed. If upgrading from v0.24.x, run `claude-tempo down` and `claude-tempo up` to reinitialize before launching the TUI.
+
+- **`/encore` removed** — use `/restart` instead. Restart works from any non-`gone` attachment phase.
+- **`/stop` semantics changed** — now hard-terminates the workflow directly (bypasses outbox drain). Prefer `/destroy` for ordered shutdown.
+- **New lifecycle commands**: `/restart`, `/detach`, `/destroy`, `/migrate`, `/attachment-info` expose the v0.25 attachment state machine.
 
 ## How the TUI Gets Data
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -11,7 +11,7 @@ These tools are available inside Claude Code sessions connected to claude-tempo.
 | `listen` | Manually check for pending messages. |
 | `recruit` | Spawn a new Claude Code session in a directory. Can recruit a conductor with `conductor: true`. |
 | `report` | Send updates to the conductor. No-op if no conductor exists. |
-| `stop` | Stop a player session by name. |
+| `stop` | Hint shim — advises callers to use `destroy` or `detach` instead. Scheduled for removal in an upcoming release. |
 | `schedule` | Create a one-shot or recurring schedule to cue a player. |
 | `unschedule` | Cancel a named schedule. |
 | `schedules` | List all active schedules. |
@@ -20,7 +20,11 @@ These tools are available inside Claude Code sessions connected to claude-tempo.
 | `save_lineup` | Save the current ensemble as a YAML lineup (conductor only). |
 | `load_lineup` | Load a lineup to recruit players and create schedules. |
 | `broadcast` | Send a message to all active players. Optional `type` filter limits to a specific player type. |
-| `encore` | Revive a stale player session — restarts the process and reconnects to the existing workflow with context restored. |
+| `restart` | Restart a player session — detaches the current adapter and re-spawns a fresh process. Works from any non-`gone` phase. Optional `host` param routes restart to a remote machine. |
+| `detach` | Gracefully detach a player's adapter — triggers draining and clean handoff. Use before a planned `migrate` or host maintenance. |
+| `destroy` | Terminate a session via ordered shutdown (outbox drain). Prefer over `stop` for permanent removal. |
+| `migrate` | Move a session to a different host — sets preferred host then triggers `restart` on the target machine's task queue. Requires `to` (target hostname). |
+| `attachment_info` | Fetch the current attachment phase, adapter ID, lease expiry, and in-flight message count for a player. Accepts `player` name. |
 | `recall` | Read your own message history. Shows received messages by default; pass `includeSent: true` for the full timeline. |
 | `worktree` | Manage git worktrees for player isolation. Actions: `create`, `remove`, `list`. Conductor only. |
 | `quality_gate` | Define or replace a quality gate for a task — a named checklist of criteria that must pass. Conductor only. |
@@ -32,6 +36,14 @@ These tools are available inside Claude Code sessions connected to claude-tempo.
 | `release` | Release held player sessions — unlocks their outboxes and delivers deferred task messages. Omit `player` to release all held sessions. |
 | `pause_ensemble` | Pause all sessions in the ensemble: locks outbox dispatch and pauses the scheduler. `stop` commands still go through. |
 | `resume_ensemble` | Resume a paused ensemble — unlocks outbox dispatch and resumes the scheduler. Buffered outbox entries are dispatched. |
+
+## v0.25 Changes
+
+> **Breaking change in v0.25.0-beta.1**: The wire protocol between sessions and workers changed. If you are upgrading from v0.24.x, run `claude-tempo down` and `claude-tempo up` to reinitialize. Sessions from different versions cannot interoperate.
+
+- **`encore` removed** — replaced by `restart`. The `restart` tool works from any non-`gone` attachment phase and is not limited to stale sessions.
+- **`stop` deprecated** — the tool is now a hint shim and will be removed in an upcoming release. Use `destroy` (ordered shutdown) or `detach` (graceful adapter reap) instead.
+- **New lifecycle verbs**: `restart`, `detach`, `destroy`, `migrate`, and `attachment_info` expose the v0.25 attachment state machine directly.
 
 ## Related
 


### PR DESCRIPTION
Closes #137. Lands before v0.25.0-beta.1 tag.

## Summary

- **`docs/cli.md`**: Fix "encore" → "restart" in `stop` description; remove `encore` command row; add `restart`, `detach`, `destroy`, `migrate` rows with full detail subsections
- **`docs/tools.md`**: Update `stop` row to reflect hint-shim status; remove `encore` row; add `restart`, `detach`, `destroy`, `migrate`, `attachment_info` rows; add v0.25 breaking-change callout section
- **`docs/dashboard.md`**: Update `/stop` description (hard-terminate semantics, prefer `/destroy`); remove `/encore` row; add `/restart`, `/detach`, `/destroy`, `/migrate`, `/attachment-info` slash command rows; add v0.25 breaking-change callout section

## Test plan

- [ ] Verify no remaining `encore` references in `docs/cli.md`, `docs/tools.md`, `docs/dashboard.md`
- [ ] Verify new verb rows match actual CLI command / MCP tool / TUI slash command names implemented in PR-D
- [ ] Confirm v0.25 callout wording does not reference `v0.25.1` or `#132`

🤖 Generated with [Claude Code](https://claude.com/claude-code)