### PR TITLE
feat(v0.25): PR-F — cross-host capstone + migrate CLI + TUI host indicator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,30 @@ Design reference: `docs/design/session-lifecycle-rebuild-v2.md`.
   Windows (Task Scheduler via `packaging/windows/install-task.ps1`,
   current-user task at logon). **User-level only** — never requires
   `sudo` or Administrator
+- **Cross-host `restart` / `migrate`** (PR-F design §16, §16.5 Option B)
+  — the `restart` MCP tool accepts an optional `host` parameter that
+  routes the downstream `spawnProcess` activity to the per-host
+  `claude-tempo-{host}` task queue. The `migrate` tool is sugar over
+  `restart --host=<h>`. Both verbs surface a `confirmStealFromHost`
+  arg and a CLI `--yes-steal=<hostname>` flag; cross-host force-restart
+  requires the flag to match the current attachment's hostname exactly
+  (client-side guard; no interactive prompts per §8 answer 5).
+  `claude-tempo migrate <name> --to <hostname>` is the operator-friendly
+  surface with copy-paste-friendly re-run errors
+- **Daemon `reconcileOnBoot` cross-host filter** (PR-F §8 answer 2) —
+  orphans whose `preferredHost` differs from the local hostname are
+  logged + skipped rather than auto-restored. The remote host's daemon
+  is the authoritative restorer for its own sessions. Proactive
+  cross-daemon notification of orphans is a v0.26 follow-up (tracked
+  as a separate issue). Log line format includes both hostnames for
+  observability: `skipping restore for {workflowId}: preferredHost={X}, localHost={Y}`
+- **TUI cross-host indicator** (PR-F §8 answer 3) — `ChatView` and
+  `PlayerDetailView` surface the attached host when a session is on a
+  remote machine: status line gains a `{host} · ` prefix in amber
+  (`THEME.accent`) for remote sessions; local sessions omit the host
+  entirely to reduce noise for the common case. Zero new Yoga nodes —
+  the host segment is composed inline in the existing `<Text>` tree as
+  a nested virtual text node per CLAUDE.md TUI Performance rules
 
 ### Changed
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -42,6 +42,8 @@ interface ParsedArgs {
   // PR-E restore flags
   fromHost?: string;
   dryRun?: boolean;
+  // PR-F cross-host flags
+  yesSteal?: string;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -107,8 +109,15 @@ function parseArgs(argv: string[]): ParsedArgs {
       result.type = argv[++i];
     } else if (arg === '--include-stale') {
       result.includeStale = true;
-    } else if (arg === '--host' && i + 1 < argv.length) {
+    } else if ((arg === '--host' || arg === '--to') && i + 1 < argv.length) {
+      // `--to` is the migrate-UX alias for `--host` (brief §3 Site 4).
       result.host = argv[++i];
+    } else if (arg === '--yes-steal' && i + 1 < argv.length) {
+      // Space-separated form: `--yes-steal <hostname>`.
+      result.yesSteal = argv[++i];
+    } else if (arg.startsWith('--yes-steal=')) {
+      // Equals form (preferred per brief): `--yes-steal=<hostname>`.
+      result.yesSteal = arg.slice('--yes-steal='.length);
     } else if (arg === '--terminate') {
       result.terminate = true;
     } else if (arg === '--fresh') {
@@ -272,7 +281,7 @@ async function main() {
     case 'restart': {
       const name = args.positional[1] || args.name;
       if (!name) {
-        out.error('Usage: claude-tempo restart <name> [--host <hostname>] [--fresh] [--force] [--context-messages <N>]');
+        out.error('Usage: claude-tempo restart <name> [--host <hostname>] [--fresh] [--force] [--yes-steal=<current-host>] [--context-messages <N>]');
         process.exit(1);
       }
       await restart({
@@ -282,6 +291,7 @@ async function main() {
         fresh: args.fresh,
         force: args.force,
         ...(args.contextMessages !== undefined ? { contextMessages: args.contextMessages } : {}),
+        ...(args.yesSteal !== undefined ? { yesSteal: args.yesSteal } : {}),
         ...overrides,
       });
       break;
@@ -320,11 +330,11 @@ async function main() {
     case 'migrate': {
       const name = args.positional[1] || args.name;
       if (!name) {
-        out.error('Usage: claude-tempo migrate <name> --host <hostname> [--fresh] [--force]');
+        out.error('Usage: claude-tempo migrate <name> --to <hostname> [--force --yes-steal=<current-host>] [--fresh]');
         process.exit(1);
       }
       if (!args.host) {
-        out.error('`--host` is required for migrate. Use `restart` to revive on the current host.');
+        out.error('`--to <hostname>` is required for migrate. Use `restart` to revive on the current host.');
         process.exit(1);
       }
       await migrate({
@@ -334,6 +344,7 @@ async function main() {
         fresh: args.fresh,
         force: args.force,
         ...(args.contextMessages !== undefined ? { contextMessages: args.contextMessages } : {}),
+        ...(args.yesSteal !== undefined ? { yesSteal: args.yesSteal } : {}),
         ...overrides,
       });
       break;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -1816,6 +1816,8 @@ interface RestartCliOpts extends VerbOpts {
   fresh?: boolean;
   force?: boolean;
   contextMessages?: number;
+  /** PR-F: required when force-restarting a session attached to a different host. */
+  yesSteal?: string;
 }
 
 interface DetachCliOpts extends VerbOpts {
@@ -1852,6 +1854,16 @@ export async function restart(opts: RestartCliOpts) {
   const ensemble = opts.ensemble || config.ensemble;
   try {
     const tempo = createTempoClient(client);
+
+    // PR-F §16.5 guard — cross-host force-restart requires --yes-steal match.
+    await enforceCliYesSteal(tempo, ensemble, opts.name, {
+      ...(opts.force !== undefined ? { force: opts.force } : {}),
+      ...(opts.yesSteal !== undefined ? { yesSteal: opts.yesSteal } : {}),
+      verbName: 'restart',
+      targetHostFlag: '--host',
+      ...(opts.host !== undefined ? { targetHostValue: opts.host } : {}),
+    });
+
     const result = await tempo.restart(ensemble, opts.name, {
       ...(opts.host !== undefined ? { host: opts.host } : {}),
       ...(opts.fresh !== undefined ? { fresh: opts.fresh } : {}),
@@ -1865,6 +1877,9 @@ export async function restart(opts: RestartCliOpts) {
       `${opts.fresh ? ' (fresh)' : ''}${opts.force ? ' (force)' : ''}.`,
     );
     out.log(`  ${out.dim(`outbox entry: ${result.entryId}`)}`);
+    if (opts.host) {
+      out.log(`  ${out.dim(`Verify a claude-tempo daemon is running on "${opts.host}" — tasks will queue until one picks them up.`)}`);
+    }
   } catch (err: any) {
     out.error(err?.message || String(err));
     process.exit(1);
@@ -1903,15 +1918,86 @@ export async function destroy(opts: DestroyCliOpts) {
   }
 }
 
+/**
+ * CLI-side `--yes-steal` guard (§16.5 Option B, brief §8 answer 5).
+ *
+ * Detects cross-host force-restart at the CLI layer and emits a
+ * copy-paste-friendly error including the exact re-run command. Returns the
+ * confirmed hostname on success; exits the process (code 1) on rejection —
+ * intentionally synchronous UX per "hard error, no interactive prompt".
+ *
+ * Shared by `migrate` and `restart` CLI commands so both surfaces have
+ * identical error text.
+ */
+async function enforceCliYesSteal(
+  tempo: ReturnType<typeof createTempoClient>,
+  ensemble: string,
+  playerName: string,
+  opts: {
+    force?: boolean;
+    yesSteal?: string;
+    /** For the "re-run" suggestion — the CLI verb name (`migrate` or `restart`). */
+    verbName: string;
+    /** For the "re-run" suggestion — flag that carries the target host. */
+    targetHostFlag: string;
+    /** Resolved target host value (e.g. opts.host for migrate). */
+    targetHostValue?: string;
+  },
+  localHostname: string = hostname(),
+): Promise<void> {
+  if (!opts.force) return;
+
+  let info;
+  try {
+    info = await tempo.attachmentInfo(ensemble, playerName);
+  } catch {
+    // Target may not exist or be destroyed — let the downstream call surface
+    // its own error. Not our job to synthesize cross-host errors here.
+    return;
+  }
+
+  const currentHost = info.currentAttachment?.hostname;
+  if (!currentHost || currentHost === localHostname) return;
+
+  const targetFlag = opts.targetHostValue
+    ? `${opts.targetHostFlag} ${opts.targetHostValue}`
+    : opts.targetHostFlag;
+  const reRun = `claude-tempo ${opts.verbName} ${playerName} ${targetFlag} --yes-steal=${currentHost} --force`;
+
+  if (!opts.yesSteal) {
+    out.error(`session "${playerName}" is attached to host "${currentHost}".`);
+    out.log('  To confirm moving it, re-run with --yes-steal:');
+    out.log(`\n    ${reRun}\n`);
+    out.log('  This safety flag prevents accidental cross-host session takeover.');
+    process.exit(1);
+  }
+  if (opts.yesSteal !== currentHost) {
+    out.error(`--yes-steal mismatch: session "${playerName}" is on "${currentHost}", not "${opts.yesSteal}".`);
+    out.log('  Re-run with the correct hostname:');
+    out.log(`\n    ${reRun}\n`);
+    process.exit(1);
+  }
+}
+
 export async function migrate(opts: MigrateCliOpts) {
   if (!opts.host) {
-    out.error('Usage: claude-tempo migrate <name> --host <hostname>');
+    out.error('Usage: claude-tempo migrate <name> --to <hostname> [--force --yes-steal=<current-host>]');
     process.exit(1);
   }
   const { config, connection, client } = await verbClient(opts);
   const ensemble = opts.ensemble || config.ensemble;
   try {
     const tempo = createTempoClient(client);
+
+    // PR-F §16.5 guard — cross-host force-migrate requires --yes-steal match.
+    await enforceCliYesSteal(tempo, ensemble, opts.name, {
+      ...(opts.force !== undefined ? { force: opts.force } : {}),
+      ...(opts.yesSteal !== undefined ? { yesSteal: opts.yesSteal } : {}),
+      verbName: 'migrate',
+      targetHostFlag: '--to',
+      targetHostValue: opts.host,
+    });
+
     const result = await tempo.migrate(ensemble, opts.name, opts.host, {
       ...(opts.fresh !== undefined ? { fresh: opts.fresh } : {}),
       ...(opts.force !== undefined ? { force: opts.force } : {}),
@@ -1920,6 +2006,7 @@ export async function migrate(opts: MigrateCliOpts) {
     });
     out.success(`Migrate queued for "${result.playerId}" → ${result.host ?? opts.host}.`);
     out.log(`  ${out.dim(`outbox entry: ${result.entryId}`)}`);
+    out.log(`  ${out.dim(`Verify a claude-tempo daemon is running on "${opts.host}" — tasks will queue until one picks them up.`)}`);
   } catch (err: any) {
     out.error(err?.message || String(err));
     process.exit(1);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -115,6 +115,29 @@ export async function reconcileOnBoot(
 
   log(`reconcile: found ${orphans.length} orphan${orphans.length === 1 ? '' : 's'}`);
 
+  // PR-F cross-host filter (design §16 + brief §8 answer 2). A session whose
+  // `preferredHost` points to a different machine should not be restored by
+  // this daemon — the remote host's daemon is the authoritative restorer.
+  // Log-and-skip only: proactive cross-daemon signaling is a v0.26 feature
+  // (tracked as a follow-up; see brief §6 "reconcileOnBoot cross-host signal
+  // path is out of scope").
+  const originalOrphans = orphans;
+  orphans = originalOrphans.filter((o) => {
+    if (o.summary.preferredHost && o.summary.preferredHost !== hostname) {
+      log(`skipping restore for ${o.workflowId}: preferredHost=${o.summary.preferredHost}, localHost=${hostname}`);
+      return false;
+    }
+    return true;
+  });
+  const crossHostSkipped = originalOrphans.length - orphans.length;
+  if (crossHostSkipped > 0) {
+    log(`reconcile: skipped ${crossHostSkipped} orphan${crossHostSkipped === 1 ? '' : 's'} preferring remote hosts`);
+  }
+  if (orphans.length === 0) {
+    // All candidates filtered out — nothing to do on this host.
+    return;
+  }
+
   if (daemonConfig.restorePolicy === 'prompt') {
     for (const o of orphans) {
       log(

--- a/src/tools/migrate.ts
+++ b/src/tools/migrate.ts
@@ -6,10 +6,10 @@
  * names route through the same `RestartOutboxEntry` outbox path so the §8.2
  * algorithm is implemented once in `deliverRestart` (QA B3).
  *
- * Multi-host routing (host → task-queue selection, `--yes-steal` flag per §16.5
- * Option B) lands in PR-F. This PR-D implementation passes `host` through to
- * the existing `enqueueSpawn` flow; the per-host task queue is selected inside
- * the session workflow's outbox dispatch (unchanged).
+ * PR-F wires the `confirmStealFromHost` guard (design §16.5 Option B) via the
+ * shared `enforceYesStealGuard` helper from `restart.ts`. When the caller passes
+ * `force: true` AND the target's current attachment is on a different host,
+ * `confirmStealFromHost` must name that hostname exactly.
  */
 import { z } from 'zod';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
@@ -18,25 +18,27 @@ import { Config } from '../config';
 import type { OutboxEntryInput } from '../types';
 import { submitOutboxUpdate } from '../workflows/signals';
 import { defineTool, ok, fail, formatError } from './helpers';
+import { enforceYesStealGuard } from './restart';
 import { PLAYER_NAME_MAX, RESTART_CONTEXT_MESSAGES_MAX, validatePlayerName } from '../utils/validation';
 
 export function registerMigrateTool(
   server: McpServer,
-  _client: Client,
-  _config: Config,
+  client: Client,
+  config: Config,
   getPlayerId: () => string,
   handle: WorkflowHandle,
 ) {
   defineTool(
     server,
     'migrate',
-    'Migrate a session to a different host — sugar for `restart` with a required `host`. Reaps the current attachment, claims fresh on the target host, spawns a new adapter. Cross-host routing (per-host task queues) is honored automatically.',
+    'Migrate a session to a different host — sugar for `restart` with a required `host`. Reaps the current attachment, claims fresh on the target host, spawns a new adapter. Cross-host routing (per-host task queues) is honored automatically. When `force=true` AND the target is currently on a different host, `confirmStealFromHost` must match that hostname (design §16.5).',
     {
       playerId: z.string().max(PLAYER_NAME_MAX).describe('The player name to migrate'),
       host: z.string().min(1).describe('Target hostname — required'),
       fresh: z.boolean().optional().describe('Skip context replay (default false)'),
       force: z.boolean().optional().describe('Steal a live attachment via forceDetach (default false)'),
       contextMessages: z.number().min(0).max(RESTART_CONTEXT_MESSAGES_MAX).optional().describe('Number of recent messages to include in context (default 10)'),
+      confirmStealFromHost: z.string().optional().describe('Required when `force=true` and the target\'s current attachment is on a different host (design §16.5 Option B).'),
     },
     async (args) => {
       const input = args as {
@@ -45,6 +47,7 @@ export function registerMigrateTool(
         fresh?: boolean;
         force?: boolean;
         contextMessages?: number;
+        confirmStealFromHost?: string;
       };
 
       const nameError = validatePlayerName(input.playerId);
@@ -53,6 +56,11 @@ export function registerMigrateTool(
       if (!input.host || !input.host.trim()) {
         return fail('`host` is required for migrate. Use `restart` (without host) to restart on the session\'s current host.');
       }
+
+      // Shared cross-host guard with `restart` — same rules, same copy-paste
+      // error messages (§16.5).
+      const guardError = await enforceYesStealGuard(client, config.ensemble, input.playerId, input);
+      if (guardError) return fail(guardError);
 
       try {
         const entry: OutboxEntryInput = {

--- a/src/tools/restart.ts
+++ b/src/tools/restart.ts
@@ -10,49 +10,132 @@
  *   → `claimAttachment` → optional `receiveMessage` context replay
  *   → `enqueueSpawn` on the target's outbox
  *
- * Durability bonus: mid-algorithm failures surface as ApplicationFailures and
- * retry per the activity's policy. Design §8.2.
+ * PR-F adds two cross-host pieces:
+ *
+ * 1. `host` param — routes the eventual `spawnProcess` to the
+ *    `claude-tempo-{host}` task queue. Threaded through the existing
+ *    `RestartOutboxEntry.host` → `deliverRestart` activity → `enqueueSpawn`
+ *    update → `SpawnOutboxEntry.targetHostname` → `case 'spawn':`
+ *    dispatcher → `getSpawnProxy(host)` → per-host task queue. All the
+ *    plumbing already exists; this PR just surfaces the input.
+ *
+ * 2. `--yes-steal` guard (design §16.5 Option B) — when `force: true`
+ *    AND the target's current attachment is on a different host, the
+ *    caller must pass `confirmStealFromHost` matching that hostname.
+ *    Client-side only; the workflow trusts the caller (P1 gotcha).
+ *
+ * Durability bonus: mid-algorithm failures surface as ApplicationFailures
+ * and retry per the activity's policy. Design §8.2.
  */
 import { z } from 'zod';
+import { hostname as osHostname } from 'os';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { Client, WorkflowHandle } from '@temporalio/client';
 import { Config } from '../config';
-import type { OutboxEntryInput } from '../types';
-import { submitOutboxUpdate } from '../workflows/signals';
+import type { OutboxEntryInput, AttachmentInfo } from '../types';
+import { submitOutboxUpdate, attachmentInfoQuery } from '../workflows/signals';
+import { resolveSession } from './resolve';
 import { defineTool, ok, fail, formatError } from './helpers';
 import { PLAYER_NAME_MAX, RESTART_CONTEXT_MESSAGES_MAX, validatePlayerName } from '../utils/validation';
 
 const DEFAULT_CONTEXT_MESSAGES = 10;
 
+export interface RestartToolArgs {
+  playerId: string;
+  host?: string;
+  fresh?: boolean;
+  force?: boolean;
+  contextMessages?: number;
+  confirmStealFromHost?: string;
+}
+
+/**
+ * Shared `--yes-steal` guard (design §16.5 Option B).
+ *
+ * Returns `null` if the call is allowed, or a user-facing error message
+ * (matching the brief's copy-paste-friendly format) if not. Exported for
+ * the `migrate` CLI command and unit tests.
+ *
+ * Only fires when BOTH:
+ *   - caller passed `force: true`
+ *   - target session currently has an attachment on a host other than ours
+ *
+ * Graceful (non-force) restarts always pass. Non-cross-host force restarts
+ * always pass. Missing `confirmStealFromHost` + mismatched
+ * `confirmStealFromHost` are both rejected with the same copy-paste format.
+ */
+export async function enforceYesStealGuard(
+  client: Client,
+  ensemble: string,
+  playerId: string,
+  args: { force?: boolean; confirmStealFromHost?: string },
+  localHostname: string = osHostname(),
+): Promise<string | null> {
+  if (!args.force) return null;
+
+  const resolved = await resolveSession(client, ensemble, playerId);
+  if (!resolved) return null; // No target — downstream enqueue will handle the error.
+
+  let info: AttachmentInfo;
+  try {
+    info = await resolved.query(attachmentInfoQuery) as AttachmentInfo;
+  } catch {
+    // If we can't read the phase, let the downstream algorithm handle the
+    // state. Not our job to synthesize cross-host errors here.
+    return null;
+  }
+
+  const currentHost = info.currentAttachment?.hostname;
+  if (!currentHost || currentHost === localHostname) return null;
+
+  // Cross-host force-restart detected — demand --yes-steal match.
+  if (!args.confirmStealFromHost) {
+    return (
+      `session "${playerId}" is attached to host "${currentHost}". ` +
+      `To force-restart from there, pass confirmStealFromHost: "${currentHost}". ` +
+      `This safety flag prevents accidental cross-host session takeover.`
+    );
+  }
+  if (args.confirmStealFromHost !== currentHost) {
+    return (
+      `confirmStealFromHost mismatch: session "${playerId}" is on ` +
+      `"${currentHost}", not "${args.confirmStealFromHost}". ` +
+      `Re-run with confirmStealFromHost: "${currentHost}".`
+    );
+  }
+
+  return null;
+}
+
 export function registerRestartTool(
   server: McpServer,
-  _client: Client,
-  _config: Config,
+  client: Client,
+  config: Config,
   getPlayerId: () => string,
   handle: WorkflowHandle,
 ) {
   defineTool(
     server,
     'restart',
-    'Restart a session — reap the current attachment (gracefully, or with force=true), claim a fresh attachment, spawn a new adapter, and optionally replay recent context. Replaces `encore`, `recruit --force`, and `stop`-then-`recruit`.',
+    'Restart a session — reap the current attachment (gracefully, or with force=true), claim a fresh attachment, spawn a new adapter, and optionally replay recent context. Replaces `encore`, `recruit --force`, and `stop`-then-`recruit`. Pass `host` to restart on a different machine; when `force=true` AND the target is currently on a different host, pass `confirmStealFromHost` matching that hostname (design §16.5).',
     {
       playerId: z.string().max(PLAYER_NAME_MAX).describe('The player name to restart'),
-      host: z.string().optional().describe('Target host (defaults to session\'s preferredHost or last-known hostname)'),
+      host: z.string().optional().describe('Target host for the new attachment (defaults to the session\'s preferredHost or last-known hostname). When set, the spawn is routed to the per-host task queue `claude-tempo-{host}`.'),
       fresh: z.boolean().optional().describe('Skip context replay — spawn a clean slate (default false)'),
       force: z.boolean().optional().describe('Steal a live attachment via forceDetach (default false; graceful detach is tried first regardless)'),
       contextMessages: z.number().min(0).max(RESTART_CONTEXT_MESSAGES_MAX).optional().describe(`Number of recent messages to include in context (default ${DEFAULT_CONTEXT_MESSAGES}, max ${RESTART_CONTEXT_MESSAGES_MAX})`),
+      confirmStealFromHost: z.string().optional().describe('Required when `force=true` and the target\'s current attachment is on a different host. Must match the hostname currently holding the attachment (design §16.5 Option B).'),
     },
     async (args) => {
-      const input = args as {
-        playerId: string;
-        host?: string;
-        fresh?: boolean;
-        force?: boolean;
-        contextMessages?: number;
-      };
+      const input = args as RestartToolArgs;
 
       const nameError = validatePlayerName(input.playerId);
       if (nameError) return fail(nameError);
+
+      // Client-side --yes-steal guard (§16.5). Cross-host force-restart
+      // requires an explicit confirmStealFromHost matching the current holder.
+      const guardError = await enforceYesStealGuard(client, config.ensemble, input.playerId, input);
+      if (guardError) return fail(guardError);
 
       try {
         const entry: OutboxEntryInput = {

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -10,6 +10,7 @@
  * - PromptArea (pinned)
  */
 import React, { useReducer, useEffect, useCallback, useMemo, useState } from 'react';
+import { hostname as osHostname } from 'os';
 import { useInk } from './ink-context';
 import { tuiReducer, initialState } from './store';
 import type { StaticItem, RecruitAnswers, ScheduleAnswers, CreateEnsembleAnswers } from './store';
@@ -1174,6 +1175,8 @@ export function App({ api, ensemble, defaultAgent }: AppProps) {
         targetPart: targetPlayer?.part,
         targetBranch: targetPlayer?.gitBranch,
         targetStatus: targetPlayer?.status,
+        targetHost: targetPlayer?.hostname,
+        localHost: osHostname(),
         isConductor: memoizedChatData.isConductor,
         receivedCount: memoizedChatData.received,
         sentCount: memoizedChatData.sent,
@@ -1232,6 +1235,7 @@ export function App({ api, ensemble, defaultAgent }: AppProps) {
         metadata: state.playerMetadata,
         messages: state.playerMessages,
         scrollOffset: state.playerScrollOffset,
+        localHost: osHostname(),
       });
     }
 

--- a/src/tui/components/ChatView.tsx
+++ b/src/tui/components/ChatView.tsx
@@ -2,6 +2,14 @@
  * ChatView — header for a conversation with a specific player.
  * Messages are rendered via <Static> in App.tsx, not here.
  * This component only shows context (player name, part, branch, counts).
+ *
+ * PR-F cross-host indicator (design §16, brief §8 answer 3 — Option 3):
+ *   - Local session (targetHost === localHost) → omit host entirely (no noise).
+ *   - Remote session → prepend `{host} · ` to the existing status line in
+ *     `THEME.accent` (amber).
+ * Zero new Yoga nodes: the host prefix goes into the same `<Text>` children
+ * tree as an additional string + nested accent-colored `<Text>` (which is a
+ * virtual text node, not a Box).
  */
 import React from 'react';
 import { useInk } from '../ink-context';
@@ -19,6 +27,10 @@ export interface ChatViewProps {
   targetPart?: string;
   targetBranch?: string;
   targetStatus?: string;
+  /** The session's home hostname (PR-A metadata). Compare vs `localHost` to decide cross-host rendering. */
+  targetHost?: string;
+  /** The local TUI process's hostname. */
+  localHost?: string;
   isConductor?: boolean;
   receivedCount: number;
   sentCount: number;
@@ -29,6 +41,8 @@ export function ChatView({
   targetPlayer,
   targetPart,
   targetBranch,
+  targetHost,
+  localHost,
   isConductor,
   receivedCount,
   sentCount,
@@ -37,6 +51,9 @@ export function ChatView({
 
   const icon = isConductor ? '\u2605 ' : '';
   const label = isConductor ? 'Conductor' : 'Conversation with';
+
+  // §8 answer 3 — remote host only; local omits entirely.
+  const showRemoteHost = Boolean(targetHost && localHost && targetHost !== localHost);
 
   const children: React.ReactNode[] = [];
 
@@ -50,10 +67,23 @@ export function ChatView({
     children.push(React.createElement(Text, { key: 'h2', color: THEME.dim }, `  Part: ${targetPart}`));
   }
   children.push('\n');
+
+  // Status line — prepend amber {host} · for remote sessions only.
+  // Zero new Yoga nodes: composed inline as nested <Text> within h3.
+  const h3Children: React.ReactNode[] = [];
+  h3Children.push('  ');
+  if (showRemoteHost) {
+    h3Children.push(
+      React.createElement(Text, { key: 'host', color: THEME.accent }, targetHost!),
+    );
+    h3Children.push(' \u00B7 ');
+  }
+  if (targetBranch) {
+    h3Children.push(`Branch: ${targetBranch} \u00B7 `);
+  }
+  h3Children.push(`${receivedCount} received, ${sentCount} sent`);
   children.push(
-    React.createElement(Text, { key: 'h3', color: THEME.dim },
-      `  ${targetBranch ? `Branch: ${targetBranch} \u00B7 ` : ''}${receivedCount} received, ${sentCount} sent`,
-    ),
+    React.createElement(Text, { key: 'h3', color: THEME.dim }, ...h3Children),
   );
   children.push('\n');
   children.push(

--- a/src/tui/components/PlayerDetailView.tsx
+++ b/src/tui/components/PlayerDetailView.tsx
@@ -1,6 +1,13 @@
 /**
  * PlayerDetailView — shows player metadata + scrollable message history.
  * Single <Text> pattern, zero Yoga nodes — all content pre-formatted as strings.
+ *
+ * PR-F cross-host indicator (design §16, brief §8 answer 3 — Option 3):
+ *   - Local session (`player.hostname === localHost`) → omit "Host:" field
+ *     from the metadata line (reduces noise; local is the common case).
+ *   - Remote session → show `Host: {hostname}` in `THEME.accent` (amber).
+ * Zero new Yoga nodes: the host segment goes into the same `<Text>` children
+ * tree as an additional nested `<Text>` (virtual text node, not a Box).
  */
 import React from 'react';
 import { useInk } from '../ink-context';
@@ -16,6 +23,8 @@ export interface PlayerDetailViewProps {
   metadata: SessionMetadata | null;
   messages: Array<Message | (SentMessage & { direction: 'sent' })>;
   scrollOffset: number;
+  /** Local TUI process hostname. When equal to the player's hostname, the Host field is omitted. */
+  localHost?: string;
 }
 
 function isSent(m: Message | (SentMessage & { direction: 'sent' })): m is SentMessage & { direction: 'sent' } {
@@ -37,6 +46,7 @@ export function PlayerDetailView({
   metadata,
   messages,
   scrollOffset,
+  localHost,
 }: PlayerDetailViewProps) {
   const { Text } = useInk();
 
@@ -46,13 +56,25 @@ export function PlayerDetailView({
   const icon = player?.isConductor ? '\u2605 ' : '  ';
   children.push(React.createElement(Text, { key: 'name', bold: true, color: THEME.accent }, `${icon}${playerId}`));
 
-  // Metadata line 1: Type · Status · Host
+  // Metadata line 1: Type · Status [· Host when remote]
   const type = player?.playerType || player?.agentType || '(default)';
   const status = player?.status || 'unknown';
   const statusDot = status === 'active' ? '\u25CF' : status === 'stale' ? '\u25CB' : '\u25A0';
-  const host = player?.hostname || metadata?.hostname || '?';
+  const host = player?.hostname || metadata?.hostname || '';
+  const showRemoteHost = Boolean(host && localHost && host !== localHost);
   children.push('\n');
-  children.push(React.createElement(Text, { key: 'meta1', color: THEME.dim }, `  Type: ${type} \u00B7 Status: ${statusDot} ${status} \u00B7 Host: ${host}`));
+  if (showRemoteHost) {
+    // Remote — Host segment rendered in amber, same Text tree (zero Yoga nodes).
+    children.push(React.createElement(Text, { key: 'meta1', color: THEME.dim },
+      `  Type: ${type} \u00B7 Status: ${statusDot} ${status} \u00B7 Host: `,
+      React.createElement(Text, { color: THEME.accent }, host),
+    ));
+  } else {
+    // Local (or unknown) — omit Host entirely.
+    children.push(React.createElement(Text, { key: 'meta1', color: THEME.dim },
+      `  Type: ${type} \u00B7 Status: ${statusDot} ${status}`,
+    ));
+  }
 
   // Metadata line 2: Branch · Dir
   const branch = player?.gitBranch || metadata?.gitBranch || '';

--- a/test/fixtures/multi-host/README.md
+++ b/test/fixtures/multi-host/README.md
@@ -1,0 +1,59 @@
+# Multi-host integration harness (PR-F)
+
+Two claude-tempo daemon containers sharing a Temporal dev server. Used by
+`test/multi-host-cross-host-restart.test.ts` to validate cross-host
+`restart` end-to-end.
+
+**Does not run in the default `npm test` suite.** The integration test
+gates on `INTEGRATION_MULTI_HOST=1` and `docker-compose` being available.
+
+## Prerequisites
+
+- Docker + Docker Compose v2
+- Ports `7233` (Temporal gRPC) and `8233` (Temporal UI) free on the host
+
+## Running the harness
+
+From the repository root:
+
+```bash
+# Boot the three services (Temporal dev + two daemons).
+docker-compose -f test/fixtures/multi-host/docker-compose.yml up -d --build
+
+# Wait for Temporal health + daemon warm-up (~15-30s on first run —
+# daemon-a and daemon-b both `npm ci && npm run build` against the
+# mounted source tree).
+docker-compose -f test/fixtures/multi-host/docker-compose.yml ps
+
+# Run the integration test. TEMPORAL_ADDRESS points at the exposed host.
+INTEGRATION_MULTI_HOST=1 TEMPORAL_ADDRESS=localhost:7233 \
+  npx mocha dist-test/test/multi-host-cross-host-restart.test.js
+
+# Tear down.
+docker-compose -f test/fixtures/multi-host/docker-compose.yml down -v
+```
+
+## Networking notes
+
+- **Linux**: `network_mode: "host"` is *not* used — the compose file uses
+  the default bridge network so that `daemon-*` can reach `temporal` by
+  service name. The published port `7233:7233` exposes Temporal to the
+  host so the test runner (which executes on the host, not inside a
+  container) can connect.
+- **macOS / Windows**: identical — containers talk to `temporal:7233`
+  via service-DNS; the host talks to `localhost:7233` via the port map.
+- If port 7233 is already in use on your host, change the `ports:` block
+  (`- "17233:7233"`) and export `TEMPORAL_ADDRESS=localhost:17233` when
+  running the test.
+
+## Why local-source build?
+
+The daemon Dockerfiles do `COPY . /app && npm ci && npm run build` — they
+build from the current working tree, not a published image. This is
+deliberate per PR-F §8 answer 4: the integration test validates the branch
+under test. Using `FROM claude-tempo:latest` would test whatever is on npm
+(v0.24 or worse) instead of your local changes.
+
+BuildKit cache mounts are available but commented out in
+`daemon-a/Dockerfile`; enable them with `DOCKER_BUILDKIT=1` if rebuild
+time becomes a friction point.

--- a/test/fixtures/multi-host/daemon-a/Dockerfile
+++ b/test/fixtures/multi-host/daemon-a/Dockerfile
@@ -1,0 +1,22 @@
+# daemon-a — claude-tempo daemon running with hostname=host-a.
+#
+# Local-source build per PR-F §8 answer 4 — the integration test must
+# validate the branch under test, not a published image. Optional
+# BuildKit cache mount (commented out) can be enabled by setting
+# DOCKER_BUILDKIT=1 if build time becomes painful.
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+# RUN --mount=type=cache,target=/root/.npm \
+#     npm ci --no-audit --no-fund
+
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY . .
+RUN npm run build
+
+# Daemon entry — spawned by `node dist/daemon.js` matching production.
+CMD ["node", "dist/daemon.js"]

--- a/test/fixtures/multi-host/daemon-b/Dockerfile
+++ b/test/fixtures/multi-host/daemon-b/Dockerfile
@@ -1,0 +1,18 @@
+# daemon-b — claude-tempo daemon running with hostname=host-b.
+#
+# Identical to daemon-a Dockerfile; kept as a separate file so compose's
+# two services can have distinct build contexts if they ever need to
+# diverge (e.g. different flags, different npm scripts). Today they're
+# pure copies.
+
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --no-audit --no-fund
+
+COPY . .
+RUN npm run build
+
+CMD ["node", "dist/daemon.js"]

--- a/test/fixtures/multi-host/docker-compose.yml
+++ b/test/fixtures/multi-host/docker-compose.yml
@@ -1,0 +1,67 @@
+# claude-tempo multi-host integration harness (PR-F).
+#
+# Two daemon containers (`host-a`, `host-b`) share a single Temporal dev
+# server. Used by `test/multi-host-cross-host-restart.test.ts` to exercise
+# cross-host restart end-to-end.
+#
+# Usage (manual):
+#   docker-compose -f test/fixtures/multi-host/docker-compose.yml up -d
+#   npx mocha dist-test/test/multi-host-cross-host-restart.test.js
+#   docker-compose -f test/fixtures/multi-host/docker-compose.yml down
+#
+# The default `npm test` run does NOT invoke this harness — the integration
+# test gates on an `INTEGRATION_MULTI_HOST=1` env var. See the README in
+# this directory.
+
+services:
+  temporal:
+    image: temporalio/temporal:1.24
+    command:
+      - server
+      - start-dev
+      - --ip=0.0.0.0
+      - --namespace=default
+      - --search-attribute=ClaudeTempoEnsemble=Keyword
+      - --search-attribute=ClaudeTempoPlayerId=Keyword
+      - --search-attribute=ClaudeTempoHostname=Keyword
+      - --search-attribute=ClaudeTempoStatus=Keyword
+      - --search-attribute=ClaudeTempoGitRoot=Keyword
+      - --search-attribute=ClaudeTempoPlayerType=Keyword
+      - --search-attribute=ClaudeTempoIsConductor=Bool
+      - --search-attribute=ClaudeTempoAttachedHost=Keyword
+      - --search-attribute=ClaudeTempoAttachmentState=Keyword
+      - --search-attribute=ClaudeTempoAttachmentId=Keyword
+    ports:
+      - "7233:7233"
+      - "8233:8233"   # temporal UI
+    healthcheck:
+      test: ["CMD", "tctl", "--ad", "localhost:7233", "cluster", "health"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  daemon-a:
+    build:
+      context: ../../..
+      dockerfile: test/fixtures/multi-host/daemon-a/Dockerfile
+    hostname: host-a
+    environment:
+      TEMPORAL_ADDRESS: temporal:7233
+      TEMPORAL_NAMESPACE: default
+      CLAUDE_TEMPO_ENSEMBLE: multi-host-test
+    depends_on:
+      temporal:
+        condition: service_healthy
+
+  daemon-b:
+    build:
+      context: ../../..
+      dockerfile: test/fixtures/multi-host/daemon-b/Dockerfile
+    hostname: host-b
+    environment:
+      TEMPORAL_ADDRESS: temporal:7233
+      TEMPORAL_NAMESPACE: default
+      CLAUDE_TEMPO_ENSEMBLE: multi-host-test
+    depends_on:
+      temporal:
+        condition: service_healthy

--- a/test/multi-host-cross-host-restart.test.ts
+++ b/test/multi-host-cross-host-restart.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Multi-host integration test (PR-F acceptance gate).
+ *
+ * Exercises cross-host `restart` end-to-end against the docker-compose
+ * harness in `test/fixtures/multi-host/`. **Gated on the
+ * `INTEGRATION_MULTI_HOST=1` env var** — the default `npm test` run
+ * skips this file with `describe.skip` so CI unit-only runs don't depend
+ * on Docker.
+ *
+ * Manual flow (from repo root):
+ *
+ *   docker-compose -f test/fixtures/multi-host/docker-compose.yml up -d --build
+ *   INTEGRATION_MULTI_HOST=1 npx mocha dist-test/test/multi-host-cross-host-restart.test.js
+ *   docker-compose -f test/fixtures/multi-host/docker-compose.yml down
+ *
+ * Scenario:
+ *   1. Connect a TempoClient to the shared Temporal dev server.
+ *   2. Recruit a session with `host: 'host-a'` — expect it to land on
+ *      daemon-a's task queue and `ClaudeTempoAttachedHost=host-a` after boot.
+ *   3. Call `restart({ host: 'host-b', force: true,
+ *      confirmStealFromHost: 'host-a' })`.
+ *   4. Poll `attachmentInfo` until `currentAttachment.hostname === 'host-b'`
+ *      or a 60s deadline expires.
+ *   5. Verify message history is preserved (length ≥ original).
+ *
+ * Rejection paths (fast, no spawn required):
+ *   - Cross-host force without `confirmStealFromHost` → error from the guard.
+ *   - Cross-host force with `confirmStealFromHost: 'wrong-host'` → error.
+ *
+ * Note: this is a **skeleton**. The full flow requires the docker-compose
+ * harness to be up + a path to create sessions on a specific host task
+ * queue. The current recruit path runs locally via `spawnInTerminal`,
+ * which does not fit inside a headless container. Full integration will
+ * need a `recruit --host` plumbing extension or a container-specific
+ * entry point — tracked as a follow-up (not blocking PR-F merge).
+ */
+import { expect } from 'chai';
+import { Client, Connection } from '@temporalio/client';
+import { createTempoClient } from '../src/client';
+
+const INTEGRATION = process.env.INTEGRATION_MULTI_HOST === '1';
+const TEMPORAL_ADDRESS = process.env.TEMPORAL_ADDRESS || 'localhost:7233';
+const TEMPORAL_NAMESPACE = process.env.TEMPORAL_NAMESPACE || 'default';
+
+// When the env-var gate is off, all cases are skipped with a single
+// describe.skip wrapper so CI doesn't try to connect to Temporal.
+const describeIf = INTEGRATION ? describe : describe.skip;
+
+describeIf('multi-host cross-host restart (PR-F acceptance gate)', function () {
+  this.timeout(120_000);
+
+  let client: Client;
+  let connection: Connection;
+
+  before(async function () {
+    connection = await Connection.connect({ address: TEMPORAL_ADDRESS });
+    client = new Client({ connection, namespace: TEMPORAL_NAMESPACE });
+  });
+
+  after(async function () {
+    await connection?.close();
+  });
+
+  it('skeleton — harness reachable, createTempoClient succeeds', async function () {
+    const tempo = createTempoClient(client);
+    const ensembles = await tempo.discoverEnsembles();
+    // Harness is up if this call returns any structure (may be empty).
+    expect(Array.isArray(ensembles)).to.be.true;
+  });
+
+  // TODO: expand with the full restart-host-b cross-host path once
+  // `recruit --host` has a container-friendly spawn path. For now the
+  // unit tests in test/restart-host-routing.test.ts + test/yes-steal-guard.test.ts
+  // cover the tool-level correctness; this harness exists so the
+  // integration rehearsal is one env-var flip away when container spawn
+  // lands.
+});

--- a/test/rebuild-reboot.test.ts
+++ b/test/rebuild-reboot.test.ts
@@ -139,6 +139,42 @@ describe('reconcileOnBoot', function () {
   });
 
   it('restorePolicy "auto" — calls restart on fresh orphan within age window', async function () {
+    // Orphan preferredHost matches local: the PR-F cross-host filter is a
+    // pass-through, and the normal age-window + ensemble-allowlist +
+    // restart enqueue path runs. If preferredHost were elsewhere, the
+    // new filter would skip (covered by the cross-host-filter case below).
+    const client = makeFakeClient([
+      fixture({
+        ensemble: 'e1',
+        playerId: 'alice',
+        detachedSince: new Date(NOW - 60_000).toISOString(),
+        preferredHost: HOSTNAME,
+      }),
+    ]);
+    await reconcileOnBoot(client, defaults({ restorePolicy: 'auto' }), HOSTNAME);
+    expect(stub.calls).to.have.length(1);
+    expect(stub.calls[0].ensemble).to.equal('e1');
+    expect(stub.calls[0].playerId).to.equal('alice');
+    expect(stub.calls[0].opts.host).to.equal(HOSTNAME);
+    expect(stub.calls[0].opts.invokerPlayerId).to.equal('daemon');
+  });
+
+  it('restorePolicy "auto" — PR-F cross-host filter skips orphan preferring a remote host', async function () {
+    const client = makeFakeClient([
+      fixture({
+        ensemble: 'e1',
+        playerId: 'alice',
+        detachedSince: new Date(NOW - 60_000).toISOString(),
+        preferredHost: 'host-2', // ← different from HOSTNAME
+      }),
+    ]);
+    await reconcileOnBoot(client, defaults({ restorePolicy: 'auto' }), HOSTNAME);
+    // Filter fires before any policy logic — restart is never called on
+    // this daemon. The remote host's daemon is the authoritative restorer.
+    expect(stub.calls).to.have.length(0);
+  });
+
+  it('restorePolicy "prompt" — PR-F cross-host filter also applies (no log, no action)', async function () {
     const client = makeFakeClient([
       fixture({
         ensemble: 'e1',
@@ -147,12 +183,8 @@ describe('reconcileOnBoot', function () {
         preferredHost: 'host-2',
       }),
     ]);
-    await reconcileOnBoot(client, defaults({ restorePolicy: 'auto' }), HOSTNAME);
-    expect(stub.calls).to.have.length(1);
-    expect(stub.calls[0].ensemble).to.equal('e1');
-    expect(stub.calls[0].playerId).to.equal('alice');
-    expect(stub.calls[0].opts.host).to.equal('host-2');
-    expect(stub.calls[0].opts.invokerPlayerId).to.equal('daemon');
+    await reconcileOnBoot(client, defaults({ restorePolicy: 'prompt' }), HOSTNAME);
+    expect(stub.calls).to.have.length(0);
   });
 
   it('restorePolicy "auto" — skips orphan older than autoRestoreMaxAgeHours', async function () {

--- a/test/restart-host-routing.test.ts
+++ b/test/restart-host-routing.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Unit tests for the `restart` MCP tool's host-param routing.
+ *
+ * Asserts that:
+ *  - the `host` arg is threaded into `RestartOutboxEntry.host` on the
+ *    submitted outbox update;
+ *  - omitting `host` produces an entry with no `host` field (so the
+ *    activity falls back to preferredHost → metadata.hostname);
+ *  - the `--yes-steal` guard fires before any outbox submission when
+ *    cross-host force is detected without `confirmStealFromHost`.
+ *
+ * No Temporal connection — the registered tool handler is captured via a
+ * fake McpServer (pattern shared with `test/tools.test.ts`), then called
+ * directly with test arguments. The Temporal `client` parameter is a
+ * mock that yields a single "target" workflow for resolveSession + returns
+ * a fixture `attachmentInfo` for the guard query. The `handle` parameter
+ * captures the submitted `submitOutbox` entry so assertions read the
+ * entry shape.
+ */
+import { expect } from 'chai';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Client, WorkflowHandle } from '@temporalio/client';
+import { registerRestartTool } from '../src/tools/restart';
+import type { AttachmentInfo } from '../src/types';
+
+type ToolHandler = (args: Record<string, any>) => Promise<{
+  content: Array<{ type: 'text'; text: string }>;
+  isError?: boolean;
+}>;
+
+const asName = (n: unknown) => typeof n === 'string' ? n : (n as any).name;
+
+function extractHandler(reg: (server: McpServer) => void): ToolHandler {
+  let captured: Function | undefined;
+  const fake = {
+    tool: (_n: unknown, _d: unknown, _s: unknown, h: Function) => { captured = h; },
+  } as unknown as McpServer;
+  reg(fake);
+  if (!captured) throw new Error('No handler captured');
+  return (args) => captured!(args, {});
+}
+
+function makeTargetClient(opts: { attachedHost?: string } = {}): any {
+  // Build a fake client whose `workflow.list` yields a single candidate
+  // and whose `getHandle().query(attachmentInfo)` returns the fixture.
+  const info: AttachmentInfo = {
+    phase: 'attached',
+    inFlightCount: 0,
+    ...(opts.attachedHost !== undefined ? {
+      currentAttachment: {
+        attachmentId: 'a1',
+        hostname: opts.attachedHost,
+        adapterId: 'claude-code',
+        adapterClass: 'interactive',
+        claimedAt: '2026-04-12T00:00:00Z',
+        lastHeartbeatAt: '2026-04-13T00:00:00Z',
+        expiresAt: '2026-04-13T01:30:00Z',
+        leaseMs: 90_000,
+        runId: 'r1',
+      },
+    } : {}),
+  };
+  return {
+    workflow: {
+      getHandle: () => ({
+        workflowId: 'claude-session-test-ensemble-target',
+        async query(name: unknown) {
+          const n = asName(name);
+          if (n === 'attachmentInfo') return info;
+          if (n === 'getMetadata') return { ensemble: 'test-ensemble', playerId: 'target' };
+          return undefined;
+        },
+      }),
+      async *list() { yield { workflowId: 'claude-session-test-ensemble-target' }; },
+    },
+  };
+}
+
+function makeCaptureHandle(): { handle: WorkflowHandle; entries: Array<{ name: string; args: unknown }> } {
+  const entries: Array<{ name: string; args: unknown }> = [];
+  const handle = {
+    executeUpdate: async (nameOrDef: unknown, opts: { args: unknown[] }) => {
+      entries.push({ name: asName(nameOrDef), args: opts.args[0] });
+      return `entry-${entries.length}`;
+    },
+  } as unknown as WorkflowHandle;
+  return { handle, entries };
+}
+
+const testConfig = {
+  temporalAddress: 'localhost:7233',
+  temporalNamespace: 'default',
+  taskQueue: 'claude-tempo',
+  ensemble: 'test-ensemble',
+  defaultAgent: 'claude' as const,
+};
+
+describe('restart tool host routing (PR-F)', function () {
+  it('threads `host` into RestartOutboxEntry.host when supplied', async function () {
+    const client = makeTargetClient({ attachedHost: 'localhost-test' });
+    const { handle, entries } = makeCaptureHandle();
+    const call = extractHandler((s) =>
+      registerRestartTool(s, client, testConfig as any, () => 'invoker', handle),
+    );
+    const result = await call({ playerId: 'target', host: 'other-host' });
+    expect(result.isError).to.not.equal(true);
+    expect(entries).to.have.length(1);
+    const entry = entries[0].args as any;
+    expect(entry.type).to.equal('restart');
+    expect(entry.host).to.equal('other-host');
+  });
+
+  it('omits `host` from the entry when not supplied (downstream chooses)', async function () {
+    const client = makeTargetClient();
+    const { handle, entries } = makeCaptureHandle();
+    const call = extractHandler((s) =>
+      registerRestartTool(s, client, testConfig as any, () => 'invoker', handle),
+    );
+    await call({ playerId: 'target' });
+    const entry = entries[0].args as any;
+    expect(entry.host).to.be.undefined;
+  });
+
+  it('forwards invokerPlayerId from getPlayerId()', async function () {
+    const client = makeTargetClient();
+    const { handle, entries } = makeCaptureHandle();
+    const call = extractHandler((s) =>
+      registerRestartTool(s, client, testConfig as any, () => 'my-tempo-eng', handle),
+    );
+    await call({ playerId: 'target' });
+    expect((entries[0].args as any).invokerPlayerId).to.equal('my-tempo-eng');
+  });
+
+  it('rejects cross-host force without confirmStealFromHost (guard fires before enqueue)', async function () {
+    const client = makeTargetClient({ attachedHost: 'remote-host' });
+    const { handle, entries } = makeCaptureHandle();
+    const call = extractHandler((s) =>
+      registerRestartTool(s, client, testConfig as any, () => 'invoker', handle),
+    );
+    const result = await call({ playerId: 'target', force: true });
+    expect(result.isError).to.be.true;
+    // Critically, no entry was enqueued before the rejection.
+    expect(entries).to.have.length(0);
+  });
+
+  it('allows cross-host force with matching confirmStealFromHost', async function () {
+    const client = makeTargetClient({ attachedHost: 'remote-host' });
+    const { handle, entries } = makeCaptureHandle();
+    const call = extractHandler((s) =>
+      registerRestartTool(s, client, testConfig as any, () => 'invoker', handle),
+    );
+    const result = await call({
+      playerId: 'target',
+      force: true,
+      confirmStealFromHost: 'remote-host',
+      host: 'target-host',
+    });
+    expect(result.isError).to.not.equal(true);
+    expect(entries).to.have.length(1);
+    expect((entries[0].args as any).host).to.equal('target-host');
+    expect((entries[0].args as any).force).to.be.true;
+  });
+});

--- a/test/yes-steal-guard.test.ts
+++ b/test/yes-steal-guard.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Unit tests for `enforceYesStealGuard` — the shared MCP-tool-side
+ * `--yes-steal` guard used by both `restart` and `migrate` tools
+ * (design §16.5 Option B, brief §8 answer 5).
+ *
+ * No Temporal connection — the guard is fed a mock Client that returns
+ * a fixture `attachmentInfo` query result. The rule under test:
+ *
+ *   force + target attached to different host + no confirmStealFromHost → error
+ *   force + target attached to different host + wrong confirmStealFromHost → error
+ *   force + target attached to different host + matching confirmStealFromHost → allow
+ *   force + target attached to local host → allow
+ *   no force → allow (regardless of target host)
+ *   no target resolved → allow (downstream handles the error)
+ */
+import { expect } from 'chai';
+import { enforceYesStealGuard } from '../src/tools/restart';
+import type { AttachmentInfo } from '../src/types';
+
+const asName = (n: unknown) => typeof n === 'string' ? n : (n as any).name;
+
+function makeClient(opts: {
+  found?: boolean;
+  info?: AttachmentInfo;
+  queryError?: Error;
+} = {}): any {
+  const found = opts.found !== false; // default: found
+  const handle = {
+    workflowId: 'claude-session-e1-alice',
+    async query(name: unknown) {
+      if (opts.queryError) throw opts.queryError;
+      if (asName(name) === 'attachmentInfo') return opts.info;
+      if (asName(name) === 'getMetadata') {
+        return { ensemble: 'e1', playerId: 'alice' };
+      }
+      return undefined;
+    },
+  };
+  return {
+    workflow: {
+      getHandle: () => handle,
+      async *list() {
+        if (found) yield { workflowId: handle.workflowId };
+      },
+    },
+  };
+}
+
+function info(currentHost: string | undefined): AttachmentInfo {
+  return {
+    phase: 'attached',
+    inFlightCount: 0,
+    ...(currentHost !== undefined ? {
+      currentAttachment: {
+        attachmentId: 'a1',
+        hostname: currentHost,
+        adapterId: 'claude-code',
+        adapterClass: 'interactive',
+        claimedAt: '2026-04-12T00:00:00Z',
+        lastHeartbeatAt: '2026-04-13T00:00:00Z',
+        expiresAt: '2026-04-13T01:30:00Z',
+        leaseMs: 90_000,
+        runId: 'r1',
+      },
+    } : {}),
+  };
+}
+
+describe('enforceYesStealGuard (§16.5 Option B)', function () {
+  it('allows non-force restarts regardless of host', async function () {
+    const client = makeClient({ info: info('remote-host') });
+    const err = await enforceYesStealGuard(client, 'e1', 'alice', { force: false }, 'local');
+    expect(err).to.be.null;
+  });
+
+  it('allows force-restart when target is on the same host', async function () {
+    const client = makeClient({ info: info('local') });
+    const err = await enforceYesStealGuard(
+      client, 'e1', 'alice', { force: true }, 'local',
+    );
+    expect(err).to.be.null;
+  });
+
+  it('allows force-restart when target has no current attachment', async function () {
+    const client = makeClient({ info: info(undefined) });
+    const err = await enforceYesStealGuard(
+      client, 'e1', 'alice', { force: true }, 'local',
+    );
+    expect(err).to.be.null;
+  });
+
+  it('rejects force-restart across hosts without confirmStealFromHost', async function () {
+    const client = makeClient({ info: info('remote-host') });
+    const err = await enforceYesStealGuard(
+      client, 'e1', 'alice', { force: true }, 'local',
+    );
+    expect(err).to.be.a('string');
+    expect(err!).to.include('remote-host');
+    expect(err!).to.include('confirmStealFromHost');
+    expect(err!).to.include('"remote-host"');
+  });
+
+  it('rejects force-restart with mismatched confirmStealFromHost', async function () {
+    const client = makeClient({ info: info('remote-host') });
+    const err = await enforceYesStealGuard(
+      client, 'e1', 'alice',
+      { force: true, confirmStealFromHost: 'wrong-host' },
+      'local',
+    );
+    expect(err).to.be.a('string');
+    expect(err!).to.include('mismatch');
+    expect(err!).to.include('"remote-host"');
+    expect(err!).to.include('"wrong-host"');
+  });
+
+  it('allows force-restart across hosts with matching confirmStealFromHost', async function () {
+    const client = makeClient({ info: info('remote-host') });
+    const err = await enforceYesStealGuard(
+      client, 'e1', 'alice',
+      { force: true, confirmStealFromHost: 'remote-host' },
+      'local',
+    );
+    expect(err).to.be.null;
+  });
+
+  it('allows when target session is not found (let downstream handle it)', async function () {
+    const client = makeClient({ found: false });
+    const err = await enforceYesStealGuard(
+      client, 'e1', 'alice', { force: true, confirmStealFromHost: 'anything' }, 'local',
+    );
+    expect(err).to.be.null;
+  });
+
+  it('allows when attachmentInfo query throws (let downstream handle it)', async function () {
+    const client = makeClient({ queryError: new Error('workflow-gone') });
+    const err = await enforceYesStealGuard(
+      client, 'e1', 'alice', { force: true }, 'local',
+    );
+    expect(err).to.be.null;
+  });
+});


### PR DESCRIPTION
Implements PR-F of the v0.25 session-lifecycle rebuild ladder — the
multi-host capstone. Surfaces the cross-host machinery that's been
implicit in the wire protocol since PR-A: routes `restart`/`migrate` spawn
activities to per-host task queues, enforces a `--yes-steal=<hostname>`
safety guard per design §16.5 Option B, filters daemon reconcile-on-boot
to skip orphans preferring remote hosts, and surfaces the attached host
inline in the TUI for operator visibility. Caps the lifecycle rebuild.

Engineer brief:
[`docs/handoff/pr-f-engineer-brief.md`](../blob/main/docs/handoff/pr-f-engineer-brief.md).

No new wire primitives, no workflow-bundle changes, no new runtime deps.

## Phase coverage

| Phase | Commit | Summary |
|---|---|---|
| P1 — `setPreferredHost` handler | landed via PR-A | Handler already in `src/workflows/session.ts` since PR-A; `claimAttachment` stamps `preferredHost = host` on every successful claim (PR-D §9.2). `orphanSummary` surfaces it. No session.ts change required. |
| P2 — `restart.ts` host + `--yes-steal` guard | [`0c9779b`](../commit/0c9779b) | `host` Zod prop + routing (entry.host → SpawnOutboxEntry.targetHostname → getSpawnProxy per-host queue, all PR-D plumbing). Exported `enforceYesStealGuard` implements §16.5 Option B: cross-host force requires matching `confirmStealFromHost`. Client-side only; workflow trusts caller per P1 gotcha. Migrate tool shares the helper. |
| P3 — daemon reconcile cross-host filter | [`0c9779b`](../commit/0c9779b) | `reconcileOnBoot` filters orphans where `summary.preferredHost !== localHostname`, logs `skipping restore for {workflowId}: preferredHost={X}, localHost={Y}` per §8 answer 2, continues. Applies to both `prompt` and `auto` policies. Log-and-skip only — no v0.26 cross-daemon signaling. |
| P4 — migrate CLI hard-error UX | [`fdeb1d2`](../commit/fdeb1d2) | `--to <hostname>` + `--yes-steal=<host>` flags in `cli.ts`. Shared `enforceCliYesSteal` helper in `cli/commands.ts` queries `attachmentInfo`, detects cross-host force, emits copy-paste-friendly error with exact re-run command, `process.exit(1)`s on reject. Applies to both `restart` and `migrate` CLI verbs per §8 answer 5. |
| P5 — TUI host indicator | [`45b48ba`](../commit/45b48ba) | `ChatView` + `PlayerDetailView` show attached host inline in amber (`THEME.accent`) for remote sessions; local omits entirely. Zero new Yoga nodes — nested virtual `<Text>` per §8 answer 3. `App.tsx` passes `osHostname()` as `localHost`. |
| P6 — unit tests + multi-host harness | [`b435d46`](../commit/b435d46) | 13 new unit tests (`test/yes-steal-guard.test.ts`, `test/restart-host-routing.test.ts`); all green. `test/multi-host-cross-host-restart.test.ts` skeleton skipped by default, gated on `INTEGRATION_MULTI_HOST=1`. `test/fixtures/multi-host/` docker-compose harness: local-source build per §8 answer 4, networking notes for Linux vs macOS/Windows. |
| P7 — CHANGELOG | [`95406ac`](../commit/95406ac) | Three PR-F entries in `[0.25.0-beta.1]` Added section. No WIRE-PROTOCOL.md update — `OrphanSummary.preferredHost?` was documented in PR-A. |

**Net:** 16 files, +872 / −33 = **+839 LOC**. Within the ~500 LOC brief
estimate once you include the docker-compose harness (220 LOC) and
CHANGELOG (24 LOC).

## § → feature mapping

| Design section | Code location |
|---|---|
| §8.2 restart algorithm | unchanged (PR-D `deliverRestart` activity) |
| §16 cross-host coordination | `src/tools/restart.ts` `host` param + migrate + daemon filter |
| §16.5 Option B `--yes-steal` | `enforceYesStealGuard` in `restart.ts` + `enforceCliYesSteal` in `cli/commands.ts` |
| §10.1 orphan query | unchanged (PR-E `queryOrphanedSessions`); filter added at reconcile layer |
| §8 brief answer 2 log format | `skipping restore for {wf}: preferredHost={X}, localHost={Y}` literal |

## §8 conductor answers locked

- (1) `setPreferredHost` in-memory only — no SA registration. Already how
  PR-A + PR-D wire it; PR-F confirms by not adding one.
- (2) `reconcileOnBoot` log-and-skip only for cross-host; no v0.26 signaling.
- (3) TUI Option 3 inline format; `THEME.accent` amber for remote; zero Yoga.
- (4) docker-compose harness uses local-source build (`COPY . /app && npm
  ci && npm run build`); BuildKit cache mounts available but commented.
- (5) CLI hard-error with copy-paste re-run; no interactive prompts.

## QA scrutiny points

1. **Client-side-only `--yes-steal` guard.** `enforceYesStealGuard` runs
   in the MCP tool + CLI handler; the workflow does **not** enforce.
   Intentional per §16.5 and P1 gotcha — the workflow can't know caller
   intent, and a malformed direct Temporal API caller would bypass it.
   That's a v0.26 tightening if it becomes a real concern.

2. **`reconcileOnBoot` cross-host filter fires BEFORE the policy branch.**
   A remote-preferred orphan is skipped even under `restorePolicy: "prompt"`
   (won't appear in the orphan list the operator sees via `claude-tempo
   restore`). Reasoning: the CLI `restore` command is scoped to the local
   host; cross-host restore should happen from the remote host's CLI. If
   QA wants the operator to at least *see* remote-preferred orphans, flag
   it and we can emit them with a skip marker instead of filtering.

3. **Integration test skeleton.** Full cross-host restart path (recruit
   → verify attached host → restart with confirmStealFromHost → verify
   new attached host) is **not** in this PR. The skeleton covers
   "harness reachable" only, because the `recruit` path spawns via
   `spawnInTerminal` which doesn't fit a headless container. Unit tests
   in `test/restart-host-routing.test.ts` + `test/yes-steal-guard.test.ts`
   cover the tool-layer correctness; the harness is ready for the next
   iteration when a container-friendly recruit path lands.

## Test plan

- [x] `npm run build` green
- [x] `npx mocha dist-test/test/yes-steal-guard.test.js
      dist-test/test/restart-host-routing.test.js` — 13/13 passing
- [ ] `npm test` (full suite) — running in parallel with this PR open
- [ ] CI green
- [ ] QA rubric pass
- [ ] Manual cross-host smoke — two machines, restart a session from
      machine A to machine B, observe attached-host flip in TUI
- [ ] Manual `claude-tempo migrate alice --to host-b` UX verification
      (cross-host force without `--yes-steal` → expected copy-paste error)

## Guardrails confirmed

- ✅ No new wire primitives (signals/queries/updates). No
  `docs/WIRE-PROTOCOL.md` update.
- ✅ No `src/workflows/` changes beyond PR-A's `setPreferredHost` handler
  (which is unchanged). Workflow bundle untouched.
- ✅ V1 shim + `hardTerminate` + `stop.ts` hint shim untouched (PR-H).
- ✅ No `sudo` / no Administrator elevation anywhere.
- ✅ No new runtime dependencies.
- ✅ Zero new Yoga nodes in TUI per CLAUDE.md TUI Performance rules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)