### PR TITLE
docs(readme): add missing companion docs to index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,12 +8,16 @@ Reference documentation for claude-tempo. See the main [README](../README.md) fo
 |------|-------------|
 | [tools.md](tools.md) | MCP tools reference — all tools available inside Claude Code sessions |
 | [cli.md](cli.md) | CLI command reference — commands, options, and examples |
+| [concepts.md](concepts.md) | Key concepts glossary — full definitions for all claude-tempo primitives |
+| [development.md](development.md) | Development setup — Temporal server, build, test, daemon worker notes |
 | [scheduling.md](scheduling.md) | Scheduling — one-shot, recurring, cron, fan-out |
 | [orchestration.md](orchestration.md) | Orchestration — Quality Gates, Pipeline Stages, Git Worktrees |
 | [ensembles.md](ensembles.md) | Ensembles — Lineups, Player Types, Agent Type Discovery |
 | [configuration.md](configuration.md) | Configuration — env vars, config file, Temporal Cloud |
 | [copilot.md](copilot.md) | Copilot CLI integration (experimental) |
 | [tui.md](tui.md) | Interactive TUI — slash commands, messaging, scheduling, ensemble management |
+| [tui-performance.md](tui-performance.md) | TUI performance — Ink/React lessons for `src/tui/` contributors |
 | [daemon.md](daemon.md) | Worker Daemon — background process that runs Temporal workers |
+| [release-process.md](release-process.md) | Release process — version bump, tag, and publish sequence |
 | [troubleshooting.md](troubleshooting.md) | Troubleshooting — stale sessions, common issues, upgrade notes |
 | [WIRE-PROTOCOL.md](WIRE-PROTOCOL.md) | Wire protocol — stable Temporal signal/query/update/workflow names |


### PR DESCRIPTION
## Summary

- Adds 4 entries to `docs/README.md` that were created in PR #155 but omitted from the index:
  - `concepts.md` — Key concepts glossary
  - `development.md` — Development setup
  - `tui-performance.md` — TUI performance notes
  - `release-process.md` — Release process

Caught by tempo-qa's post-merge audit of #155.

🤖 Generated with [Claude Code](https://claude.com/claude-code)