### PR TITLE
chore: release v0.25.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,40 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.25.0-beta.5] - 2026-04-18
+
+> **Beta release.** Three daemon and outbox stability fixes.
+>
+> **Install:** `npm i -g claude-tempo@beta`
+> **Rollback:** `npm i -g claude-tempo@0.25.0-beta.4`
+
+### Fixed
+
+- **#182 — Daemon recovers from stale startup lock.** A daemon process that
+  died abruptly (OOM kill, power loss) left a `.lock` file behind, causing the
+  next daemon startup to hang indefinitely waiting for the lock to clear. The
+  lock file is now JSON-formatted (`{ pid, mtime }`) so the daemon can detect
+  whether the lock owner is still alive; stale locks (dead PID) are removed and
+  acquisition retried. Atomic tmp+rename pid writes prevent partial reads.
+  Daemon-ready timeout extended from 10 s to 30 s to accommodate slower CI
+  machines.
+  ([#182](https://github.com/vinceblank/claude-tempo/issues/182), [#186](https://github.com/vinceblank/claude-tempo/pull/186))
+- **#183 — `restart --fresh` regenerates session UUID.** `restart --fresh` (and
+  `migrate --fresh`) reused the session's stored UUID for the new spawn, causing
+  "Session ID already in use" errors when a prior spawn had written a partial
+  `.jsonl` transcript before crashing. A new UUID is now generated for every
+  forced-fresh restart, ensuring a clean transcript path.
+  ([#183](https://github.com/vinceblank/claude-tempo/issues/183), [#187](https://github.com/vinceblank/claude-tempo/pull/187))
+- **#184 — Agent type propagates through `restart --fresh` pipeline.** A
+  regression caused forced-fresh restarts to lose the player's agent type
+  (`agentDefinition`, `agentDefinitionPath`, `nativeResolvable`), falling back to
+  defaults on the new spawn. These fields now flow through `restart --fresh` →
+  `enqueueSpawnUpdate` → spawn activity. The `enqueueSpawnUpdate` wire protocol
+  change is additive (new optional fields, non-breaking).
+  ([#184](https://github.com/vinceblank/claude-tempo/issues/184), [#188](https://github.com/vinceblank/claude-tempo/pull/188))
+
+---
+
 ## [0.25.0-beta.4] - 2026-04-17
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-tempo",
-  "version": "0.25.0-beta.3",
+  "version": "0.25.0-beta.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-tempo",
-      "version": "0.25.0-beta.3",
+      "version": "0.25.0-beta.4",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.25.0-beta.4",
+  "version": "0.25.0-beta.5",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## v0.25.0-beta.5

Bundles four bug fixes landed since beta.4, plus a CHANGELOG and version bump.

### Changes included

**Fixed**
- **#182** — `fix(daemon): recover from stale startup lock` — Daemon no longer hangs on boot when a stale `.lock` file is left over from a crash.
- **#183** — `fix(outbox): regenerate sessionId on force:fresh restart` — `force: fresh` restarts now get a new session ID, preventing ghost-session collisions.
- **#184** — `fix(outbox): carry agent type through restart pipeline` — Agent type is preserved across restarts so re-recruited sessions use the correct player-type definition.
- **#180** — `fix(hard-terminate): scope process kill by ensemble` — Hard-terminate now correctly scopes the kill signal to the target ensemble, preventing cross-ensemble collateral damage.

### Merged PRs
- #186 (fix #182 — stale startup lock)
- #187 (fix #183 — sessionId on fresh restart)
- #188 (fix #184 — carry agent type through restart)
- #180 (fix hard-terminate ensemble scoping)

### CHANGELOG
See [`CHANGELOG.md`](CHANGELOG.md) for the full `[0.25.0-beta.5]` section.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)