### PR TITLE
fix(outbox): regenerate sessionId on force:fresh restart (#183)

### DIFF
--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -24,6 +24,7 @@ import {
   getPartQuery,
   allMessagesQuery,
   receiveMessageSignal,
+  updateMetadataSignal,
 } from '../workflows/signals';
 
 const log = (...args: unknown[]) => console.error('[claude-tempo:outbox]', ...args);
@@ -601,19 +602,34 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
           });
         }
 
-        // Step 6 — enqueue the spawn on the target.
+        // Step 6 — enqueue the spawn.
+        //
+        // Issue #183: Claude Code rejects `--session-id <uuid>` when a transcript
+        // already exists at `~/.claude/projects/<encoded-path>/<uuid>.jsonl`
+        // ("Session ID already in use"). A prior failed spawn can leave that
+        // file behind, wedging every subsequent `fresh` restart that reuses the
+        // stored sessionId. Since `fresh` already skips `--resume`, we mint a
+        // new UUID and persist it on the target's metadata so later non-fresh
+        // restarts resume against the new transcript. Non-fresh restarts keep
+        // the stored sessionId for deterministic `--resume`.
+        let spawnSessionId = metadata.sessionId;
+        if (fresh) {
+          spawnSessionId = crypto.randomUUID();
+          await handle.signal(updateMetadataSignal, { sessionId: spawnSessionId });
+        }
+
         const { spawnEntryId } = await handle.executeUpdate(enqueueSpawnUpdate, {
           args: [{
             host: targetHost,
             attachmentId: token.attachmentId,
             runId: token.runId,
             resume: !fresh,
-            ...(metadata.sessionId ? { sessionId: metadata.sessionId } : {}),
+            ...(spawnSessionId ? { sessionId: spawnSessionId } : {}),
             adapterId,
           }],
         });
 
-        log(`Restart prepared for "${targetPlayerId}" — attachmentId=${token.attachmentId}, spawnEntryId=${spawnEntryId}, host=${targetHost}`);
+        log(`Restart prepared for "${targetPlayerId}" — attachmentId=${token.attachmentId}, spawnEntryId=${spawnEntryId}, host=${targetHost}${fresh ? ` (fresh sessionId=${spawnSessionId})` : ''}`);
         return { success: true };
       } catch (err) {
         if (err instanceof ApplicationFailure) throw err;

--- a/test/outbox.test.ts
+++ b/test/outbox.test.ts
@@ -279,6 +279,114 @@ describe('outbox', function () {
         await bob.result();
       });
     });
+
+    it('#183 fresh restart regenerates sessionId and persists it to target metadata', async function () {
+      this.timeout(30_000);
+      const spawnInputs: Array<Record<string, unknown>> = [];
+      await withWorkerAndRecruitCapture(spawnInputs, async () => {
+        const ensemble = `fresh-sid-${Date.now()}`;
+        const originalSessionId = 'original-uuid-from-a-failed-spawn';
+
+        const alice = await startSession({
+          metadata: playerMetadata({ playerId: 'alice-fresh-sid', ensemble }),
+        });
+        const bob = await startSession({
+          metadata: playerMetadata({
+            playerId: 'bob-fresh-sid',
+            ensemble,
+            sessionId: originalSessionId,
+          }),
+        });
+
+        // Sanity: bob starts with the original sessionId.
+        const before = await bob.query(getMetadataQuery) as { sessionId?: string };
+        expect(before.sessionId).to.equal(originalSessionId);
+
+        await alice.executeUpdate(submitOutboxUpdate, {
+          args: [{
+            type: 'restart',
+            targetPlayerId: 'bob-fresh-sid',
+            invokerPlayerId: 'alice-fresh-sid',
+            fresh: true,
+          }],
+        });
+
+        await sleep(3000);
+
+        const aliceOutbox = await alice.query(outboxQuery);
+        const entry = aliceOutbox.find((e) => e.type === 'restart');
+        expect(entry, 'restart entry exists').to.exist;
+        expect(entry!.status).to.equal('delivered');
+
+        // The spawn should have received a NEW sessionId, not the collided one.
+        expect(spawnInputs, 'spawnProcess was called').to.have.lengthOf.at.least(1);
+        const spawn = spawnInputs[spawnInputs.length - 1];
+        expect(spawn.sessionId, 'spawn sessionId set').to.be.a('string');
+        expect(spawn.sessionId, 'spawn sessionId regenerated').to.not.equal(originalSessionId);
+        expect(spawn.resume, 'fresh restart does not resume').to.equal(false);
+
+        // Target's metadata should now reflect the new sessionId so future
+        // (non-fresh) restarts resume against the new transcript.
+        const after = await bob.query(getMetadataQuery) as { sessionId?: string };
+        expect(after.sessionId).to.equal(spawn.sessionId);
+        expect(after.sessionId).to.not.equal(originalSessionId);
+
+        await alice.executeUpdate(destroyUpdate, { args: [{}] });
+        await bob.executeUpdate(destroyUpdate, { args: [{}] });
+        await alice.result();
+        await bob.result();
+      });
+    });
+
+    it('#183 non-fresh restart preserves stored sessionId for --resume', async function () {
+      this.timeout(30_000);
+      const spawnInputs: Array<Record<string, unknown>> = [];
+      await withWorkerAndRecruitCapture(spawnInputs, async () => {
+        const ensemble = `resume-sid-${Date.now()}`;
+        const originalSessionId = 'stored-uuid-we-want-to-keep';
+
+        const alice = await startSession({
+          metadata: playerMetadata({ playerId: 'alice-resume-sid', ensemble }),
+        });
+        const bob = await startSession({
+          metadata: playerMetadata({
+            playerId: 'bob-resume-sid',
+            ensemble,
+            sessionId: originalSessionId,
+          }),
+        });
+
+        await alice.executeUpdate(submitOutboxUpdate, {
+          args: [{
+            type: 'restart',
+            targetPlayerId: 'bob-resume-sid',
+            invokerPlayerId: 'alice-resume-sid',
+            // no `fresh` — default (context replay + resume)
+          }],
+        });
+
+        await sleep(3000);
+
+        const aliceOutbox = await alice.query(outboxQuery);
+        const entry = aliceOutbox.find((e) => e.type === 'restart');
+        expect(entry!.status).to.equal('delivered');
+
+        // Spawn should reuse the stored sessionId for deterministic --resume.
+        expect(spawnInputs).to.have.lengthOf.at.least(1);
+        const spawn = spawnInputs[spawnInputs.length - 1];
+        expect(spawn.sessionId, 'non-fresh restart preserves sessionId').to.equal(originalSessionId);
+        expect(spawn.resume, 'non-fresh restart resumes').to.equal(true);
+
+        // Metadata sessionId unchanged.
+        const after = await bob.query(getMetadataQuery) as { sessionId?: string };
+        expect(after.sessionId).to.equal(originalSessionId);
+
+        await alice.executeUpdate(destroyUpdate, { args: [{}] });
+        await bob.executeUpdate(destroyUpdate, { args: [{}] });
+        await alice.result();
+        await bob.result();
+      });
+    });
   });
 
   // ── Failure handling ──


### PR DESCRIPTION
Fixes #183 — session transcript collision on restart.

## Problem

When a Claude Code spawn fails partway through startup, the CLI still writes a transcript file at `~/.claude/projects/<encoded-path>/<sessionId>.jsonl`. A subsequent `restart` with `fresh: true` re-used the stored `sessionId` via `--session-id <uuid>`. Claude Code rejects it with **"Session ID already in use"** because of the leftover transcript — the restart wedges indefinitely.

Reproduced in tonight's recovery incident.

## Fix (Option 2: regenerate sessionId on fresh)

Evaluated three approaches:

1. **Detect & unlink** the leftover `.jsonl` before spawn — risky if a live session is mid-write, requires stale/abandoned detection.
2. **Regenerate sessionId on `fresh: true`** — fits the existing `fresh` semantic ("don't resume, start clean"), no detection logic.
3. **Retry with new sessionId on collision** — brittle (error string parsing), recovery-only.

Option 2 is cleanest: `fresh` already means "skip `--resume`, start a clean slate", so minting a new sessionId is semantically appropriate. No detection, no error parsing, no file I/O.

`deliverRestart` (`src/activities/outbox.ts`) now, when `fresh === true`:
1. Mints a new UUID via `crypto.randomUUID()`.
2. Signals `updateMetadataSignal({ sessionId: newId })` on the **target** session's handle so later non-fresh restarts resume against the new transcript.
3. Passes the new UUID into `enqueueSpawnUpdate`.

Non-fresh restarts are unchanged — they still reuse `metadata.sessionId` for deterministic `--resume`. This also covers `migrate --fresh`, which routes through the same activity.

### Retry safety

If the activity is retried after the `updateMetadataSignal` but before `enqueueSpawnUpdate` lands, the next attempt generates yet another UUID and overwrites metadata. The abandoned UUIDs are harmless because Claude Code only writes the `.jsonl` transcript once it actually launches with that `--session-id` — nothing has launched, so nothing collides.

## Tests added

In `test/outbox.test.ts` under `restart delivery (PR-D)`:

- **`#183 fresh restart regenerates sessionId and persists it to target metadata`** — seeds bob with an `originalSessionId`, submits a `fresh: true` restart, asserts (a) the captured spawn input has a `sessionId` different from `originalSessionId`, (b) `spawn.resume === false`, (c) bob's `metadata.sessionId` now matches the spawned UUID.
- **`#183 non-fresh restart preserves stored sessionId for --resume`** — regression guard: same setup without `fresh`; asserts spawn uses the stored `sessionId` and `spawn.resume === true`, and metadata is unchanged.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` passes (730 mocha + 76 vitest)
- [x] `/simplify` pass — trimmed comment bloat, confirmed no duplication, no reinvented utilities
- [x] Manual review: non-fresh path (`restart` and `migrate` without `--fresh`) unchanged

cc @vinceblank