### PR TITLE
perf(ci): drop redundant Type check step (refs #191)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,6 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Type check
-        run: npx tsc --noEmit
-
       - name: Build
         run: npm run build
 


### PR DESCRIPTION
## Summary
- Delete the `Type check` step (`npx tsc --noEmit`) from `.github/workflows/ci.yml`.
- `npm run build` already runs `tsc` as its first command (emits to `dist/` with the same root `tsconfig.json`), so the type-check coverage is preserved by the immediately-following `Build` step. Additionally, `npm test`'s `pretest` runs `tsc -p test/tsconfig.json` over a src+test superset — any type error in src is caught twice downstream.
- **Measured ~6s per matrix job** (run [24593316908](https://github.com/vinceblank/claude-tempo/actions/runs/24593316908), Node 20). Wall clock 6:30 → ~6:24 across all 4 Node versions.

## Backing evidence
Full recon by tempo-researcher: https://github.com/vinceblank/claude-tempo/issues/191#issuecomment-4272481371 — see §7 row 4 (Quick-win #4) for the measurement and §"Quick-win implementation brief" for the exact change shape.

## Out of scope (flagged for user review in the recon)
The recon surfaced larger levers that are **not** in this PR:
- **Shared Temporal env across suites** (refactor `test/helpers.ts` + global root hook) — ~1:30–2:00 savings, touches ~20 test files, architectural, needs user sign-off.
- **`mocha --parallel`** — potentially 2–3× speedup, but needs measurement first to confirm the 2-core runner can host concurrent Temporal servers.
- **#190 flake** — `skipTime(1)` is real `testEnv.sleep(1)` on a `createLocal()` env, not a time-skip. Should be hardened with poll-with-timeout. Owned by #190.
- **Matrix trim** (drop Node 18 EOL / Node 24 pre-release) — tracked by #161.

## Test plan
- [x] Confirmed `package.json` `"build"` script still runs `tsc` (first command before the workflow-bundle emit).
- [x] Confirmed `package.json` `"pretest"` script additionally runs `tsc -p test/tsconfig.json`.
- [ ] CI on this branch passes — correctness proof for the change itself.

`refs #191` — #191 remains open for the architectural follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)