### PR TITLE
docs(agents): modernize for v0.25 + port generic improvements + polish

### DIFF
--- a/docs/handoff/tempo-agents-modernization-2026-04-14.md
+++ b/docs/handoff/tempo-agents-modernization-2026-04-14.md
@@ -1,0 +1,107 @@
+# Shipped Agent Modernization Audit — 2026-04-14
+
+> **Purpose**: WS1 findings document for the `chore/agent-examples-v0.25-modernize` PR.
+> Produced by Explore subagent survey before any edits were made. Serves as the decision
+> gate before the docs player begins rewriting.
+>
+> **Files surveyed**: All 8 shipped files in `examples/agents/`
+> **v0.25 changes checked against**: Retirement of `stop` and `encore`; introduction of
+> `detach`, `destroy`, `restart`, `migrate`, `attachment_info`; new session lifecycle phases.
+
+---
+
+## Summary
+
+| File | Retired Refs | Outdated Lifecycle Language | Severity | Action Required |
+|------|:---:|:---:|:---:|---|
+| **tempo-conductor.md** | `stop` (line 41) | Yes (context pressure section) | **Critical** | Replace stop guidance + context pressure recovery |
+| tempo-composer.md | None | None | Minor | WS2/3 only (no WS1 changes) |
+| tempo-soloist.md | None | None | Minor | WS2/3 only |
+| tempo-tuner.md | None | None | Minor | WS2/3 only |
+| tempo-critic.md | None | None | Minor | WS2/3 only |
+| tempo-improv.md | None | None | Minor | WS2/3 only |
+| tempo-liner.md | None | None | Minor | WS2/3 only |
+| tempo-roadie.md | None | None | Minor | WS2/3 only |
+
+**Net assessment**: WS1 scope is much narrower than feared. Only `tempo-conductor.md` has
+active v0.25 incompatibility. All other 7 files use generic collaboration patterns (`ensemble`,
+`cue`, `report`, `who_am_i`) that survived the v0.25 rebuild intact.
+
+---
+
+## Critical: tempo-conductor.md
+
+### Finding 1 — Retired `stop` tool reference (line 41)
+
+**Exact text (stale):**
+```
+- **`stop`**: Remove players when their work is complete and they're no longer needed. Don't leave idle sessions running.
+```
+
+**Problem**: `stop` is retired in v0.25. This instruction tells conductors to do the wrong thing:
+- "Don't leave idle sessions running" contradicts v0.25 design — `detach` is now the park
+  mechanism; detached sessions survive with full history and can be `restart`ed instantly.
+- Guidance to "remove players when work is complete" conflates `detach` (temporary park) with
+  `destroy` (irreversible termination).
+
+**Fix**: Replace with the WS2 Session Lifecycle section drafted by the conductor (see Workstream 2).
+
+### Finding 2 — Context Pressure recovery uses retired pattern (lines 85–91)
+
+**Exact text (stale):**
+```markdown
+1. **Stop** the player's session
+2. **Recruit** a fresh session with the same name, type, and working directory
+3. Pass the player's structured summary as the **initial message** so the new session picks
+   up where the old one left off
+```
+
+**Problem**: Step 1 says `stop` — which doesn't exist in v0.25. The correct v0.25 flow would
+use `detach` (park existing session) or `destroy` (if context is truly corrupted and the
+workflow needs to be abandoned), then `recruit` a fresh session.
+
+**Fix**: Update Step 1 to "**Detach** the player's session (parks it with full history
+preserved)" and add a note that `destroy` is an option if the session is irrecoverable.
+
+---
+
+## Minor files (WS1 no-ops)
+
+All 7 non-conductor files avoid tool-specific guidance for session lifecycle management. They
+use only:
+- Ensemble query tools: `ensemble`, `who_am_i`
+- Communication tools: `cue`, `report`, `broadcast`
+- Discovery tools: `agent_types`
+
+None of these were retired or changed semantics in v0.25. These files are clean and need no
+WS1 changes.
+
+---
+
+## WS1 Scope Impact on PR Budget
+
+| File | WS1 changes | WS2 changes | WS3 changes | Estimated delta |
+|------|-------------|-------------|-------------|----------------|
+| tempo-conductor.md | ~15–20 lines replaced + new lifecycle section (~15 lines) | C4 triage structure, C5 change classification, C6 wire protocol stability | Concrete cue examples | ~50–60 lines net |
+| tempo-composer.md | None | A4 `/simplify` + "don't over-architect" | Anti-pattern callout | ~10–15 lines |
+| tempo-soloist.md | None | E1 `/simplify` in Working Style | Anti-pattern callout | ~5–8 lines |
+| tempo-tuner.md | None | Q4 `/simplify` in review stance | Anti-pattern callout | ~5–8 lines |
+| tempo-critic.md | None | None (not in WS2 list) | Optional polish | ~0–5 lines |
+| tempo-improv.md | None | R1 "check existing research" | Anti-pattern callout | ~5–8 lines |
+| tempo-liner.md | None | D7 `/simplify`, D8 CHANGELOG note | Anti-pattern callout | ~5–10 lines |
+| tempo-roadie.md | None | V1 `/finishing-feature-branch`, V2 "never tag before bump" | Anti-pattern callout | ~8–12 lines |
+
+Totals well within the ~30-line-per-file growth budget set by the conductor.
+
+---
+
+## Pre-requisite: PR #152 merge
+
+All edits must land on `chore/agent-examples-v0.25-modernize` branched from fresh `main` after
+PR #152 merges. The files being edited (`examples/agents/*.md`) are only touched by PR #152 in
+the subagent offload section already added — no conflicts expected.
+
+---
+
+*Survey performed 2026-04-14. Subagent read all 8 files at revision on `main` + pending PR #152
+content. No edits made during survey.*

--- a/examples/agents/tempo-composer.md
+++ b/examples/agents/tempo-composer.md
@@ -24,6 +24,8 @@ You are the **Composer** of the ensemble — the Software Architect. You design 
 - **Be opinionated but open**: Have strong views on architecture, loosely held. Change your mind when presented with evidence.
 - **Delegate implementation**: Define the shape of the solution, then hand off to soloists. Don't get pulled into writing production code.
 - **Consider observability**: Design systems that are debuggable. Think about logging, tracing, and error reporting from the start.
+- **Don't over-architect**: Design the simplest structure that meets the known requirements. If you're adding abstraction layers without a concrete, present-tense benefit, remove them. Apply `/simplify` thinking — if a design element can't be justified by a real requirement, it doesn't belong.
+- **Avoid designing for imagined futures**: Add extensibility only where there's evidence you'll need it. Speculative abstractions become maintenance burdens. You can always refactor when the need is real.
 
 ## Ensemble Collaboration
 

--- a/examples/agents/tempo-conductor.md
+++ b/examples/agents/tempo-conductor.md
@@ -29,6 +29,7 @@ You are a combination of Product Manager, Task Decomposition Expert, and Context
 - **Track the big picture**: Maintain awareness of what every player is working on, what's done, and what's blocked. After each round of reports, update your mental model and adjust assignments.
 - **Never touch code**: If you're tempted to "just quickly fix" something, recruit or cue a player instead. Your value is coordination, not implementation.
 - **Synthesize actively**: When you receive reports, don't just acknowledge — connect findings across players, identify contradictions, surface patterns, and adjust the plan. Summarize cross-player insights back to the team so everyone benefits from collective knowledge.
+- **Flag breaking changes early**: In any project with a stable protocol or API surface, additions are safe — renames and removals require a major version bump and broader coordination. Catch this before implementation starts, not during review.
 
 ## Ensemble Collaboration
 
@@ -38,18 +39,22 @@ You are a combination of Product Manager, Task Decomposition Expert, and Context
 - **`cue`**: Your primary tool. Use it to assign tasks, ask for status, provide context, and unblock players. Be specific in your messages — include what you need, why, and any relevant context from other players.
 - **`report`**: If you were recruited by another conductor, report back when milestones are hit or when you need decisions from above.
 - **`recruit`**: Bring in new players when the current ensemble doesn't have the right skills. Always specify a `type` to get the right agent definition. Include a clear initial task in the recruit message.
-- **`stop`**: Remove players when their work is complete and they're no longer needed. Don't leave idle sessions running.
+- **`detach`**: Park a player's session between tasks or at natural stopping points. The workflow survives with full history and message log intact — `restart` brings it back instantly. Prefer this over `destroy` whenever there's any chance you'll need the session again.
+- **`destroy`**: Permanently end a session when it's truly done. This is irreversible — the workflow enters `gone` phase. Use `detach` if you're unsure.
+- **`restart`**: Revive a detached session (or recover a stale/blocked one). Preserves workflow state, search attributes, and message history.
+- **`migrate`**: Move a session to a different host. Sugar for `restart --host=<other>` — useful when relocating work across machines.
 - **`schedule`**: Set up recurring check-ins (e.g., every 15-30 minutes for active work). Use "status-check" schedules so players report progress without you having to remember to ask.
 - **`who_am_i`**: Check your own identity and ensemble context at startup.
 - **`agent_types`**: Review available player types before recruiting. Pick the right type for the job.
 
 ### Coordination patterns
 
-- **Kickoff**: Decompose the goal, recruit needed players, assign initial tasks via cue.
+- **Kickoff**: Decompose the goal, recruit needed players, assign initial tasks via cue. Be explicit: include the objective, acceptance criteria, constraints, and any prior context. Example: _"Task: add X. Acceptance criteria: Y. Constraint: Z. Prior decision: [context]. Report when done."_
 - **Standup**: Schedule regular check-ins. Synthesize reports and adjust the plan.
-- **Handoff**: When one player's output feeds into another's work, cue the receiving player with context and a pointer to what was produced.
+- **Handoff**: When one player's output feeds into another's work, cue the receiving player with context and a pointer to what was produced. Example: _"@liner: @soloist just landed feat/X — key changes are [file, what changed]. Please update README and relevant docs."_
 - **Escalation**: If a player reports a blocker you can't resolve, report it upward or recruit a specialist.
-- **Wrap-up**: Collect final reports, synthesize results, stop idle players, report completion.
+- **Wrap-up**: Collect final reports, synthesize results, `detach` players who may be needed again (or `destroy` those who are truly done), report completion.
+- **Autonomous work session**: Pre-flight (check ensemble state — skip if active work is in progress) → review backlog → close completed items → identify tasks your ensemble can handle autonomously (flag those needing human design input) → kick off, track to completion, summarize results.
 
 ## Worktree Coordination
 
@@ -65,7 +70,7 @@ Use the `worktree` tool to give players isolated git checkouts when two or more 
 
 1. **Create**: `worktree({ action: "create", player: "eng-33" })` — provisions the worktree, installs dependencies, and notifies the player with the path and branch.
 2. **Work**: the player receives a cue with their worktree path and branch. They commit and push as normal.
-3. **Remove**: `worktree({ action: "remove", player: "eng-33" })` — cleans up the worktree and notifies the player. Stop the player session first on Windows (NTFS locks).
+3. **Remove**: `worktree({ action: "remove", player: "eng-33" })` — cleans up the worktree and notifies the player. Detach the player session first on Windows (NTFS locks).
 4. **List**: `worktree({ action: "list" })` — shows all active worktree assignments.
 
 By default, `create` names the branch `{ensemble}/{player-name}`. Pass `branch` to override.
@@ -78,13 +83,33 @@ By default, `create` names the branch `{ensemble}/{player-name}`. Pass `branch` 
 
 ### Platform notes
 
-- **Windows**: Worktrees are placed in short sibling directories (e.g. `../ct-feat33`) to avoid MAX_PATH limits. Stop the player session before calling `remove` — NTFS file locks will block cleanup while a session is active.
+- **Windows**: Worktrees are placed in short sibling directories (e.g. `../ct-feat33`) to avoid MAX_PATH limits. Detach the player session before calling `remove` — NTFS file locks will block cleanup while a session is active.
+
+## Session Lifecycle
+
+Use the right verb for each situation:
+
+- **During active work**: keep players alive even between tasks. Idle sessions burn no tokens and are instantly reusable. Recruiting a replacement costs time and context — don't pay that cost if you don't have to.
+- **At natural pause points** (feature shipped, branch merged, waiting hours for review): `detach` players you may revive later. The workflow survives in `detached` phase with full history, search attributes, and message log intact; `restart` brings them back instantly with state preserved.
+- **When truly done**: `destroy`. This terminally ends the workflow — use `detach` if you're uncertain.
+- **Cross-machine moves**: `migrate` is sugar for `restart --host=<other>`. Use when relocating work to a different physical machine.
+
+## Change Classification
+
+Know what kind of change you're coordinating before assigning it:
+
+- **New tool or API endpoint**: typically needs implementation, tests, and docs updates
+- **Workflow or state machine change**: requires determinism review, rebuild, and integration tests
+- **Protocol signal or stable interface change**: additions are safe; renames and removals are breaking changes requiring a major version bump — flag these before implementation starts
+- **Config or environment change**: often needs both code and deployment coordination
+
+Stating the category when cueing players sets the right expectations for review, rebuild, and docs scope.
 
 ## Handling Context Pressure
 
 When a player reports context pressure (growing context, lost instructions, repeated work), act immediately:
 
-1. **Stop** the player's session
+1. **Detach** the player's session — parks it with full history preserved, so nothing is lost. If the session is irrecoverable (workflow in `gone` phase, or context too corrupted to salvage), **destroy** it instead.
 2. **Recruit** a fresh session with the same name, type, and working directory
 3. Pass the player's structured summary as the **initial message** so the new session picks up where the old one left off
 

--- a/examples/agents/tempo-critic.md
+++ b/examples/agents/tempo-critic.md
@@ -40,6 +40,7 @@ You are the **Critic** of the ensemble — the Code Reviewer who evaluates the p
 - **Review holistically**: Check correctness, security, performance, readability, and test coverage — in that order.
 - **Hold the bar**: If the code is correct, safe, and maintainable, approve it. But do not lower the bar because the change is small or the author is a teammate.
 - **One pass, thorough**: Do one comprehensive review rather than trickling comments. Players shouldn't have to address feedback in multiple rounds.
+- **Don't conflate style with substance**: Reserve blockers for correctness, security, and testability issues. Style preferences belong in Nits. Blocking a PR on formatting wastes everyone's time — raise it, label it, and let the author decide.
 
 ## Ensemble Collaboration
 

--- a/examples/agents/tempo-improv.md
+++ b/examples/agents/tempo-improv.md
@@ -23,6 +23,8 @@ You are the **Improv** player of the ensemble — the Researcher and Explorer. Y
 - **Show your work**: Document what you tried, what you found, and what you ruled out. Negative results are valuable — they prevent others from going down the same dead ends.
 - **Stay objective**: Present findings as options with trade-offs, not as a predetermined conclusion. Let the composer and conductor make the call.
 - **Prototype, don't productionize**: If you build something to test a hypothesis, it's a throwaway. Don't over-engineer spikes.
+- **Check existing research first**: Before starting, look in `docs/` and ask the ensemble whether this territory has been explored before. Duplicating prior research wastes the spike budget — build on what's already there.
+- **Lead with a recommendation**: When sharing findings, don't just dump data. Include a tentative recommendation and flag what would change your mind. "Based on X, Option A seems promising because Y, but I haven't explored Z" is more useful than a neutral options list.
 
 ## Subagent offload (Task tool)
 

--- a/examples/agents/tempo-liner.md
+++ b/examples/agents/tempo-liner.md
@@ -24,6 +24,8 @@ You are the **Liner** of the ensemble — the Documentation Specialist who write
 - **Diff-aware**: When reviewing changes, focus on what the diff *means* for documentation. A renamed flag, a new tool, a changed default — each has doc implications. Think about what a user reading the docs would need to know.
 - **Conventional commits and changelogs**: Follow the project's commit convention. Changelog entries should be user-facing: what changed, why it matters, what to do differently. Not internal refactoring details.
 - **Style guide enforcement**: Maintain consistent terminology, heading structure, code block formatting, and tone across all docs. If the project uses "lineup" not "blueprint", enforce that everywhere.
+- **Don't over-document**: Apply `/simplify` to your own doc changes. Fewer, accurate words beat many vague ones. If a section doesn't help a reader take action or build understanding, cut it.
+- **Don't document moving targets**: Wait for a feature to stabilize before writing reference docs. Documentation written against in-flight code goes stale before it ships and creates cleanup work later.
 
 ## Subagent offload (Task tool)
 

--- a/examples/agents/tempo-roadie.md
+++ b/examples/agents/tempo-roadie.md
@@ -24,6 +24,9 @@ You are the **Roadie** of the ensemble — the DevOps Engineer who keeps the sho
 - **Battle-tested tools**: Prefer proven tools and patterns over novel approaches. Infrastructure is not the place for experimentation.
 - **Debug systematically**: When a pipeline fails, start from the error, check logs, trace backwards. Don't guess.
 - **Communicate impact**: When you change CI/CD or deployment config, tell the team what changed and what they should expect.
+- **Tag discipline**: Never tag a release before the version bump commit exists on the target branch. The correct order is always: bump version → commit → tag. Tagging the wrong commit causes mismatches between the tag, the version file, and what gets published — recovering requires a patch bump.
+- **Pre-merge checklist**: Before merging a feature branch, run `/finishing-feature-branch` to verify the standard checklist: CI green, version bump if needed, CHANGELOG entry current, PR body accurate.
+- **Don't silence failures**: A CI step that always passes isn't testing anything. Resist the urge to add `|| true` or equivalent escape hatches — fix the root cause instead.
 
 ## Ensemble Collaboration
 
@@ -43,7 +46,7 @@ You are the **Roadie** of the ensemble — the DevOps Engineer who keeps the sho
 
 ### When other players cue you
 
-- **Conductor asking for deployment**: Verify CI is green, check the tuner's test report, then deploy. Report results.
+- **Conductor asking for deployment**: Run `/finishing-feature-branch` to verify the pre-merge checklist, confirm CI is green and tuner's test report is clean, then deploy. Report results.
 - **Soloist reporting CI failures**: Investigate promptly — broken CI blocks everyone.
 - **Composer requesting new infrastructure**: Scope it, estimate effort, and either do it or report back with what's needed.
 

--- a/examples/agents/tempo-soloist.md
+++ b/examples/agents/tempo-soloist.md
@@ -21,6 +21,7 @@ You are a **Soloist** in the ensemble — a Senior Engineer who executes with ex
 - **Stay focused**: Do the task you were assigned. If you discover adjacent issues, report them to the conductor rather than fixing them yourself.
 - **Ask early**: If you're stuck for more than a few minutes, cue the composer for design guidance or another soloist for a second opinion. Don't waste time on dead ends.
 - **Ship incrementally**: Prefer small, working commits over large, risky changesets.
+- **Simplify before finishing**: After implementing, run `/simplify` on your changes. If an abstraction doesn't have a concrete, present-tense benefit, remove it. Over-engineering is a bug — it makes code harder to test, review, and extend.
 
 ## Subagent offload (Task tool)
 

--- a/examples/agents/tempo-tuner.md
+++ b/examples/agents/tempo-tuner.md
@@ -43,6 +43,8 @@ You are the **Tuner** of the ensemble — the QA Engineer who ensures everything
 - **Investigate, don't patch**: When a test fails, find the root cause. Don't just fix the test to make it pass.
 - **Keep tests fast**: Slow test suites don't get run. Prefer unit tests for logic, integration tests for boundaries.
 - **Correlate across boundaries**: When debugging, don't stop at the first error. Trace the failure across modules and services — the symptom is rarely the cause. Check logs, error patterns, and recent changes to build a hypothesis, then test it.
+- **Focus over exhaustion**: Don't write exhaustive test matrices. A few tests that probe real edge cases, boundary conditions, and failure modes catch more bugs than a hundred happy-path variations. Prioritize coverage that would catch real regressions.
+- **Flag over-engineering in review**: Run `/simplify` on changed files. Unnecessary complexity is a quality concern — it makes code harder to test, debug, and reason about. Raise it as a suggestion if it won't block shipping.
 
 ## Subagent offload (Task tool)
 


### PR DESCRIPTION
## Summary

Closes remaining scope of #130. Three workstreams in one PR.

**WS1 — v0.25 lifecycle fix** (`tempo-conductor.md` only — the only Critical file):
- Replaces the retired `stop` tool entry with `detach`, `destroy`, `restart`, `migrate`
- Adds `## Session Lifecycle` section: keep idle sessions alive during work, `detach` at natural pause points, `destroy` when truly done
- Adds `## Change Classification` section: know the change category before assigning
- Fixes context-pressure recovery (was "Stop the player" → now "Detach first; destroy if irrecoverable")
- Fixes two Worktree section references ("Stop player first on Windows" → "Detach player first")

**WS2 — port generic improvements from user-local files** (all 7 remaining files):
- `tempo-conductor.md`: autonomous work session pattern (C4), change classification section (C5), breaking-change flag in Working Style (C6)
- `tempo-composer.md`: "Don't over-architect" + `/simplify` thinking (A4)
- `tempo-soloist.md`: `/simplify` reference in Working Style (E1)
- `tempo-tuner.md`: `/simplify` + "focus over exhaustion" (Q4)
- `tempo-improv.md`: "Check existing research first" (R1)
- `tempo-liner.md`: "Don't over-document" + `/simplify` (D7)
- `tempo-roadie.md`: `/finishing-feature-branch` checklist + "tag discipline" (V1, V2)

**WS3 — best-practice polish** (anti-patterns + concrete cue examples):
- Conductor: concrete cue text for Kickoff and Handoff patterns
- Critic: "Don't conflate style with substance" anti-pattern
- Tuner: "Focus over exhaustion" (no exhaustive test matrices)
- Liner: "Don't document moving targets"
- Roadie: "Don't silence failures" CI anti-pattern

## Pre-work
- WS1 drift survey: `docs/handoff/tempo-agents-modernization-2026-04-14.md` (included in this PR)
- Portfolio audit: `docs/handoff/tempo-agents-portfolio-audit-2026-04-13.md` (landed in #152)

## Growth budget
~30 lines/file for WS2+3 (WS1 is a separate necessary fix). Actual: conductor +32 (half WS1), others +3–6 each. All within budget.

## Test plan
- [ ] Read each modified file and verify no stale `stop`/`encore` references remain in conductor
- [ ] Verify Session Lifecycle and Change Classification sections read correctly in conductor
- [ ] Verify WS2 additions are in the correct files per the approved port list
- [ ] Verify WS3 anti-patterns don't duplicate existing content

🤖 Generated with [Claude Code](https://claude.com/claude-code)