### PR TITLE
fix(tests): eliminate pipeline stages Node 20 flake

### DIFF
--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -244,9 +244,13 @@ export async function startSession(
     ...(inputOverrides.metadata ? {} : { metadata }),
   };
 
-  const workflowId = metadata.isConductor
-    ? `claude-session-${metadata.ensemble}-conductor`
-    : `claude-session-${metadata.ensemble}-${metadata.playerId}`;
+  // Always use playerId in the workflow ID. conductorMetadata() defaults
+  // playerId to 'conductor', so callers that don't override get the canonical
+  // 'claude-session-{ensemble}-conductor' ID unchanged. Callers that pass a
+  // non-default playerId (e.g. stages.test.ts uses 'stage-cond-N') get a
+  // unique ID per test, preventing WorkflowExecutionAlreadyStartedError
+  // cascades when a test fails before its cleanup destroyUpdate runs.
+  const workflowId = `claude-session-${metadata.ensemble}-${metadata.playerId}`;
 
   return testEnv.client.workflow.start('claudeSessionWorkflow', {
     workflowId,

--- a/test/stages.test.ts
+++ b/test/stages.test.ts
@@ -10,7 +10,7 @@ import {
   conductorMetadata,
   withWorker,
   updateMetadataSignal,
-
+  skipTime,
   destroyUpdate,
 } from './helpers';
 import {
@@ -78,6 +78,7 @@ describe('pipeline stages', function () {
         text: 'Tests pass',
         type: 'result',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       let stages: StageEntry[] = await handle.query(stagesQuery);
       expect(stages[0].status).to.equal('active');
@@ -89,6 +90,7 @@ describe('pipeline stages', function () {
         text: 'All good',
         type: 'result',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       stages = await handle.query(stagesQuery);
       expect(stages[0].status).to.equal('complete');
@@ -125,6 +127,7 @@ describe('pipeline stages', function () {
         text: 'Build broken',
         type: 'blocker',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       const stages: StageEntry[] = await handle.query(stagesQuery);
       expect(stages[0].status).to.equal('failed');
@@ -163,6 +166,7 @@ describe('pipeline stages', function () {
         text: 'Found issues',
         type: 'blocker',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       let stages: StageEntry[] = await handle.query(stagesQuery);
       expect(stages[0].status).to.equal('active'); // Still active with continue policy
@@ -173,6 +177,7 @@ describe('pipeline stages', function () {
         text: 'Looks good',
         type: 'result',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       stages = await handle.query(stagesQuery);
       expect(stages[0].status).to.equal('failed');
@@ -205,6 +210,7 @@ describe('pipeline stages', function () {
         text: 'What API should I use?',
         type: 'question',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       const stages: StageEntry[] = await handle.query(stagesQuery);
       expect(stages[0].status).to.equal('active');
@@ -216,6 +222,7 @@ describe('pipeline stages', function () {
         text: 'Done',
         type: 'result',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       const stages2: StageEntry[] = await handle.query(stagesQuery);
       expect(stages2[0].status).to.equal('complete');
@@ -238,6 +245,7 @@ describe('pipeline stages', function () {
       });
 
       await handle.signal(cancelStageSignal, 'cancelled-stage');
+      await skipTime(1); // flush pending workflow task before querying
 
       const stages: StageEntry[] = await handle.query(stagesQuery);
       expect(stages[0].status).to.equal('cancelled');
@@ -271,6 +279,7 @@ describe('pipeline stages', function () {
         failurePolicy: 'continue',
         createdBy: 'stage-cond-7',
       });
+      await skipTime(1); // flush pending workflow task before querying
 
       const stages: StageEntry[] = await handle.query(stagesQuery);
       expect(stages).to.have.lengthOf(1);


### PR DESCRIPTION
## Summary

- Fixes #179 — intermittent `pipeline stages` failures on Node 20 (Node 18/22/24 pass consistently)
- No product-code changes; test infrastructure only

## Root causes

**1. Workflow ID collision in `startSession()`** — the conductor branch hard-coded `claude-session-{ensemble}-conductor` regardless of `playerId`. The stages suite uses `conductorMetadata({ playerId: 'stage-cond-N' })` across 7 tests, so all of them collided on a single workflow ID. When test N failed before its `destroyUpdate` cleanup, test N+1 crashed with `WorkflowExecutionAlreadyStartedError`, cascading the whole suite.

**Fix** (`test/helpers.ts`): always use `playerId` in the workflow ID. `conductorMetadata()` defaults `playerId` to `'conductor'`, so existing callers that don't override keep the canonical ID unchanged.

**2. Signal/query race** — after `await handle.signal(...)` the Temporal server has accepted the signal but the workflow task processing it may not have run by the time the next `await handle.query(...)` fires. On Node 20's slightly slower event loop this surfaces more often.

**Fix** (`test/stages.test.ts`): insert `await skipTime(1)` after each signal that precedes a state assertion (8 callsites), advancing the simulated clock 1ms and flushing pending workflow tasks before the query.

## Test plan

- [x] 5 CI runs completed without flake on this branch prior to push
- [ ] CI green on this PR across Node 18 / 20 / 22 / 24

🤖 Generated with [Claude Code](https://claude.com/claude-code)