### PR TITLE
docs(load-lineup): fix hold-flag docstring to match warm-hold implementation

### DIFF
--- a/src/tools/load-lineup.ts
+++ b/src/tools/load-lineup.ts
@@ -33,7 +33,7 @@ export function registerLoadLineupTool(
     {
       name: z.string().max(PLAYER_NAME_MAX).optional().describe('Name of a lineup — resolves saved lineups, then shipped examples (e.g. "tempo-dev-team")'),
       path: z.string().max(PATH_MAX).optional().describe('Explicit file path to a lineup YAML file'),
-      hold: z.boolean().optional().describe('When true, create player workflows but do not spawn processes. Players stay in "held" status until explicitly released.'),
+      hold: z.boolean().optional().describe('When true, spawn players in "warm hold": processes start and attach but their outbox is locked, so they receive a standby message and defer their initial task until `release` is called.'),
     },
     async (args) => {
       const lineupName = (args as any).name as string | undefined;


### PR DESCRIPTION
## Summary

Smoke testing surfaced a contract mismatch: `load_lineup name="foo" hold=true` spawned two claude.exe sessions in new terminal tabs, despite the tool description promising no spawn.

Tool description says:
> When true, create player workflows but do not spawn processes. Players stay in "held" status until explicitly released.

Activity implementation says (comment in `src/activities/outbox.ts`):
> Warm hold: process will spawn and go active, but outbox is locked and the initial message is deferred.

The activity's "warm hold" behavior is correct and useful (sessions ready-to-receive, no spawn delay when release fires). The docstring was inherited from an earlier design that never materialized. This PR updates the description to match reality.

## Changes

- `src/tools/load-lineup.ts`: one-line docstring edit

## Test plan

- [x] Build passes
- [x] No behavior change — description only