### PR TITLE
fix: close macOS terminal tabs when claude session exits

### DIFF
--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -255,11 +255,14 @@ export function spawnInTerminal(
     log(`Terminal detection: TERM_PROGRAM=${JSON.stringify(process.env.TERM_PROGRAM)}, detected=${detected}`);
 
     if (detected === 'ghostty') {
+      // Append `; exit` so the wrapping shell exits when claude does (clean or killed).
+      // Without it, claude exit returns control to the shell prompt and the tab lingers —
+      // parity with the Windows WT `closeOnExit: 'always'` + parent-walk fix from #166.
       const osaScript = `
         tell application "Ghostty"
           set cfg to new surface configuration
           set initial working directory of cfg to ${JSON.stringify(workDir)}
-          set initial input of cfg to ${JSON.stringify(claudeInvocation + '\n')}
+          set initial input of cfg to ${JSON.stringify(claudeInvocation + '; exit\n')}
           set win to new window with configuration cfg
         end tell`;
       log('Using Ghostty initial-input path');
@@ -273,11 +276,13 @@ export function spawnInTerminal(
     }
 
     if (detected === 'iterm2') {
+      // Append `; exit` so the wrapping shell exits when claude does. `;` rather than
+      // `&&` so exit runs regardless of claude's exit code (force-kill returns non-zero).
       const osaScript = `
         tell application "iTerm2"
           set newWindow to (create window with default profile)
           tell current session of newWindow
-            write text "cd ${shellQuote(workDir)} && ${claudeInvocation}"
+            write text "cd ${shellQuote(workDir)} && ${claudeInvocation} ; exit"
           end tell
         end tell`;
       log('Using iTerm2 write-text path');
@@ -313,7 +318,11 @@ export function spawnInTerminal(
       envExports,
       profileSource,
       `cd ${shellQuote(workDir)}`,
-      `${shellQuote(claudeBin)} ${claudeArgs.map(a => shellQuote(a)).join(' ')}`,
+      // `exec` so the shell is replaced by claude — when claude exits (clean or killed),
+      // the script process ends and Terminal.app closes the window per its settings.
+      // Without `exec`, bash waits for claude and then returns to prompt, leaving the
+      // window open. Parity with the WT `closeOnExit: 'always'` fix from #166.
+      `exec ${shellQuote(claudeBin)} ${claudeArgs.map(a => shellQuote(a)).join(' ')}`,
     ];
     writeFileSync(scriptPath, lines.join('\n') + '\n', { mode: 0o755 });
     log('Using Terminal.app .command path:', scriptPath);

--- a/src/spawn.ts
+++ b/src/spawn.ts
@@ -278,11 +278,15 @@ export function spawnInTerminal(
     if (detected === 'iterm2') {
       // Append `; exit` so the wrapping shell exits when claude does. `;` rather than
       // `&&` so exit runs regardless of claude's exit code (force-kill returns non-zero).
+      // JSON.stringify embeds the full shell command as a properly-escaped string literal
+      // so any `"` or `\` in paths/args doesn't break the AppleScript parser. Parity with
+      // the Ghostty path above.
+      const shellCmd = `cd ${shellQuote(workDir)} && ${claudeInvocation} ; exit`;
       const osaScript = `
         tell application "iTerm2"
           set newWindow to (create window with default profile)
           tell current session of newWindow
-            write text "cd ${shellQuote(workDir)} && ${claudeInvocation} ; exit"
+            write text ${JSON.stringify(shellCmd)}
           end tell
         end tell`;
       log('Using iTerm2 write-text path');


### PR DESCRIPTION
## Summary

Parity with the Windows WT `closeOnExit: 'always'` fix from #166. macOS spawn paths (Ghostty, iTerm2, Terminal.app) wrapped claude in an interactive shell that returned to a prompt after claude exited, leaving the tab alive with no useful state.

## Changes

- **Ghostty**: `initial input` ends with `; exit` so the shell exits after claude returns.
- **iTerm2**: `write text "... ; exit"` — `;` (not `&&`) so exit runs even when claude is force-killed and returns non-zero.
- **Terminal.app**: `.command` script uses `exec` to replace the shell with claude directly — when claude exits, the script process ends and Terminal.app closes the window per its settings.

Linux spawn paths already wrap claude in `bash -c` which auto-exits — no change needed.

## ⚠ Untested on macOS

No Apple hardware available for validation. The change is additive and localized to `src/spawn.ts`. Worst case is a regression back to the orphan-tab behavior. **No process-leak risk.**

## Test plan

- [ ] Manual smoke on macOS + Ghostty: `recruit` → `detach` → tab closes
- [ ] Manual smoke on macOS + iTerm2: same
- [ ] Manual smoke on macOS + Terminal.app: same
- [ ] Also test with `restart --force --fresh` and `destroy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)