### PR TITLE
fix(hard-terminate): scope process kill by ensemble (#180)

### DIFF
--- a/src/activities/hard-terminate.ts
+++ b/src/activities/hard-terminate.ts
@@ -28,11 +28,18 @@ import { execFileSync, spawnSync } from 'child_process';
 import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import type { AgentType } from '../types';
+import { ENSEMBLE_SENTINEL_FLAG, escapeNameForRegex } from '../constants';
 
 const log = (...args: unknown[]) => console.error('[claude-tempo:hard-terminate]', ...args);
 
 export interface HardTerminateInput {
-  /** Ensemble name — log context only. */
+  /**
+   * Ensemble name. Load-bearing: matched against the `ENSEMBLE_SENTINEL_FLAG
+   * <ensemble>` pair in each candidate's CommandLine so two ensembles sharing a
+   * lineup template (identical player names) don't kill each other's processes
+   * on `destroy --all` (issue #180). The sentinel is injected by
+   * `src/activities/outbox.ts` on every Claude Code spawn. See src/constants.ts.
+   */
   ensemble: string;
   /** Player name the session was spawned as. Matched against `claude.exe -n <name>` in the search path. */
   playerName: string;
@@ -102,9 +109,9 @@ export async function hardTerminateAttachment(input: HardTerminateInput): Promis
   const binaryName = agent === 'copilot'
     ? (process.platform === 'win32' ? 'node.exe' : 'node')
     : (process.platform === 'win32' ? 'claude.exe' : 'claude');
-  const pids = findProcessesByCommandLine(binaryName, playerName);
+  const pids = findProcessesByCommandLine(binaryName, playerName, ensemble);
   if (pids.length === 0) {
-    notes.push(`No ${binaryName} processes found matching playerName="${playerName}" — nothing to kill.`);
+    notes.push(`No ${binaryName} processes found matching playerName="${playerName}" ensemble="${ensemble}" — nothing to kill.`);
     log(`hardTerminate done (none) — nothing to kill`);
     return { killedPids, strategy: 'none', notes };
   }
@@ -115,7 +122,7 @@ export async function hardTerminateAttachment(input: HardTerminateInput): Promis
       notes.push(`kill(${pid}) failed: ${errMsg(err)}`);
     }
   }
-  notes.push(`Killed ${killedPids.length} ${binaryName} process(es) matching "${playerName}": [${killedPids.join(', ')}]`);
+  notes.push(`Killed ${killedPids.length} ${binaryName} process(es) matching "${playerName}" in ensemble "${ensemble}": [${killedPids.join(', ')}]`);
   log(`hardTerminate done (search) — killedPids=[${killedPids.join(',')}]`);
   return { killedPids, strategy: 'search', notes };
 }
@@ -216,16 +223,23 @@ async function killProcessTree(pid: number): Promise<boolean> {
 
 /**
  * Search the live process table for entries whose image matches `binaryName` and whose command
- * line contains `-n <playerName>`. Returns the set of matching PIDs, or `[]` when nothing
- * matches (including when the native lookup tool is missing).
+ * line contains BOTH `-n <playerName>` AND `--remote-control-session-name-prefix <ensemble>`.
+ * Returns the set of matching PIDs, or `[]` when nothing matches (including when the native
+ * lookup tool is missing).
  *
  * The command-line match mirrors the operator workaround documented in #159 — every spawn
- * we care about passes `-n <playerName>` (see `src/activities/outbox.ts` spawnArgs).
+ * we care about passes `-n <playerName>` (see `src/activities/outbox.ts` spawnArgs). The
+ * ensemble-prefix sentinel was added in #180 so two ensembles sharing a lineup template
+ * (identical player names) don't clobber each other on `destroy --all`.
  */
-function findProcessesByCommandLine(binaryName: string, playerName: string): number[] {
+function findProcessesByCommandLine(binaryName: string, playerName: string, ensemble: string): number[] {
   // Defensive: bail out on absurd inputs so we never inject into the PowerShell/pgrep expression.
   if (!playerName || !/^[A-Za-z0-9._\-]+$/.test(playerName)) {
     log(`findProcessesByCommandLine: refusing lookup for playerName="${playerName}" (failed regex guard)`);
+    return [];
+  }
+  if (!ensemble || !/^[A-Za-z0-9._\-]+$/.test(ensemble)) {
+    log(`findProcessesByCommandLine: refusing lookup for ensemble="${ensemble}" (failed regex guard)`);
     return [];
   }
 
@@ -262,7 +276,8 @@ function findProcessesByCommandLine(binaryName: string, playerName: string): num
     // grandparents are WT.exe / conhost.exe and must not be touched. The sentinel check
     // reuses the same regex pattern used for the primary match — only cmd.exe shells
     // that we spawned via the #159 pipeline can match.
-    const escapedName = playerName.replace(/[.-]/g, (c) => `\\${c}`);
+    const escapedName = escapeNameForRegex(playerName);
+    const escapedEnsemble = escapeNameForRegex(ensemble);
     try {
       // Emit PARENT PIDs before child PIDs. taskkill /T /F cascades to descendants,
       // so killing cmd.exe first also kills its claude.exe child in the same call —
@@ -275,16 +290,24 @@ function findProcessesByCommandLine(binaryName: string, playerName: string): num
       // class `[\s"'']` therefore denotes the set { whitespace, `"`, `'` } in the
       // compiled regex. Double-quote needs no escaping inside a PS single-quoted
       // literal.
+      //
+      // Two patterns are required to match (both AND-ed in the Where clause) so we
+      // never kill a process from a sibling ensemble that happens to share the same
+      // player name (#180). The ensemble sentinel is
+      // `--remote-control-session-name-prefix <ensemble>`, injected by outbox.ts.
+      // The parent-walk check applies the same pair so parent cmd.exe wrappers that
+      // don't carry the ensemble sentinel are left alone.
       const psScript = [
         `$procs = Get-CimInstance Win32_Process -Filter "Name='${binaryName}'";`,
         `$pattern = '-n[\\s"'']+${escapedName}([\\s"'']|$)';`,
-        `$matched = $procs | Where-Object { $_.CommandLine -match $pattern };`,
+        `$ensemblePattern = '${ENSEMBLE_SENTINEL_FLAG}[\\s"'']+${escapedEnsemble}([\\s"'']|$)';`,
+        `$matched = $procs | Where-Object { $_.CommandLine -match $pattern -and $_.CommandLine -match $ensemblePattern };`,
         `$result = @();`,
         `foreach ($p in @($matched)) {`,
         `  $ppid = $p.ParentProcessId;`,
         `  if ($ppid) {`,
         `    $parent = Get-CimInstance Win32_Process -Filter "ProcessId=$ppid" -ErrorAction SilentlyContinue;`,
-        `    if ($parent -and $parent.Name -ieq 'cmd.exe' -and $parent.CommandLine -match $pattern) {`,
+        `    if ($parent -and $parent.Name -ieq 'cmd.exe' -and $parent.CommandLine -match $pattern -and $parent.CommandLine -match $ensemblePattern) {`,
         `      $result += [int]$parent.ProcessId;`,
         `    }`,
         `  }`,
@@ -313,21 +336,27 @@ function findProcessesByCommandLine(binaryName: string, playerName: string): num
     // this widening, the quoted production form (`"-n" "<name>"`) slips past the
     // stricter `%-n <name>%` LIKE pattern entirely, which is the root cause this
     // fix addresses.
-    const tolerantPattern = new RegExp(`-n[\\s"']+${escapedName}(?:[\\s"']|$)`);
+    //
+    // Both patterns (player name AND ensemble sentinel) must match for the block to
+    // survive the filter — mirrors the PowerShell path's AND guard for #180.
+    const tolerantPatterns = [
+      new RegExp(`-n[\\s"']+${escapedName}(?:[\\s"']|$)`),
+      new RegExp(`${ENSEMBLE_SENTINEL_FLAG}[\\s"']+${escapedEnsemble}(?:[\\s"']|$)`),
+    ];
     try {
       const out = execFileSync(
         'wmic',
         [
           'process',
           'where',
-          `Name='${binaryName}' and CommandLine like '%-n%${playerName}%'`,
+          `Name='${binaryName}' and CommandLine like '%-n%${playerName}%' and CommandLine like '%${ENSEMBLE_SENTINEL_FLAG}%${ensemble}%'`,
           'get',
           'CommandLine,ProcessId,ParentProcessId',
           '/format:value',
         ],
         { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], windowsHide: true },
       );
-      const { pids: childPids, ppids } = parseWmicPidPpidFiltered(out, tolerantPattern);
+      const { pids: childPids, ppids } = parseWmicPidPpidFiltered(out, tolerantPatterns);
       const parentPids: number[] = [];
       for (const ppid of ppids) {
         try {
@@ -336,14 +365,14 @@ function findProcessesByCommandLine(binaryName: string, playerName: string): num
             [
               'process',
               'where',
-              `ProcessId=${ppid} and Name='cmd.exe' and CommandLine like '%-n%${playerName}%'`,
+              `ProcessId=${ppid} and Name='cmd.exe' and CommandLine like '%-n%${playerName}%' and CommandLine like '%${ENSEMBLE_SENTINEL_FLAG}%${ensemble}%'`,
               'get',
               'CommandLine,ProcessId,ParentProcessId',
               '/format:value',
             ],
             { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
           );
-          const { pids: matched } = parseWmicPidPpidFiltered(parentOut, tolerantPattern);
+          const { pids: matched } = parseWmicPidPpidFiltered(parentOut, tolerantPatterns);
           parentPids.push(...matched);
         } catch {
           /* no matching parent — leave it */
@@ -360,9 +389,17 @@ function findProcessesByCommandLine(binaryName: string, playerName: string): num
   // Unix: pgrep -f returns PIDs whose full cmdline matches the pattern.
   // pgrep uses POSIX ERE — `\s` is NOT a metacharacter (it matches literal 's').
   // Use `[[:space:]"']` for the whitespace/quote class instead.
+  //
+  // The combined pattern requires BOTH `-n <playerName>` AND
+  // `--remote-control-session-name-prefix <ensemble>` to be present, matching the
+  // Windows AND guard for #180. argv order is deterministic because spawnArgs in
+  // src/activities/outbox.ts places the ensemble sentinel before the name args.
   try {
-    const escapedNameU = playerName.replace(/[.-]/g, (c) => `\\${c}`);
-    const pattern = `${binaryName}.*-n[[:space:]"']+${escapedNameU}([[:space:]"']|$)`;
+    const escapedNameU = escapeNameForRegex(playerName);
+    const escapedEnsembleU = escapeNameForRegex(ensemble);
+    const pattern =
+      `${binaryName}.*${ENSEMBLE_SENTINEL_FLAG}[[:space:]"']+${escapedEnsembleU}([[:space:]"']|$)` +
+      `.*-n[[:space:]"']+${escapedNameU}([[:space:]"']|$)`;
     const out = execFileSync('pgrep', ['-f', pattern], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'ignore'],
@@ -387,20 +424,25 @@ function parsePids(raw: string): number[] {
 
 /**
  * Parse wmic `/format:value` output that requested `CommandLine`, `ProcessId`, and
- * `ParentProcessId`, and retain only blocks whose CommandLine matches `cmdPattern`.
+ * `ParentProcessId`, and retain only blocks whose CommandLine matches EVERY pattern
+ * in `cmdPatterns`.
  *
  * The caller widens the LIKE filter to `%-n%<name>%` so the quoted production form
  * `"-n" "<name>"` passes the SQL-style match. Because that filter overmatches
  * (it would also accept e.g. `-name foo<name>bar`), we post-filter per-block here
  * using the same tolerate-quotes regex used in the PowerShell path. Blocks whose
- * CommandLine fails the regex are discarded — their PID/PPID never enter the kill
+ * CommandLine fails any pattern are discarded — their PID/PPID never enter the kill
  * list. Output blocks look like:
  *     CommandLine=<cmdline>\r\nParentProcessId=<n>\r\nProcessId=<m>\r\n\r\n
  * `wmic` key ordering is alphabetical so CommandLine always precedes the IDs.
+ *
+ * Multi-pattern matching supports the #180 AND guard: callers pass [`-n <name>`,
+ * `--remote-control-session-name-prefix <ensemble>`] and both must match before
+ * the block's PID is eligible to kill.
  */
 function parseWmicPidPpidFiltered(
   raw: string,
-  cmdPattern: RegExp,
+  cmdPatterns: RegExp[],
 ): { pids: number[]; ppids: number[] } {
   const pids = new Set<number>();
   const ppids = new Set<number>();
@@ -412,7 +454,7 @@ function parseWmicPidPpidFiltered(
     const ppidMatch = block.match(/^ParentProcessId=(\d+)$/m);
     if (!cmdLineMatch || !pidMatch) continue;
     const cmdLine = cmdLineMatch[1];
-    if (!cmdPattern.test(cmdLine)) continue;
+    if (!cmdPatterns.every((p) => p.test(cmdLine))) continue;
     const pid = parseInt(pidMatch[1], 10);
     if (Number.isFinite(pid) && pid > 0 && pid !== process.pid) pids.add(pid);
     if (ppidMatch) {

--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -6,6 +6,7 @@ import * as crypto from 'crypto';
 import { Config, conductorWorkflowId, sessionWorkflowId } from '../config';
 import { AgentType, SessionInput, AdapterClass, AttachmentInfo, SessionMetadata, Message, DetachReason } from '../types';
 import { PREVIEW_MAX_LENGTH } from '../utils/validation';
+import { ENSEMBLE_SENTINEL_FLAG } from '../constants';
 import { getGitInfo } from '../git-info';
 import { spawnInTerminal, spawnCopilotBridge } from '../spawn';
 import { ENV } from '../config';
@@ -353,9 +354,13 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             ? ['--allowedTools', ...allowedTools]
             : [];
 
+          // ENSEMBLE_SENTINEL_FLAG carries the ensemble name into the spawned
+          // claude.exe's CommandLine so hard-terminate can scope `destroy --all`
+          // kills by ensemble (issue #180). See src/constants.ts for details.
           const spawnArgs = [
             '--dangerously-skip-permissions',
             '--dangerously-load-development-channels', 'server:claude-tempo',
+            ENSEMBLE_SENTINEL_FLAG, ensemble,
             ...nameArgs,
             ...agentFlags,
             ...allowedToolsFlags,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,6 +6,28 @@
  */
 
 /**
+ * CLI flag injected into every Claude Code spawn to carry the ensemble name as a
+ * sentinel in the process's CommandLine. `src/activities/hard-terminate.ts`
+ * matches against this flag to scope `destroy --all` kills to a single ensemble
+ * (issue #180): two ensembles sharing a lineup template (identical player names)
+ * must not clobber each other's processes.
+ *
+ * The claude CLI silently accepts this flag even when remote control is inactive,
+ * and the value remains visible in Win32_Process.CommandLine / /proc/<pid>/cmdline
+ * for the kill regex to match.
+ */
+export const ENSEMBLE_SENTINEL_FLAG = '--remote-control-session-name-prefix';
+
+/**
+ * Escape the two regex metacharacters that can appear in validated player/ensemble
+ * names (which are constrained to `[A-Za-z0-9._-]+`). Safe to interpolate the
+ * result into a regex source string.
+ */
+export function escapeNameForRegex(s: string): string {
+  return s.replace(/[.-]/g, (c) => `\\${c}`);
+}
+
+/**
  * Canonical "ensemble ready" banner shown after `up` / `conduct` completes
  * ensemble startup but before the user has typed their first message.
  *

--- a/test/hard-terminate.test.ts
+++ b/test/hard-terminate.test.ts
@@ -95,10 +95,22 @@ function reapStaleTestVictims(): void {
  * or pass it through a shell (Unix). This forces the CommandLine visible to
  * Win32_Process to contain the quoted sentinel exactly as production does.
  */
-async function spawnTestVictim(opts: { binaryArg: string; playerName: string; tmpDir?: string }): Promise<{
+async function spawnTestVictim(opts: {
+  binaryArg: string;
+  playerName: string;
+  tmpDir?: string;
+  /**
+   * Ensemble name to embed as `--remote-control-session-name-prefix <ensemble>` in
+   * the victim's argv. Defaults to 'test-ensemble' to match the common-case callers
+   * that pass `ensemble: 'test-ensemble'` to `hardTerminateAttachment`. Tests that
+   * exercise cross-ensemble scoping (#180) pass distinct values per victim.
+   */
+  ensemble?: string;
+}): Promise<{
   pid: number;
   waitForExit: () => Promise<number | null>;
 }> {
+  const ensemble = opts.ensemble ?? 'test-ensemble';
   // Node one-liner that keeps the event loop alive forever. Process title isn't used
   // for command-line matching — we rely on the `-n <playerName>` marker in argv.
   const nodeScript = `setInterval(() => {}, 60000); process.on('SIGTERM', () => process.exit(0)); process.on('SIGINT', () => process.exit(0));`;
@@ -135,6 +147,8 @@ async function spawnTestVictim(opts: { binaryArg: string; playerName: string; tm
           q('-e'),
           q(nodeScript),
           q('--'),
+          q('--remote-control-session-name-prefix'),
+          q(ensemble),
           q('-n'),
           q(opts.playerName),
           q('--tempo-test-marker'),
@@ -149,9 +163,17 @@ async function spawnTestVictim(opts: { binaryArg: string; playerName: string; tm
     });
     cmdChild.unref();
     // cmd /c exits after spawning node; resolve the node child by its quoted
-    // sentinel. Async polling so we don't block the event loop — the earlier
+    // sentinels. Async polling so we don't block the event loop — the earlier
     // busy-wait variant starved spawn callbacks and the child never appeared.
-    const quotedSentinel = new RegExp(`"-n"\\s+"${opts.playerName.replace(/[.-]/g, (c) => `\\${c}`)}"`);
+    //
+    // Both the playerName AND the ensemble sentinel are required to identify a
+    // unique spawn: cross-ensemble tests (#180) spawn two victims with the same
+    // playerName but distinct ensembles, so matching on playerName alone would
+    // return the first-spawned PID for both calls.
+    const escName = opts.playerName.replace(/[.-]/g, (c) => `\\${c}`);
+    const escEnsemble = ensemble.replace(/[.-]/g, (c) => `\\${c}`);
+    const quotedNameSentinel = new RegExp(`"-n"\\s+"${escName}"`);
+    const quotedEnsembleSentinel = new RegExp(`"--remote-control-session-name-prefix"\\s+"${escEnsemble}"`);
     let victimPid = -1;
     for (let i = 0; i < 60 && victimPid === -1; i++) {
       await new Promise((r) => setTimeout(r, 100));
@@ -170,7 +192,7 @@ async function spawnTestVictim(opts: { binaryArg: string; playerName: string; tm
           if (sep === -1) continue;
           const pidStr = line.slice(0, sep);
           const cmdLine = line.slice(sep + 1);
-          if (quotedSentinel.test(cmdLine)) {
+          if (quotedNameSentinel.test(cmdLine) && quotedEnsembleSentinel.test(cmdLine)) {
             victimPid = parseInt(pidStr, 10);
             break;
           }
@@ -179,7 +201,7 @@ async function spawnTestVictim(opts: { binaryArg: string; playerName: string; tm
     }
     if (victimPid === -1) {
       throw new Error(
-        `spawnTestVictim: could not locate node.exe child with quoted sentinel for playerName=${opts.playerName}`,
+        `spawnTestVictim: could not locate node.exe child with quoted sentinels for playerName=${opts.playerName} ensemble=${ensemble}`,
       );
     }
     const waitForExit = () =>
@@ -199,6 +221,8 @@ async function spawnTestVictim(opts: { binaryArg: string; playerName: string; tm
     '-e',
     nodeScript,
     '--',
+    '--remote-control-session-name-prefix',
+    ensemble,
     '-n',
     opts.playerName,
     '--tempo-test-marker',
@@ -417,6 +441,9 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
     const nodeScript = `setInterval(function(){},60000);process.on('SIGTERM',function(){process.exit(0)});process.on('SIGINT',function(){process.exit(0)});`;
     const q = (s: string) => `"${s.replace(/"/g, '""')}"`;
     const probeBat = join(tmpWorkDir, `probe-${playerName}.bat`);
+    // Both the parent cmd.exe and the child node.exe must carry the ensemble
+    // sentinel so the per-ensemble scoping (#180) lets hard-terminate match them.
+    const probeEnsemble = 'test-ensemble';
     writeFileSync(
       probeBat,
       [
@@ -429,6 +456,8 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
           q('-e'),
           q(nodeScript),
           q('--'),
+          q('--remote-control-session-name-prefix'),
+          q(probeEnsemble),
           q('-n'),
           q(playerName),
           q('--tempo-165-probe'),
@@ -436,13 +465,14 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
         '',
       ].join('\r\n'),
     );
-    // Spawn cmd.exe with `/k <bat> "-n" "<playerName>"` — Node's default argv
-    // serializer wraps each argument that contains no whitespace with... well,
-    // actually `-n` and `<playerName>` are bare tokens and Node will leave
-    // them unquoted. We need the parent cmd.exe's CommandLine to explicitly
-    // carry the quoted sentinel. Build the full command line as a pre-quoted
+    // Spawn cmd.exe with `/k <bat> "--remote-control-session-name-prefix" "<ensemble>" "-n" "<playerName>"` —
+    // Node's default argv serializer wraps each argument that contains no whitespace
+    // with... well, actually `-n` and `<playerName>` are bare tokens and Node will leave
+    // them unquoted. We need the parent cmd.exe's CommandLine to explicitly carry
+    // BOTH the quoted `-n` sentinel and the quoted ensemble sentinel so parent-walk
+    // engages with the #180 AND guard. Build the full command line as a pre-quoted
     // string and use verbatim mode so cmd receives it as-is.
-    const parentCmdTail = `${probeBat} "-n" "${playerName}" "--tempo-165-probe"`;
+    const parentCmdTail = `${probeBat} "--remote-control-session-name-prefix" "${probeEnsemble}" "-n" "${playerName}" "--tempo-165-probe"`;
     const cmdProc = spawn('cmd.exe', ['/k', parentCmdTail], {
       detached: true,
       stdio: 'ignore',
@@ -580,6 +610,86 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
     const result = await hardTerminateAttachment({
       ensemble: 'test-ensemble',
       playerName: `bad; rm -rf /; $(echo pwned)`,
+      agent: 'claude',
+      workDir: tmpWorkDir,
+    });
+    expect(result.killedPids).to.deep.equal([]);
+    expect(result.strategy).to.equal('none');
+  });
+
+  it('scopes kill to the target ensemble when two ensembles share a player name (#180)', async function () {
+    // Reproduces the cross-ensemble destroy bug: two ensembles using the same
+    // lineup template spawn sessions with identical player names. Before #180,
+    // `destroy --all` in ensembleA would find and kill claude.exe processes in
+    // BOTH ensembles because the kill regex only matched on `-n <playerName>`.
+    //
+    // With the ensemble sentinel injected by outbox.ts and the AND guard in
+    // findProcessesByCommandLine, only the ensembleA victim should die — the
+    // ensembleB victim carries a different sentinel and must survive.
+    const sharedName = `smoke-${process.pid}-${Date.now()}`;
+    const victimA = await spawnTestVictim({
+      binaryArg: 'node',
+      playerName: sharedName,
+      ensemble: 'ensembleA',
+      tmpDir: tmpWorkDir,
+    });
+    spawnedPids.push(victimA.pid);
+    const victimB = await spawnTestVictim({
+      binaryArg: 'node',
+      playerName: sharedName,
+      ensemble: 'ensembleB',
+      tmpDir: tmpWorkDir,
+    });
+    spawnedPids.push(victimB.pid);
+
+    // Give the OS a moment so both processes are visible in the table.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(isAlive(victimA.pid), 'victim A should be alive after spawn').to.equal(true);
+    expect(isAlive(victimB.pid), 'victim B should be alive after spawn').to.equal(true);
+
+    // Fixture invariants on Windows: confirm each CommandLine carries BOTH the
+    // `-n <sharedName>` and the distinct ensemble sentinel. Without this, the
+    // test cannot exercise the #180 AND guard.
+    if (isWindows) {
+      const cmdA = readWindowsCommandLine(victimA.pid);
+      const cmdB = readWindowsCommandLine(victimB.pid);
+      const escName = sharedName.replace(/[.-]/g, (c) => `\\${c}`);
+      expect(cmdA, `victim A CommandLine: ${cmdA}`).to.match(new RegExp(`"-n"\\s+"${escName}"`));
+      expect(cmdA, `victim A CommandLine: ${cmdA}`).to.match(/"--remote-control-session-name-prefix"\s+"ensembleA"/);
+      expect(cmdB, `victim B CommandLine: ${cmdB}`).to.match(new RegExp(`"-n"\\s+"${escName}"`));
+      expect(cmdB, `victim B CommandLine: ${cmdB}`).to.match(/"--remote-control-session-name-prefix"\s+"ensembleB"/);
+    }
+
+    // Call hardTerminate scoped to ensembleA only.
+    const result = await hardTerminateAttachment({
+      ensemble: 'ensembleA',
+      playerName: sharedName,
+      // 'copilot' routes the search to `node`/`node.exe` (same as other tests);
+      // the AND guard is identical for both adapters.
+      agent: 'copilot',
+      workDir: tmpWorkDir,
+    });
+
+    // Wait for victim A to actually die.
+    for (let i = 0; i < 30 && isAlive(victimA.pid); i++) {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(isAlive(victimA.pid), 'victim A (ensembleA) should be dead').to.equal(false);
+    expect(
+      isAlive(victimB.pid),
+      `victim B (ensembleB) should still be alive — cross-ensemble kill regression`,
+    ).to.equal(true);
+    expect(result.killedPids, 'killedPids should contain A only').to.deep.equal([victimA.pid]);
+    expect(result.strategy).to.equal('search');
+  });
+
+  it('refuses to search when ensemble fails the regex guard (injection defense)', async function () {
+    // Symmetric with the playerName injection guard: ensemble names with shell-special
+    // chars must not be interpolated into the PowerShell/pgrep pattern. The search
+    // should return empty with strategy 'none' — no kill attempted.
+    const result = await hardTerminateAttachment({
+      ensemble: `bad; $(echo pwned)`,
+      playerName: `benign-name-${process.pid}`,
       agent: 'claude',
       workDir: tmpWorkDir,
     });


### PR DESCRIPTION
## Summary

Fixes #180 — cross-ensemble destroy scoping.

Before this change, two ensembles that used the same lineup template (identical player names) could clobber each other's processes on `destroy --all`: the kill regex in `src/activities/hard-terminate.ts` matched on `-n <playerName>` only, so Claude Code processes belonging to sibling ensembles with the same-named players were terminated together.

### Approach (architect-approved)

Add `--remote-control-session-name-prefix <ensemble>` as a sentinel flag to every Claude Code spawn, then require BOTH `-n <playerName>` AND the ensemble sentinel to match before killing.

**Why the RC flag?** The `claude` CLI silently accepts it even when remote control is inactive, and the value stays visible in `Win32_Process.CommandLine` (Windows) / `/proc/<pid>/cmdline` (Unix) for the kill regex to match. No new wire-protocol surface needed.

### What changed

- **`src/activities/outbox.ts`**: every Claude Code spawn now carries `ENSEMBLE_SENTINEL_FLAG <ensemble>` before `nameArgs`.
- **`src/activities/hard-terminate.ts`**: three lookup paths (PowerShell, wmic fallback, Unix pgrep) now require both sentinels to match. Ensemble is validated against the same regex guard as `playerName` (`/^[A-Za-z0-9._\-]+$/`) before interpolation, mirroring the existing injection defense. `parseWmicPidPpidFiltered` takes `cmdPatterns: RegExp[]` and AND-matches all of them.
- **`src/constants.ts`**: new `ENSEMBLE_SENTINEL_FLAG` constant and `escapeNameForRegex()` helper — shared between the producer (`outbox.ts`) and consumer (`hard-terminate.ts`) so the flag name has a single source of truth.
- **`test/hard-terminate.test.ts`**: two new cases — cross-ensemble isolation (victim-A dies, victim-B survives) and ensemble-injection guard (`ensemble: 'bad; $(echo pwned)'` → `strategy: 'none'`). Existing fixture `spawnTestVictim` now embeds the ensemble sentinel in every victim's argv so the AND guard is satisfied.

### Copilot is unaffected

The copilot adapter takes a separate path (`spawnCopilotBridge` at `outbox.ts:313`) and spawns `node.exe` (the bridge subprocess), not `claude.exe`. The bridge's process resolution continues to use the PID file written by the adapter. No copilot code touched.

### Wire-protocol impact: none

`HardTerminateInput.ensemble` was already defined; its JSDoc is upgraded from "log context only" to describe its new load-bearing role.

### Migration note

**After upgrading to v0.25.0-beta.5, restart any live sessions.** Pre-upgrade spawns lack the ensemble sentinel in their CommandLine and will no longer be killable by the new matcher. No fallback logic was added — a release note is sufficient for this beta-channel upgrade.

## Test plan

- [x] `npm run build` — TypeScript compiles, workflow bundle generated.
- [x] `npm test` — 719 passing on the branch (same as `main`). One pre-existing failure in `hardTerminateAttachment — also kills parent cmd.exe (#165)` that is unrelated to this PR; confirmed reproducible on clean `main` via `git stash` + isolated mocha run. File a separate ticket.
- [x] New `#180` cross-ensemble isolation test passes: `victim-A` with `ensembleA` is killed, `victim-B` with `ensembleB` survives, `killedPids === [A.pid]`.
- [x] New ensemble-injection guard test passes: malicious `ensemble: 'bad; $(echo pwned)'` returns `strategy: 'none'` + empty `killedPids`.
- [x] `/simplify` pass applied — extracted magic string + regex-escape helper to `src/constants.ts`; other findings reviewed and either applied or deemed out-of-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)