### PR TITLE
refactor(tools): migrate ensemble/CLI/client off status shim (#176)

### DIFF
--- a/src/activities/maestro.ts
+++ b/src/activities/maestro.ts
@@ -100,7 +100,10 @@ export function createMaestroActivities(client: Client): MaestroActivities {
           isConductor: s.isConductor,
           agentType: s.agentType,
           playerType: s.playerType,
-          status: s.status,
+          // Post-#176: `status` carries the attachment phase value. The field
+          // name is legacy-debt pending a rename to `phase` (see
+          // MaestroPlayerInfo declaration in types.ts).
+          status: s.phase,
         }));
       } catch (err) {
         log('refreshEnsembleState failed:', err);

--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -259,7 +259,6 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             // session workflow and dispatch path can resolve the adapter descriptor
             // from the registry without falling back to the legacy agentType field.
             adapterId: registry.resolveFromAgentType(agent),
-            status: 'pending',
             sessionId,
             ...(agentDefinition ? { playerType: agentDefinition } : {}),
             ...(agentDefinitionDescription ? { playerTypeDescription: agentDefinitionDescription } : {}),

--- a/src/activities/resolve.ts
+++ b/src/activities/resolve.ts
@@ -45,19 +45,10 @@ export interface EnsembleSessionInfo {
   playerType?: string;
   /**
    * Attachment phase read from the `ClaudeTempoAttachmentState` search attribute.
-   * The authoritative post-#175 field. May be undefined for older workflows that
-   * predate the attachment lifecycle, or transiently while search attributes propagate.
+   * May be undefined for older workflows that predate the attachment lifecycle,
+   * or transiently while search attributes propagate.
    */
   phase?: AttachmentPhase;
-  /**
-   * @deprecated Vestigial bridge — removed in #176 along with the
-   * `SessionMetadata.status` field and its four consumer readers
-   * (cli/commands, client/index, tools/broadcast, tools/who-am-i).
-   * Populated from `metadata.status` (itself vestigial) for compile
-   * continuity only — the workflow no longer writes a meaningful value.
-   * Do not add new readers.
-   */
-  status?: string;
 }
 
 /**
@@ -101,8 +92,6 @@ export async function scanEnsembleSessions(
         agentType: metadata.agentType || 'claude',
         playerType: metadata.playerType,
         phase,
-        // Vestigial passthrough for #176's consumers — see EnsembleSessionInfo.status.
-        status: metadata.status,
       });
     } catch {
       // Workflow may have just completed — skip it

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -147,7 +147,6 @@ async function seedConductorWorkflow(args: {
       gitBranch: conductorGitBranch,
       isConductor: true,
       agentType: args.conductorAgent,
-      status: 'pending',
       sessionId: conductorSessionId,
       ...(resolvedConductorType ? { playerType: resolvedConductorType.name, playerTypeDescription: resolvedConductorType.description || '' } : {}),
     },
@@ -216,7 +215,6 @@ async function applyLineupPlayersAndSchedules(args: {
         gitBranch: playerGitBranch,
         isConductor: false,
         agentType: playerAgent,
-        status: 'pending',
         sessionId: playerSessionId,
         recruitedBy: conductorName,
         ...(resolvedPlayerType ? { playerType: resolvedPlayerType.name, playerTypeDescription: resolvedPlayerType.description || '' } : {}),
@@ -610,7 +608,7 @@ export async function status(opts: StatusOpts) {
     host: string;
     conductor: boolean;
     agentType: string;
-    status: string;
+    phase: string | undefined;
   }> = [];
 
   for await (const wf of client.workflow.list({ query })) {
@@ -626,6 +624,10 @@ export async function status(opts: StatusOpts) {
       // Filter by ensemble if specified
       if (opts.ensemble && ensemble !== opts.ensemble) continue;
 
+      // Attachment phase lives on the `ClaudeTempoAttachmentState` search attribute (post-#175).
+      const phaseArr = wf.searchAttributes?.ClaudeTempoAttachmentState as string[] | undefined;
+      const phase = Array.isArray(phaseArr) && phaseArr.length > 0 ? phaseArr[0] : undefined;
+
       sessions.push({
         id: wf.workflowId,
         name: (meta.playerId as string) || wf.workflowId.split('-').pop() || '?',
@@ -636,7 +638,7 @@ export async function status(opts: StatusOpts) {
         host: (meta.hostname as string) || '',
         conductor: (meta.isConductor as boolean) || false,
         agentType: (meta.agentType as string) || 'claude',
-        status: (meta.status as string) || 'active',
+        phase,
       });
     } catch {
       // workflow may have closed between list and query
@@ -700,13 +702,20 @@ export async function status(opts: StatusOpts) {
       return a.name.localeCompare(b.name);
     });
 
+    // Option-B phase → tag mapping (see #176 PR):
+    //   booting → (pending); attached/processing/awaiting → no tag;
+    //   draining/detached → (disconnected); gone → (gone).
+    const phaseLabel = (phase: string | undefined): string => {
+      if (phase === 'booting') return out.dim(' (pending)');
+      if (phase === 'draining' || phase === 'detached') return out.yellow(' (disconnected)');
+      if (phase === 'gone') return out.dim(' (gone)');
+      return '';
+    };
+
     for (const s of members) {
       const role = s.conductor ? out.yellow(' (conductor)') : '';
       const agent = s.agentType === 'copilot' ? out.dim(' [copilot]') : '';
-      const statusLabel = s.status === 'stale' ? out.yellow(' (stale)')
-        : s.status === 'pending' ? out.dim(' (pending)')
-        : s.status === 'blocked' ? out.yellow(' (blocked)')
-        : '';
+      const statusLabel = phaseLabel(s.phase);
       // Show PID info for copilot bridge sessions
       const pidInfo = s.agentType === 'copilot' ? getBridgePidInfo(s.name) : '';
       const name = out.bold(s.name);
@@ -1997,8 +2006,11 @@ export async function broadcast(opts: BroadcastOpts) {
 
       if (metadata.ensemble !== ensemble) continue;
 
-      // Filter by status
-      if (!shouldIncludeInBroadcast(metadata.status, !!opts.includeStale)) continue;
+      // Filter by attachment phase (post-#176). Phase lives on the
+      // `ClaudeTempoAttachmentState` search attribute.
+      const phaseArr = wf.searchAttributes?.ClaudeTempoAttachmentState as string[] | undefined;
+      const phase = Array.isArray(phaseArr) && phaseArr.length > 0 ? phaseArr[0] : undefined;
+      if (!shouldIncludeInBroadcast(phase, !!opts.includeStale)) continue;
 
       // Filter by player type if specified
       if (opts.type && metadata.playerType !== opts.type) continue;

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -91,8 +91,10 @@ export function createTempoClient(client: Client): TempoClient {
           const isConductorFromId = wf.workflowId?.endsWith('-conductor') ?? false;
           if (isConductorFromSA || isConductorFromId) {
             entry.hasConductor = true;
-            const statusArr = wf.searchAttributes?.ClaudeTempoStatus;
-            entry.conductorStatus = Array.isArray(statusArr) ? String(statusArr[0]) : undefined;
+            // Post-#175 the workflow writes `ClaudeTempoAttachmentState` (phase) in
+            // place of the removed `ClaudeTempoStatus` search attribute.
+            const phaseArr = wf.searchAttributes?.ClaudeTempoAttachmentState;
+            entry.conductorStatus = Array.isArray(phaseArr) ? String(phaseArr[0]) : undefined;
           }
 
           ensembleMap.set(name, entry);
@@ -147,7 +149,9 @@ export function createTempoClient(client: Client): TempoClient {
             workDir: '',
             isConductor: isConductorFromSA || isConductorFromId,
             agentType: 'claude',
-            status: Array.isArray(sa.ClaudeTempoStatus) ? String(sa.ClaudeTempoStatus[0]) : undefined,
+            // `MaestroPlayerInfo.status` carries the attachment phase post-#176.
+            // Populated from `ClaudeTempoAttachmentState` (replaces removed `ClaudeTempoStatus`).
+            status: Array.isArray(sa.ClaudeTempoAttachmentState) ? String(sa.ClaudeTempoAttachmentState[0]) : undefined,
           });
         }
         return players;

--- a/src/tools/broadcast.ts
+++ b/src/tools/broadcast.ts
@@ -22,7 +22,7 @@ export function registerBroadcastTool(
     {
       message: z.string().max(MESSAGE_MAX).describe('The message to broadcast'),
       type: z.string().optional().describe('Only send to players of this type (e.g., "tempo-soloist")'),
-      includeStale: z.boolean().optional().describe('Include stale sessions (default: false)'),
+      includeStale: z.boolean().optional().describe('Include disconnected sessions (draining/detached phases; default: false). Argument name kept for backward compatibility.'),
     },
     async (args) => {
       const { message, type: playerType, includeStale: rawIncludeStale } = args as {
@@ -30,7 +30,7 @@ export function registerBroadcastTool(
         type?: string;
         includeStale?: boolean;
       };
-      const includeStale = rawIncludeStale === true;
+      const includeDisconnected = rawIncludeStale === true;
 
       try {
         const query = `WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running"`;
@@ -47,8 +47,13 @@ export function registerBroadcastTool(
             // Exclude sender
             if (metadata.playerId === getPlayerId()) continue;
 
-            // Filter by status
-            if (!shouldIncludeInBroadcast(metadata.status, includeStale)) continue;
+            // Filter by attachment phase (post-#176). Phase lives on the
+            // `ClaudeTempoAttachmentState` search attribute.
+            const phaseArr = workflow.searchAttributes?.ClaudeTempoAttachmentState as
+              | string[]
+              | undefined;
+            const phase = Array.isArray(phaseArr) && phaseArr.length > 0 ? phaseArr[0] : undefined;
+            if (!shouldIncludeInBroadcast(phase, includeDisconnected)) continue;
 
             // Filter by player type if specified
             if (playerType && metadata.playerType !== playerType) continue;

--- a/src/tools/ensemble.ts
+++ b/src/tools/ensemble.ts
@@ -58,14 +58,22 @@ export function registerEnsembleTool(
         return ok('No active sessions found.');
       }
 
+      // Option-B phase → tag mapping (see #176 PR):
+      //   booting → (pending); attached/processing/awaiting → no tag;
+      //   draining/detached → (disconnected); gone → (gone).
+      const phaseTag = (phase: string | undefined): string => {
+        if (phase === 'booting') return '(pending)';
+        if (phase === 'draining' || phase === 'detached') return '(disconnected)';
+        if (phase === 'gone') return '(gone)';
+        return '';
+      };
+
       const lines = players.map((p) => {
         const tags = [
           p.isYou ? '(you)' : '',
           p.isConductor ? '(conductor)' : '',
           p.agentType === 'copilot' ? '[copilot]' : '',
-          p.status === 'stale' ? '(stale)' : '',
-          p.status === 'pending' ? '(pending)' : '',
-          p.status === 'blocked' ? '(blocked)' : '',
+          phaseTag(p.phase),
         ].filter(Boolean).join(' ');
 
         const nameDisplay = p.playerType

--- a/src/tools/who-am-i.ts
+++ b/src/tools/who-am-i.ts
@@ -1,6 +1,6 @@
 import { WorkflowHandle } from '@temporalio/client';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { SessionMetadata } from '../types';
+import { SessionMetadata, AttachmentInfo } from '../types';
 import { defineTool, ok } from './helpers';
 
 export function registerWhoAmITool(
@@ -11,6 +11,16 @@ export function registerWhoAmITool(
   defineTool(server, 'who_am_i', 'Get your identity, role, and session details', {}, async () => {
     const metadata: SessionMetadata = await handle.query('getMetadata');
     const part: string = await handle.query('getPart');
+
+    // Attachment phase is authoritative post-#175/#176 (replaced legacy status).
+    let phase: string | undefined;
+    try {
+      const info: AttachmentInfo = await handle.query('attachmentInfo');
+      phase = info.phase;
+    } catch {
+      // Older workflows pre-dating the attachment lifecycle may not support this query.
+      phase = undefined;
+    }
 
     const lines = [
       `**Name:** ${metadata.playerId}`,
@@ -23,7 +33,7 @@ export function registerWhoAmITool(
       `**Directory:** ${metadata.workDir}`,
       `**Host:** ${metadata.hostname}`,
       metadata.gitBranch ? `**Branch:** ${metadata.gitBranch}` : null,
-      `**Status:** ${metadata.status || 'active'}`,
+      `**Phase:** ${phase ?? 'unknown'}`,
     ].filter(Boolean);
 
     return ok(lines.join('\n'));

--- a/src/types.ts
+++ b/src/types.ts
@@ -146,8 +146,6 @@ export interface SessionMetadata {
    * mapping via `AdapterRegistry.resolveFromAgentType`.
    */
   adapterId?: string;
-  /** @deprecated Vestigial — removed in #176. Do not add new readers. */
-  status?: string;
   /** Agent definition name (e.g., "tempo-soloist"). */
   playerType?: string;
   /** Short description from the agent definition. */
@@ -539,6 +537,13 @@ export interface MaestroPlayerInfo {
   isConductor: boolean;
   agentType: string;
   playerType?: string;
+  /**
+   * Attachment phase value (e.g. `'attached'`, `'detached'`, `'gone'`).
+   *
+   * TODO: rename to `phase` and retype as AttachmentPhase once the shim epic
+   * settles; kept as `status?: string` during #176 to minimize workflow-replay
+   * blast radius. Safe to clean up any time after beta.6.
+   */
   status?: string;
 }
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -65,13 +65,24 @@ export const RESTART_CONTEXT_MESSAGES_MAX = 50;
 export const MAX_DETACH_DEADLINE_MS = 120_000;
 
 /**
- * Whether a session should be included in a broadcast based on its status.
- * Always excludes pending, terminated, and blocked. Excludes stale unless includeStale is true.
+ * Whether a session should be included in a broadcast based on its attachment phase.
+ *
+ * Option-B mapping (see #176 PR description):
+ *   - `attached` / `processing` / `awaiting` → include (talkable)
+ *   - `booting`                              → exclude (not ready — legacy "pending")
+ *   - `draining` / `detached`                → include only if includeDisconnected
+ *   - `gone`                                 → exclude (terminal — legacy "terminated")
+ *
+ * Undefined phase (older workflows pre-attachment-lifecycle, or transient
+ * search-attribute propagation) is treated as `booting` — safe default.
+ *
+ * The `includeDisconnected` parameter is surfaced to callers via the `includeStale`
+ * MCP tool argument (kept for wire compat; description updated).
  */
-export function shouldIncludeInBroadcast(status: string | undefined, includeStale: boolean): boolean {
-  const s = status || 'active';
-  if (s === 'pending' || s === 'terminated' || s === 'blocked') return false;
-  if (s === 'stale' && !includeStale) return false;
+export function shouldIncludeInBroadcast(phase: string | undefined, includeDisconnected: boolean): boolean {
+  const p = phase || 'booting';
+  if (p === 'gone' || p === 'booting') return false;
+  if ((p === 'draining' || p === 'detached') && !includeDisconnected) return false;
   return true;
 }
 

--- a/src/workflows/maestro.ts
+++ b/src/workflows/maestro.ts
@@ -149,7 +149,9 @@ export async function claudeMaestroWorkflow(input: MaestroInput): Promise<void> 
           events.push({ type: 'player_joined', playerId: id, timestamp: now });
         } else {
           const old = oldMap.get(id)!;
-          // Status changed
+          // `status_changed` events fire on attachment-phase transitions
+          // post-#176 (the field value drifted from legacy SessionStatus to
+          // AttachmentPhase; the event name is kept for dashboard stability).
           if (old.status !== player.status) {
             events.push({
               type: 'status_changed',
@@ -184,9 +186,12 @@ export async function claudeMaestroWorkflow(input: MaestroInput): Promise<void> 
 
       players = newPlayers;
 
-      // Track last time we saw running (non-terminated) sessions
+      // Track last time we saw running sessions — phases the ensemble can
+      // meaningfully coordinate with (post-#176). `status` carries an
+      // attachment-phase value (see MaestroPlayerInfo field-rename TODO).
+      const COORDINATABLE_PHASES = ['attached', 'processing', 'awaiting', 'booting'];
       const hasRunningSessions = players.some(
-        (p) => p.status !== 'terminated' && p.status !== 'stale',
+        (p) => p.status !== undefined && COORDINATABLE_PHASES.includes(p.status),
       );
       if (hasRunningSessions) {
         lastActiveSessionTime = Date.now();
@@ -431,6 +436,8 @@ export async function claudeGlobalMaestroWorkflow(input: GlobalMaestroInput): Pr
             events.push({ type: 'player_joined', playerId: id, timestamp: now });
           } else {
             const old = oldMap.get(id)!;
+            // Post-#176: diffs attachment-phase values (see per-ensemble Maestro
+            // comment for rationale).
             if (old.status !== player.status) {
               events.push({ type: 'status_changed', playerId: id, timestamp: now, oldValue: old.status, newValue: player.status });
             }

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -397,10 +397,10 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
       input.metadata.sessionId = update.sessionId ?? (update as any).claudeSessionId;
     }
     // `update.status` / `update.enableStaleDetection` are silently dropped.
-    // Status tracking was removed in #175 — attachment phase (set by the V2
-    // wire surface: claimAttachment / adapterExited / forceDetach / destroy)
-    // is authoritative. The `SessionMetadata.status` field remains as a
-    // vestigial typing bridge and is removed in #176 along with its readers.
+    // Status tracking was removed in #175–#176 — attachment phase (set by the
+    // V2 wire surface: claimAttachment / adapterExited / forceDetach / destroy)
+    // is authoritative. The signal wire shape keeps these optional fields for
+    // backward compat with older clients; their values are no-ops.
     upsertSearchAttributes({
       ClaudeTempoEnsemble: [input.metadata.ensemble],
       ClaudeTempoPlayerId: [input.metadata.playerId],
@@ -1477,9 +1477,7 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
 
     // Legacy stale/blocked detection + `_heartbeat`/`_ping` probe removed in #175.
     // The phase machine (lease expiry, `processingDeadline`, `adapterExited`) is now
-    // the single source of liveness truth; see §§9.5.a/b above. The
-    // `SessionMetadata.status` field remains as a vestigial typing bridge and is
-    // dropped in #176 along with its four consumer readers.
+    // the single source of liveness truth; see §§9.5.a/b above.
 
     // Prevent unbounded history growth — let the SDK decide when.
     const info = workflowInfo();

--- a/test/activities.test.ts
+++ b/test/activities.test.ts
@@ -42,7 +42,7 @@ function mockConfig(overrides: Partial<Config> = {}): Config {
 
 /** Create a mock workflow handle that records signal/query/update calls. */
 function mockHandle(opts: {
-  metadata?: Partial<SessionMetadata>;
+  metadata?: Partial<SessionMetadata> & { status?: string };
   part?: string;
   messages?: Array<{ from: string; text: string; timestamp: string }>;
   history?: unknown[];
@@ -60,6 +60,9 @@ function mockHandle(opts: {
   const signals: Array<{ name: string; args: unknown }> = [];
   const updates: Array<{ name: string; args: unknown }> = [];
 
+  // `status` field removed from `SessionMetadata` in #176; strip it off any
+  // `opts.metadata` override that still carries it (most tests predate the removal).
+  const { status: _legacyStatus, ...mdOverrides } = (opts.metadata ?? {}) as Partial<SessionMetadata> & { status?: string };
   const defaultMetadata: SessionMetadata = {
     playerId: 'player-1',
     ensemble: 'test-ensemble',
@@ -67,8 +70,7 @@ function mockHandle(opts: {
     workDir: '/tmp/work',
     isConductor: false,
     agentType: 'claude',
-    status: 'active',
-    ...opts.metadata,
+    ...mdOverrides,
   };
 
   // Normalize: callers may pass either a string or a typed constant from
@@ -278,7 +280,9 @@ describe('scanEnsembleSessions', function () {
     expect(sessions[0].isConductor).to.be.true;
     expect(sessions[0].agentType).to.equal('copilot');
     expect(sessions[0].playerType).to.equal('tempo-conductor');
-    expect(sessions[0].status).to.equal('active');
+    // Note: legacy `status` passthrough assertion removed in #176 — `scanEnsembleSessions`
+    // now exposes `phase` from `ClaudeTempoAttachmentState`. The mock does not populate
+    // search attributes, so `phase` stays undefined here; covered by #178 rewrite.
   });
 });
 

--- a/test/blocked-detection.test.ts
+++ b/test/blocked-detection.test.ts
@@ -63,14 +63,14 @@ describe.skip('blocked session detection', function () {
       await handle.signal(updateMetadataSignal, { status: 'blocked' });
 
       let meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('blocked');
+      expect((meta as any).status).to.equal('blocked');
 
       await handle.executeUpdate(submitOutboxUpdate, {
         args: [{ type: 'cue' as const, targetPlayerId: 'someone', message: 'hello' }],
       });
 
       meta = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('active');
+      expect((meta as any).status).to.equal('active');
 
       await handle.executeUpdate(destroyUpdate, { args: [{}] });
       await handle.result();
@@ -90,7 +90,7 @@ describe.skip('blocked session detection', function () {
       });
 
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('stale');
+      expect((meta as any).status).to.equal('stale');
 
       await handle.executeUpdate(destroyUpdate, { args: [{}] });
       await handle.result();
@@ -106,7 +106,7 @@ describe.skip('blocked session detection', function () {
       await handle.signal(updateMetadataSignal, { status: 'blocked' });
 
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('blocked');
+      expect((meta as any).status).to.equal('blocked');
 
       await handle.executeUpdate(destroyUpdate, { args: [{}] });
       await handle.result();
@@ -123,7 +123,7 @@ describe.skip('blocked session detection', function () {
       await handle.signal(setPartSignal, 'working on something');
 
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('blocked');
+      expect((meta as any).status).to.equal('blocked');
 
       await handle.executeUpdate(destroyUpdate, { args: [{}] });
       await handle.result();
@@ -154,7 +154,7 @@ describe.skip('blocked session detection', function () {
 
       await new Promise(r => setTimeout(r, 2000));
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.not.equal('blocked');
+      expect((meta as any).status).to.not.equal('blocked');
 
       await deliverAll(handle);
       // PR-C commit 4: terminate shim routes to §2.5 destroy semantics (abandon in-flight,
@@ -177,7 +177,7 @@ describe.skip('blocked session detection', function () {
 
       await new Promise(r => setTimeout(r, 2000));
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.not.equal('blocked');
+      expect((meta as any).status).to.not.equal('blocked');
 
       await deliverAll(handle);
       // PR-C commit 4: terminate shim routes to §2.5 destroy semantics (abandon in-flight,
@@ -201,7 +201,7 @@ describe.skip('blocked session detection', function () {
 
       await new Promise(r => setTimeout(r, 2000));
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('blocked');
+      expect((meta as any).status).to.equal('blocked');
 
       await deliverAll(handle);
       // PR-C commit 4: terminate shim routes to §2.5 destroy semantics (abandon in-flight,
@@ -228,7 +228,7 @@ describe.skip('blocked session detection', function () {
 
       await new Promise(r => setTimeout(r, 2000));
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.not.equal('blocked');
+      expect((meta as any).status).to.not.equal('blocked');
 
       await handle.executeUpdate(destroyUpdate, { args: [{}] });
       // PR-C commit 4: terminate → §2.5 destroy; second deliverAll removed.
@@ -247,14 +247,14 @@ describe.skip('blocked session detection', function () {
       });
 
       let meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('blocked');
+      expect((meta as any).status).to.equal('blocked');
 
       await handle.executeUpdate(submitOutboxUpdate, {
         args: [{ type: 'cue' as const, targetPlayerId: 'someone', message: 'alive' }],
       });
 
       meta = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('active');
+      expect((meta as any).status).to.equal('active');
 
       await handle.executeUpdate(destroyUpdate, { args: [{}] });
       await handle.result();
@@ -275,7 +275,7 @@ describe.skip('blocked session detection', function () {
 
       await new Promise(r => setTimeout(r, 2000));
       const meta: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta.status).to.not.equal('blocked');
+      expect((meta as any).status).to.not.equal('blocked');
 
       await deliverAll(handle);
       // PR-C commit 4: terminate shim routes to §2.5 destroy semantics (abandon in-flight,

--- a/test/destroy.test.ts
+++ b/test/destroy.test.ts
@@ -41,7 +41,7 @@ describe('destroy verb — fixes #102 (graceful stop → resurrection loop)', fu
       // Post-destroy: query returns true, metadata status is terminated
       expect(await handle.query(isDestroyedQuery)).to.equal(true);
       const meta = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('terminated');
+      expect((meta as any).status).to.equal('terminated');
 
       // Workflow drains and completes on its own
       await handle.result();
@@ -180,7 +180,7 @@ describe('destroy verb — fixes #164 (destroy with live attachment)', function 
 
       expect(await handle.query(isDestroyedQuery)).to.equal(true);
       const meta = await handle.query(getMetadataQuery);
-      expect(meta.status).to.equal('terminated');
+      expect((meta as any).status).to.equal('terminated');
     });
   });
 

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -203,8 +203,20 @@ export async function withWorkerAndActivities<T>(fn: () => Promise<T>): Promise<
   return worker.runUntil(fn);
 }
 
+/**
+ * Options accepted by {@link playerMetadata}.
+ *
+ * `status` is not a `SessionMetadata` field anymore (removed in #176) — but many
+ * pre-existing test cases still pass a legacy `status: 'pending' | 'active'` etc.
+ * The helper accepts it for test ergonomics and silently drops it; those tests
+ * are either already skipped (#175 followup) or will be rewritten against
+ * `attachmentInfo.phase` in #178.
+ */
+export type TestMetadataOverrides = Partial<SessionMetadata> & { status?: string };
+
 /** Default metadata for a player session. Override fields as needed. */
-export function playerMetadata(overrides: Partial<SessionMetadata> = {}): SessionMetadata {
+export function playerMetadata(overrides: TestMetadataOverrides = {}): SessionMetadata {
+  const { status: _legacyStatus, ...rest } = overrides;
   return {
     playerId: `player-${Date.now()}`,
     ensemble: 'test-ensemble',
@@ -212,12 +224,12 @@ export function playerMetadata(overrides: Partial<SessionMetadata> = {}): Sessio
     workDir: '/tmp/test',
     isConductor: false,
     agentType: 'claude',
-    ...overrides,
+    ...rest,
   };
 }
 
 /** Default metadata for a conductor session. Override fields as needed. */
-export function conductorMetadata(overrides: Partial<SessionMetadata> = {}): SessionMetadata {
+export function conductorMetadata(overrides: TestMetadataOverrides = {}): SessionMetadata {
   return playerMetadata({
     playerId: 'conductor',
     isConductor: true,

--- a/test/hold-release.test.ts
+++ b/test/hold-release.test.ts
@@ -35,7 +35,8 @@ describe('hold and release (warm hold)', function () {
   });
 
   describe('recruit with held flag (warm hold)', function () {
-    it('creates workflow with outboxLocked and spawns process', async function () {
+    // TODO(#178): rewrite against attachmentInfo.phase
+    it.skip('creates workflow with outboxLocked and spawns process', async function () {
       this.timeout(30_000);
       const spawnInputs: Array<Record<string, unknown>> = [];
       await withWorkerAndRecruitCapture(spawnInputs, async () => {
@@ -79,7 +80,7 @@ describe('hold and release (warm hold)', function () {
           `claude-session-${ensemble}-warm-held-player`,
         );
         const metadata = await recruitedHandle.query(getMetadataQuery);
-        expect(metadata.status).to.equal('pending'); // not 'held' — process spawned
+        expect((metadata as any).status).to.equal('pending'); // not 'held' — process spawned. TODO(#178): rewrite against attachmentInfo.phase.
 
         // Verify outbox IS locked
         const isLocked = await recruitedHandle.query(outboxLockedQuery);

--- a/test/outbox.test.ts
+++ b/test/outbox.test.ts
@@ -181,7 +181,7 @@ describe('outbox', function () {
         await sleep(2000);
 
         const bobMeta = await bob.query(getMetadataQuery);
-        expect(bobMeta.status).to.equal('terminated');
+        expect((bobMeta as any).status).to.equal('terminated');
 
         const aliceOutbox = await alice.query(outboxQuery);
         expect(aliceOutbox[0].status).to.equal('delivered');
@@ -466,7 +466,8 @@ describe('outbox', function () {
   // ── Recruit delivery ──
 
   describe('recruit delivery', function () {
-    it('pre-creates session workflow with initial message, playerType, and recruitedBy', async function () {
+    // TODO(#178): rewrite against attachmentInfo.phase
+    it.skip('pre-creates session workflow with initial message, playerType, and recruitedBy', async function () {
       this.timeout(30_000);
       await withWorkerAndRecruitActivities(async () => {
         const ensemble = `recruit-${Date.now()}`;
@@ -519,7 +520,7 @@ describe('outbox', function () {
         expect(meta.playerType).to.equal('tempo-soloist');
         expect(meta.playerTypeDescription).to.equal('Senior engineer');
         expect(meta.recruitedBy).to.equal('recruiter');
-        expect(meta.status).to.equal('pending');
+        expect((meta as any).status).to.equal('pending'); // TODO(#178): rewrite against attachmentInfo.phase
         expect(meta.ensemble).to.equal(ensemble);
         expect(meta.isConductor).to.equal(false);
 
@@ -654,7 +655,7 @@ describe('outbox', function () {
 
         // Target should be marked terminated
         const targetMeta = await target.query(getMetadataQuery);
-        expect(targetMeta.status).to.equal('terminated');
+        expect((targetMeta as any).status).to.equal('terminated');
 
         // Conductor should receive the system notification about the termination
         const conductorMessages = await conductor.query(allMessagesQuery);

--- a/test/processing-lifecycle.test.ts
+++ b/test/processing-lifecycle.test.ts
@@ -155,7 +155,7 @@ describe('processing lifecycle — fixes #99 (long tool calls misclassified as s
       // Give the workflow a beat to run its first main-loop iteration.
       await new Promise((r) => setTimeout(r, 2000));
       const meta1: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta1.status).to.not.equal('stale');
+      expect((meta1 as any).status).to.not.equal('stale');
       expect(await handle.query(inFlightMessagesQuery)).to.deep.equal(['msg-1']);
 
       // End processing — next iteration should let stale detection fire.
@@ -167,7 +167,7 @@ describe('processing lifecycle — fixes #99 (long tool calls misclassified as s
       await new Promise((r) => setTimeout(r, 2000));
 
       const meta2: SessionMetadata = await handle.query(getMetadataQuery);
-      expect(meta2.status).to.equal('stale');
+      expect((meta2 as any).status).to.equal('stale');
 
       // Cleanup: deliver pending messages, then destroy. v0.25 destroy (§2.5) is
       // "abandon and COMPLETE" — no drain-wait — so no signals after destroy.

--- a/test/runid-pinning.test.ts
+++ b/test/runid-pinning.test.ts
@@ -99,7 +99,7 @@ describe('runId pinning — prevents zombie-resurrection via unpinned handles', 
       expect(pinnedDesc.runId).to.equal(runId1);
       // Historical metadata still queryable
       const meta = await pinned1.query(getMetadataQuery);
-      expect(meta.status).to.equal('terminated');
+      expect((meta as any).status).to.equal('terminated');
 
       // Start run 2 (fresh)
       const h2 = await client.workflow.start('claudeSessionWorkflow', {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -759,7 +759,6 @@ function makeClientWithPlayers(
               workDir: '/tmp',
               isConductor: false,
               agentType: 'claude',
-              status: player?.status ?? 'active',
               playerType: player?.playerType,
             } satisfies SessionMetadata;
           }
@@ -769,8 +768,25 @@ function makeClientWithPlayers(
       }),
       start: async () => ({ runId: 'fake-run-id' }),
       list: async function* () {
+        // Post-#176: broadcast/ensemble filtering reads phase from the
+        // `ClaudeTempoAttachmentState` search attribute. Synthesize phase
+        // values here from the test's legacy `status` field so existing
+        // tests continue to exercise the filter logic:
+        //   active → attached, stale → detached, pending → booting,
+        //   terminated → gone, blocked → detached, undefined → attached.
+        const statusToPhase = (status: string | undefined): string => {
+          if (status === 'stale' || status === 'blocked') return 'detached';
+          if (status === 'pending') return 'booting';
+          if (status === 'terminated') return 'gone';
+          return 'attached';
+        };
         for (const p of players) {
-          yield { workflowId: `claude-session-${testConfig.ensemble}-${p.playerId}` };
+          yield {
+            workflowId: `claude-session-${testConfig.ensemble}-${p.playerId}`,
+            searchAttributes: {
+              ClaudeTempoAttachmentState: [statusToPhase(p.status)],
+            },
+          };
         }
       },
     },
@@ -1414,7 +1430,6 @@ function makeResumeClient(players: string[]): {
               workDir: '/tmp',
               isConductor: false,
               agentType: 'claude',
-              status: 'active',
             } satisfies SessionMetadata;
           }
           if (queryName === 'getPart') return 'no description';

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -402,14 +402,15 @@ describe('claudeSessionWorkflow', function () {
   // ── Session status lifecycle ──
 
   describe('session status lifecycle', function () {
-    it('starts with status from metadata', async function () {
+    // TODO(#178): rewrite against attachmentInfo.phase
+    it.skip('starts with status from metadata', async function () {
       await withWorker(async () => {
         const handle = await startSession({
           metadata: playerMetadata({ playerId: 'status-init', status: 'pending' }),
         });
 
         const meta = await handle.query(getMetadataQuery);
-        expect(meta.status).to.equal('pending');
+        expect((meta as any).status).to.equal('pending');
 
         await handle.executeUpdate(destroyUpdate, { args: [{}] });
         await handle.result();
@@ -426,7 +427,7 @@ describe('claudeSessionWorkflow', function () {
         // but metadata.status itself remains undefined unless set
         const meta = await handle.query(getMetadataQuery);
         // status is undefined in metadata but search attribute defaults to 'active'
-        expect(meta.status).to.satisfy((s: string | undefined) => s === undefined || s === 'active');
+        expect((meta as any).status).to.satisfy((s: string | undefined) => s === undefined || s === 'active');
 
         await handle.executeUpdate(destroyUpdate, { args: [{}] });
         await handle.result();
@@ -442,13 +443,13 @@ describe('claudeSessionWorkflow', function () {
 
         // Verify starts as pending
         let meta = await handle.query(getMetadataQuery);
-        expect(meta.status).to.equal('pending');
+        expect((meta as any).status).to.equal('pending');
 
         // Transition to active (simulates what server.ts does when session connects)
         await handle.signal(updateMetadataSignal, { status: 'active' });
 
         meta = await handle.query(getMetadataQuery);
-        expect(meta.status).to.equal('active');
+        expect((meta as any).status).to.equal('active');
 
         await handle.executeUpdate(destroyUpdate, { args: [{}] });
         await handle.result();
@@ -509,7 +510,7 @@ describe('claudeSessionWorkflow', function () {
 
         const meta = await handle.query(getMetadataQuery);
         expect(meta.hostname).to.equal('prod-host');
-        expect(meta.status).to.equal('active');
+        expect((meta as any).status).to.equal('active');
         expect(meta.gitBranch).to.equal('main');
 
         await handle.executeUpdate(destroyUpdate, { args: [{}] });
@@ -876,7 +877,7 @@ describe('claudeSessionWorkflow', function () {
 
         // Workflow should still be running and queryable
         const meta = await handle.query(getMetadataQuery);
-        expect(meta.status).to.equal('active');
+        expect((meta as any).status).to.equal('active');
         expect(meta.playerId).to.equal('stale-enable-test');
 
         // Terminate — PR-C commit 4 retired the v0.24 drain-wait semantic. The

--- a/tests/client/fallback.test.ts
+++ b/tests/client/fallback.test.ts
@@ -130,7 +130,7 @@ describe('TempoClient.getPlayers — fallback precedence', () => {
             ClaudeTempoEnsemble: ['demo'],
             ClaudeTempoPlayerId: ['dave'],
             ClaudeTempoHostname: ['host-1'],
-            ClaudeTempoStatus: ['active'],
+            ClaudeTempoAttachmentState: ['attached'],
           },
         },
       ],
@@ -140,7 +140,9 @@ describe('TempoClient.getPlayers — fallback precedence', () => {
     const players = await client.getPlayers('demo');
     expect(players).toHaveLength(1);
     expect(players[0].playerId).toBe('dave');
-    expect(players[0].status).toBe('active');
+    // Post-#176: `MaestroPlayerInfo.status` carries the attachment phase value
+    // read from `ClaudeTempoAttachmentState` (mock returns 'attached' above).
+    expect(players[0].status).toBe('attached');
   });
 
   it('returns empty array when all three tiers fail', async () => {
@@ -211,7 +213,7 @@ describe('TempoClient.discoverEnsembles — fallback precedence', () => {
           searchAttributes: {
             ClaudeTempoEnsemble: ['mine'],
             ClaudeTempoIsConductor: [true],
-            ClaudeTempoStatus: ['active'],
+            ClaudeTempoAttachmentState: ['attached'],
           },
         },
         {
@@ -229,7 +231,9 @@ describe('TempoClient.discoverEnsembles — fallback precedence', () => {
     expect(ensembles[0].name).toBe('mine');
     expect(ensembles[0].playerCount).toBe(2);
     expect(ensembles[0].hasConductor).toBe(true);
-    expect(ensembles[0].conductorStatus).toBe('active');
+    // Post-#176: `conductorStatus` reads attachment phase from
+    // `ClaudeTempoAttachmentState` (mock returns 'attached' above).
+    expect(ensembles[0].conductorStatus).toBe('attached');
   });
 
   it('returns empty array when both Global Maestro and workflow list fail', async () => {


### PR DESCRIPTION
## Summary

Second PR in the beta.6 legacy shim-removal epic (parent #174, prior #175 merged as `bc69966`). Removes the two vestigial `status?: string` bridges left by #175 and migrates all consumers to attachment phase.

## Type surface

- `SessionMetadata.status` — **removed** (was vestigial bridge in #175).
- `EnsembleSessionInfo.status` — **removed**; `EnsembleSessionInfo.phase?: AttachmentPhase` is authoritative.
- `MaestroPlayerInfo.status?: string` — **kept with field-name TODO** per design decision. Value drifts from legacy `SessionStatus` to `AttachmentPhase`; field rename is safe follow-up cleanup post-beta.6.

## Option-B phase → display mapping

Documented inline at each tag computation site:

| Phase | Tag |
|---|---|
| `booting` | `(pending)` |
| `attached` / `processing` / `awaiting` | (no tag — talkable) |
| `draining` / `detached` | `(disconnected)` |
| `gone` | `(gone)` |

## Files migrated

| File | Change |
|---|---|
| `src/utils/validation.ts` | `shouldIncludeInBroadcast` rewritten — phase-aware filter; param renamed `includeDisconnected`; MCP tool arg stays `includeStale` for wire compat |
| `src/tools/ensemble.ts` | Tag computation uses Option-B mapping (inline helper) |
| `src/tools/who-am-i.ts` | Queries `attachmentInfo` for phase; `**Status:**` → `**Phase:**` |
| `src/tools/broadcast.ts` | Reads phase from `ClaudeTempoAttachmentState` search attribute on workflow list iterator |
| `src/cli/commands.ts` | Client shape uses `phase`; Option-B display tags; broadcast filter reads phase from search attr; dropped `status: 'pending'` writes on SessionInput construction (conductor + player spawn) |
| `src/client/index.ts` | Strategy-1 + Strategy-3 read phase from `ClaudeTempoAttachmentState` (replaces removed `ClaudeTempoStatus` from #175) |
| `src/activities/maestro.ts` | Passes `s.phase` through to `MaestroPlayerInfo.status` field (value drift, name stays) |
| `src/workflows/maestro.ts` | `has-running-sessions` filter uses positive phase enumeration (`attached`/`processing`/`awaiting`/`booting`); diff-semantic comment added |
| `src/activities/outbox.ts` | Dropped legacy `status: 'pending'` write on recruit SessionInput |
| `src/types.ts` | Deleted `SessionMetadata.status`; added field-name TODO on `MaestroPlayerInfo.status` |
| `src/activities/resolve.ts` | Deleted vestigial `EnsembleSessionInfo.status` + passthrough |

## Workflow bundle

`npm run build` regenerates `workflow-bundle.js` clean at **1.62 MB** (identical to post-#175 size — no unintended include).

Workflow changes (`src/workflows/maestro.ts`) are deterministic only (filter constant array, no I/O). `src/workflows/session.ts` got comment-only updates to reflect post-#176 state.

## Out of scope (preserved)

- `src/tools/stages.ts` — keeps `'blocked'` reportType (legitimate stage-report value per parent #174)
- TUI — #177's scope
- Cluster-side `ClaudeTempoStatus` deregistration at `src/cli/commands.ts:834` + `test/fixtures/multi-host/docker-compose.yml` — #178
- `docs/WIRE-PROTOCOL.md` deprecation markers — #178 (tempo-qa flagged)

## Test impact

**707 passing / 49 pending / 0 failing** locally.

Test-side compile patches (Option-B-consistent minimum-viable):

- `test/helpers.ts` — `playerMetadata`/`conductorMetadata` accept a `TestMetadataOverrides` type that silently drops the legacy `status` field (tests predate the shim removal)
- `test/activities.test.ts` — `mockHandle` metadata override accepts + drops `status`; one scanEnsembleSessions status-passthrough assertion removed (mock doesn't populate search attrs; covered by #178 rewrite)
- `test/tools.test.ts` — two literal `SessionMetadata` constructions drop `status`; `makeClientWithPlayers` mock synthesizes `ClaudeTempoAttachmentState` search attr from legacy test `status` so broadcast tests keep exercising the filter
- Status-reading `expect(meta.status)` sites cast via `(meta as any).status` in 6 files whose asserting tests are skipped (either via #175 followup or newly here)
- **Newly skipped** (add 3 to the 15 from #175): `workflow.test.ts: 'starts with status from metadata'`, `hold-release.test.ts: 'creates workflow with outboxLocked...'`, `outbox.test.ts: 'pre-creates session workflow...'` — each relied on legacy status values no longer written

## Commits

- `5f5551b` — the migration (22 files, +180/-95)

## Test plan

- [x] `npm run build` — clean, workflow bundle 1.62 MB (unchanged from #175)
- [x] `npm test` — 707 passing / 49 pending / 0 failing
- [x] `grep -rn 'ClaudeTempoStatus\|SessionStatus' src/` — only intentional references remain:
      - `src/client/index.ts:95,153` (migration comments)
      - `src/cli/commands.ts:834` (cluster registration — deferred to #178)
      - `src/workflows/maestro.ts:153` (migration comment)
- [x] Option-B mapping documented inline at both consumer sites (ensemble tool + CLI display)
- [x] Workflow bundle deterministic — only constant-array + comment changes in maestro/session
- [x] `MaestroPlayerInfo.status` TODO comment matches conductor's amended text

## Epic sequencing

1. **#175** — workflow + types + resolver ✅ (merged `bc69966`)
2. **#176 (this PR)** — tools + CLI + client + maestro: delete both vestigial `status` fields, migrate readers to phase ✅
3. **#177** — TUI attachment-phase migration
4. **#178** — rewrite skipped tests (**now 18, was 15 after #175**) against `attachmentInfo.phase`; deregister cluster-side `ClaudeTempoStatus` search attribute; update `docs/WIRE-PROTOCOL.md` deprecation markers
5. **Post-beta.6**: rename `MaestroPlayerInfo.status` → `phase` (see inline TODO)

🤖 Generated with [Claude Code](https://claude.com/claude-code)