### PR TITLE
refactor(tui): migrate TUI off status shim (#177)

### DIFF
--- a/src/activities/maestro.ts
+++ b/src/activities/maestro.ts
@@ -100,10 +100,7 @@ export function createMaestroActivities(client: Client): MaestroActivities {
           isConductor: s.isConductor,
           agentType: s.agentType,
           playerType: s.playerType,
-          // Post-#176: `status` carries the attachment phase value. The field
-          // name is legacy-debt pending a rename to `phase` (see
-          // MaestroPlayerInfo declaration in types.ts).
-          status: s.phase,
+          phase: s.phase,
         }));
       } catch (err) {
         log('refreshEnsembleState failed:', err);

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -7,6 +7,7 @@
 import { Client, WorkflowIdConflictPolicy } from '@temporalio/client';
 import { maestroWorkflowId, schedulerWorkflowId, sessionWorkflowId, conductorWorkflowId, GLOBAL_MAESTRO_WORKFLOW_ID } from '../config';
 import type {
+  AttachmentPhase,
   MaestroPlayerInfo,
   MaestroRelayMessage,
   HistoryEntry,
@@ -60,7 +61,9 @@ export function createTempoClient(client: Client): TempoClient {
             name,
             playerCount: players.length,
             hasConductor: !!conductor,
-            conductorStatus: conductor?.status,
+            // `conductorStatus` is a public TempoClient API field (EnsembleInfo);
+            // its value now carries the attachment-phase string (post-#176 drift).
+            conductorStatus: conductor?.phase,
           };
         });
         // Only trust Maestro if it has discovered ensembles; fall through to
@@ -149,9 +152,10 @@ export function createTempoClient(client: Client): TempoClient {
             workDir: '',
             isConductor: isConductorFromSA || isConductorFromId,
             agentType: 'claude',
-            // `MaestroPlayerInfo.status` carries the attachment phase post-#176.
-            // Populated from `ClaudeTempoAttachmentState` (replaces removed `ClaudeTempoStatus`).
-            status: Array.isArray(sa.ClaudeTempoAttachmentState) ? String(sa.ClaudeTempoAttachmentState[0]) : undefined,
+            // Attachment phase from `ClaudeTempoAttachmentState` search attr.
+            phase: Array.isArray(sa.ClaudeTempoAttachmentState)
+              ? (String(sa.ClaudeTempoAttachmentState[0]) as AttachmentPhase)
+              : undefined,
           });
         }
         return players;

--- a/src/tui/App.tsx
+++ b/src/tui/App.tsx
@@ -67,6 +67,8 @@ import { Picker } from './components/Picker';
 import type { PickerItem } from './components/Picker';
 import { parseCommand, isValidCommand, formatHelpSummary, COMMANDS, getCommandNames, PLAYER_PARAM_COMMANDS, SUBCOMMAND_MAP } from './commands';
 import { THEME } from './utils/theme';
+import { phaseToLabel, phaseToColor, phaseToIconName } from './utils/format';
+import { statusIcons as phaseStatusIcons, supportsUnicode as phaseSupportsUnicode } from './utils/platform';
 import { wordWrap } from './utils/format';
 import { loadHistory, saveHistory } from './utils/history';
 import type { TempoClient } from '../client';
@@ -410,7 +412,7 @@ export function App({ api, ensemble, defaultAgent }: AppProps) {
     if (state.chatTarget) {
       const isConductor = state.chatTarget === state.conductorName;
       const player = state.players.find(p => p.playerId === state.chatTarget);
-      const status = player?.status || 'unknown';
+      const status = phaseToLabel(player?.phase);
       const icon = isConductor ? '\u2605' : '\u2022';
       return `${icon} ${state.chatTarget} \u00b7 ${status}${state.activeEnsemble ? ` \u00b7 ${state.activeEnsemble}` : ''}`;
     }
@@ -460,7 +462,7 @@ export function App({ api, ensemble, defaultAgent }: AppProps) {
     if (state.pickerType === 'players') {
       // Apply status filter if set.
       const filtered = state.pickerStatusFilter
-        ? state.players.filter(p => p.status === state.pickerStatusFilter)
+        ? state.players.filter(p => p.phase === state.pickerStatusFilter)
         : state.players;
       // Sort by type for grouping, conductor first
       const sorted = [...filtered].sort((a, b) => {
@@ -469,13 +471,16 @@ export function App({ api, ensemble, defaultAgent }: AppProps) {
         const typeB = b.playerType || b.agentType || '';
         return typeA.localeCompare(typeB) || a.playerId.localeCompare(b.playerId);
       });
+      // Resolve icons once for the whole map (not per-item) per
+      // docs/tui-performance.md — `statusIcons()` allocates a small object.
+      const icons = phaseStatusIcons(phaseSupportsUnicode());
       return sorted.map(p => ({
         id: p.playerId,
         label: p.playerId,
-        detail: `[${p.status || '?'}]`,
+        detail: `[${phaseToLabel(p.phase)}]`,
         meta: p.part || undefined,
-        icon: p.isConductor ? '\u2605' : p.status === 'active' ? '\u25CF' : p.status === 'stale' ? '\u25CB' : '\u25D4',
-        color: p.status === 'active' ? THEME.success : p.status === 'stale' ? THEME.warning : THEME.dim,
+        icon: p.isConductor ? '\u2605' : icons[phaseToIconName(p.phase)],
+        color: phaseToColor(p.phase),
         current: p.playerId === state.chatTarget,
         group: p.playerType || p.agentType || 'unknown',
       }));
@@ -1177,7 +1182,7 @@ export function App({ api, ensemble, defaultAgent }: AppProps) {
         targetPlayer: state.chatTarget,
         targetPart: targetPlayer?.part,
         targetBranch: targetPlayer?.gitBranch,
-        targetStatus: targetPlayer?.status,
+        targetStatus: targetPlayer?.phase,
         targetHost: targetPlayer?.hostname,
         localHost: osHostname(),
         isConductor: memoizedChatData.isConductor,

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -8,6 +8,7 @@ import type { TempoClient } from '../client';
 import type { TuiAction, StaticItem } from './store';
 import type { Message, SentMessage } from '../types';
 import { statusIcons, supportsUnicode } from './utils/platform';
+import { phaseToLabel } from './utils/format';
 import { listAllLineups } from '../ensemble/saver';
 
 // ── Types ──
@@ -202,7 +203,10 @@ async function handleBroadcast(
     const players = await api.getPlayers(ctx.activeEnsemble);
     let sent = 0;
     for (const p of players) {
-      if (p.status === 'active') {
+      // Broadcast to talkable phases only — `active` (attached/processing) and
+      // `idle` (awaiting). Mirrors `shouldIncludeInBroadcast` in utils/validation.
+      const label = phaseToLabel(p.phase);
+      if (label === 'active' || label === 'idle') {
         try {
           await api.sendMessage(ctx.activeEnsemble, p.playerId, message, 'maestro');
           sent++;

--- a/src/tui/components/MainView.tsx
+++ b/src/tui/components/MainView.tsx
@@ -8,6 +8,7 @@ import { useInk } from '../ink-context';
 import { statusIcons, supportsUnicode } from '../utils/platform';
 import type { MaestroPlayerInfo, MaestroRelayMessage } from '../../types';
 import { THEME } from '../utils/theme';
+import { phaseToColor, phaseToIconName } from '../utils/format';
 
 export interface ScheduleInfo {
   name: string;
@@ -63,17 +64,9 @@ export function MainView({ ensemble, players, messages, schedules, staticItemCou
   } else {
     for (let i = 0; i < players.length; i++) {
       const p = players[i];
-      const icon = p.isConductor ? icons.conductor
-        : p.status === 'active' ? icons.active
-        : p.status === 'stale' ? icons.stale
-        : p.status === 'pending' ? icons.pending
-        : p.status === 'terminated' ? icons.terminated
-        : icons.blocked;
-
-      const color = p.status === 'active' ? THEME.success
-        : p.status === 'stale' ? THEME.warning
-        : p.status === 'terminated' ? THEME.dim
-        : THEME.textMuted;
+      // Collapse the attachment phase via the Option-B helpers in utils/format.
+      const icon = p.isConductor ? icons.conductor : icons[phaseToIconName(p.phase)];
+      const color = phaseToColor(p.phase);
 
       const typeName = p.playerType || p.agentType || '';
       const part = p.part || '';

--- a/src/tui/components/PlayerDetailView.tsx
+++ b/src/tui/components/PlayerDetailView.tsx
@@ -13,6 +13,8 @@ import React from 'react';
 import { useInk } from '../ink-context';
 import { THEME } from '../utils/theme';
 import type { MaestroPlayerInfo, SessionMetadata, Message, SentMessage } from '../../types';
+import { phaseToLabel, phaseToIconName } from '../utils/format';
+import { statusIcons, supportsUnicode } from '../utils/platform';
 
 const MAX_VISIBLE = 20;
 
@@ -57,9 +59,11 @@ export function PlayerDetailView({
   children.push(React.createElement(Text, { key: 'name', bold: true, color: THEME.accent }, `${icon}${playerId}`));
 
   // Metadata line 1: Type · Status [· Host when remote]
+  // Collapse the attachment phase via the Option-B helpers in utils/format.
   const type = player?.playerType || player?.agentType || '(default)';
-  const status = player?.status || 'unknown';
-  const statusDot = status === 'active' ? '\u25CF' : status === 'stale' ? '\u25CB' : '\u25A0';
+  const status = phaseToLabel(player?.phase);
+  const phaseIcons = statusIcons(supportsUnicode());
+  const statusDot = phaseIcons[phaseToIconName(player?.phase)];
   const host = player?.hostname || metadata?.hostname || '';
   const showRemoteHost = Boolean(host && localHost && host !== localHost);
   children.push('\n');

--- a/src/tui/components/StatusBar.tsx
+++ b/src/tui/components/StatusBar.tsx
@@ -6,6 +6,7 @@ import React from 'react';
 import { useInk } from '../ink-context';
 import { THEME } from '../utils/theme';
 import type { MaestroPlayerInfo } from '../../types';
+import { phaseToLabel } from '../utils/format';
 
 export interface StatusBarProps {
   ensemble: string | null;
@@ -36,17 +37,28 @@ export function StatusBar({ ensemble, players, playersLoaded, scheduleCount, con
     // Still loading — don't show incorrect counts
     children.push(React.createElement(Text, { key: 'pl', color: THEME.dim }, 'Loading...'));
   } else {
-    // Player breakdown by status
-    const active = players.filter(p => p.status === 'active').length;
-    const stale = players.filter(p => p.status === 'stale').length;
-    const pending = players.filter(p => p.status === 'pending').length;
-    const blocked = players.filter(p => p.status === 'blocked').length;
+    // Player breakdown by phase label (Option-B five buckets collapsed to four
+    // meaningful ones for the bar — `gone` players are terminal and not
+    // shown in the ensemble list).
+    let active = 0;
+    let idle = 0;
+    let disconnected = 0;
+    let pending = 0;
+    for (const p of players) {
+      switch (phaseToLabel(p.phase)) {
+        case 'active':       active++; break;
+        case 'idle':         idle++; break;
+        case 'disconnected': disconnected++; break;
+        case 'pending':      pending++; break;
+        // 'gone' / 'unknown' intentionally not counted in the summary line.
+      }
+    }
 
     const parts: string[] = [];
-    if (active > 0) parts.push(`${active} active`);
-    if (stale > 0) parts.push(`${stale} stale`);
-    if (blocked > 0) parts.push(`${blocked} blocked`);
-    if (pending > 0) parts.push(`${pending} pending`);
+    if (active > 0)       parts.push(`${active} active`);
+    if (idle > 0)         parts.push(`${idle} idle`);
+    if (disconnected > 0) parts.push(`${disconnected} disconnected`);
+    if (pending > 0)      parts.push(`${pending} pending`);
     const breakdown = parts.length > 0 ? ` (${parts.join(', ')})` : '';
     const playerLabel = `${players.length} player${players.length !== 1 ? 's' : ''}${breakdown}`;
 

--- a/src/tui/components/StatusOverlay.tsx
+++ b/src/tui/components/StatusOverlay.tsx
@@ -8,6 +8,8 @@ import React from 'react';
 import { useInk } from '../ink-context';
 import { THEME } from '../utils/theme';
 import type { MaestroPlayerInfo } from '../../types';
+import { phaseToLabel, phaseToColor, phaseToIconName } from '../utils/format';
+import { statusIcons, supportsUnicode } from '../utils/platform';
 
 export interface StatusOverlayProps {
   players: MaestroPlayerInfo[];
@@ -16,11 +18,9 @@ export interface StatusOverlayProps {
   contentHeight: number;
 }
 
-const iconMap: Record<string, string> = { active: '\u25CF', blocked: '\u25CB', stale: '\u25CC', pending: '\u23F3' };
-const colorMap: Record<string, string> = { active: THEME.success, blocked: THEME.text, stale: THEME.dim, pending: THEME.warning };
-
 export function StatusOverlay({ players, ensemble, scrollOffset, contentHeight }: StatusOverlayProps) {
   const { Text } = useInk();
+  const icons = statusIcons(supportsUnicode());
   const cols = process.stdout.columns || 80;
   const indent = 4;
   const maxWidth = Math.max(20, cols - indent);
@@ -54,8 +54,9 @@ export function StatusOverlay({ players, ensemble, scrollOffset, contentHeight }
   }
 
   for (const p of visiblePlayers) {
-    const icon = iconMap[p.status || 'unknown'] || '?';
-    const iconColor = colorMap[p.status || 'unknown'] || THEME.text;
+    // Attachment-phase → icon/color lookup (post-#177 Option-B mapping).
+    const icon = icons[phaseToIconName(p.phase)];
+    const iconColor = phaseToColor(p.phase);
     const conductor = p.isConductor ? ' \u2605' : '';
     children.push('\n\n');
     children.push(React.createElement(React.Fragment, { key: `${p.playerId}-1` },
@@ -63,7 +64,7 @@ export function StatusOverlay({ players, ensemble, scrollOffset, contentHeight }
       React.createElement(Text, { bold: true, color: THEME.text }, p.playerId),
       conductor ? React.createElement(Text, { color: THEME.warning }, conductor) : null,
     ));
-    const details = [p.status || 'unknown'];
+    const details: string[] = [phaseToLabel(p.phase)];
     if (p.gitBranch) details.push(p.gitBranch);
     if (p.playerType || p.agentType) details.push(p.playerType || p.agentType || '');
     children.push('\n');

--- a/src/tui/utils/format.ts
+++ b/src/tui/utils/format.ts
@@ -1,7 +1,11 @@
 /**
  * Formatting utilities for the TUI.
- * Timestamp formatting, text truncation, duration display.
+ * Timestamp formatting, text truncation, duration display,
+ * attachment-phase → label/color/icon mapping (post-#177).
  */
+
+import type { AttachmentPhase } from '../../types';
+import { THEME } from './theme';
 
 /** Format an ISO timestamp as a short time string (HH:MM:SS). */
 export function formatTime(iso: string): string {
@@ -33,16 +37,65 @@ export function truncate(text: string, maxLen: number, ellipsis = '...'): string
   return text.slice(0, maxLen - ellipsis.length) + ellipsis;
 }
 
-/** Format a player status for display. */
-export function formatStatus(status?: string): string {
-  switch (status) {
-    case 'active': return 'active';
-    case 'stale': return 'stale';
-    case 'pending': return 'pending';
-    case 'blocked': return 'blocked';
-    case 'terminated': return 'terminated';
-    default: return status || 'unknown';
-  }
+// ── Attachment-phase presentation mapping (post-#177) ──
+//
+// TUI consumers receive attachment-phase strings via `MaestroPlayerInfo.phase`
+// (renamed from `.status` in #177 after the shim-removal epic). The helpers
+// below collapse the seven attachment phases into five user-facing buckets:
+// active / idle / disconnected / pending / gone.
+//
+// Performance: the per-phase maps are frozen at module scope (per
+// docs/tui-performance.md — no per-frame object allocation). Callers just
+// do a dictionary lookup.
+
+/** User-facing phase labels shown in the TUI. */
+export type PhaseLabel = 'active' | 'idle' | 'disconnected' | 'pending' | 'gone' | 'unknown';
+
+/** Icon-bucket name used to key into `statusIcons()` (src/tui/utils/platform.ts). */
+export type PhaseIconName = 'active' | 'stale' | 'pending' | 'blocked' | 'terminated';
+
+const PHASE_TO_LABEL: Readonly<Record<AttachmentPhase, PhaseLabel>> = Object.freeze({
+  attached:   'active',
+  processing: 'active',
+  awaiting:   'idle',
+  draining:   'disconnected',
+  detached:   'disconnected',
+  booting:    'pending',
+  gone:       'gone',
+});
+
+const LABEL_TO_COLOR: Readonly<Record<PhaseLabel, string>> = Object.freeze({
+  active:       THEME.success,
+  idle:         THEME.text,
+  disconnected: THEME.warning,
+  pending:      THEME.dim,
+  gone:         THEME.dim,
+  unknown:      THEME.text,
+});
+
+const LABEL_TO_ICON_NAME: Readonly<Record<PhaseLabel, PhaseIconName>> = Object.freeze({
+  active:       'active',      // ● (filled)
+  idle:         'stale',       // ○ (hollow, neutral)
+  disconnected: 'blocked',     // ◐ (half, yellow)
+  pending:      'pending',     // ◔ (quarter, dim)
+  gone:         'terminated',  // ✕
+  unknown:      'blocked',     // ? → cautionary
+});
+
+/** Collapse an attachment phase into its user-facing label. */
+export function phaseToLabel(phase?: string): PhaseLabel {
+  if (!phase) return 'unknown';
+  return PHASE_TO_LABEL[phase as AttachmentPhase] ?? 'unknown';
+}
+
+/** Theme color (hex string or undefined under NO_COLOR) for a phase. */
+export function phaseToColor(phase?: string): string {
+  return LABEL_TO_COLOR[phaseToLabel(phase)];
+}
+
+/** Icon-bucket key for `statusIcons()` for a phase. */
+export function phaseToIconName(phase?: string): PhaseIconName {
+  return LABEL_TO_ICON_NAME[phaseToLabel(phase)];
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -537,14 +537,8 @@ export interface MaestroPlayerInfo {
   isConductor: boolean;
   agentType: string;
   playerType?: string;
-  /**
-   * Attachment phase value (e.g. `'attached'`, `'detached'`, `'gone'`).
-   *
-   * TODO: rename to `phase` and retype as AttachmentPhase once the shim epic
-   * settles; kept as `status?: string` during #176 to minimize workflow-replay
-   * blast radius. Safe to clean up any time after beta.6.
-   */
-  status?: string;
+  /** Attachment phase (post-#177 — replaced legacy `status` field). */
+  phase?: AttachmentPhase;
 }
 
 /** A message relayed through the global Maestro for dashboard visibility. */

--- a/src/workflows/maestro.ts
+++ b/src/workflows/maestro.ts
@@ -149,16 +149,15 @@ export async function claudeMaestroWorkflow(input: MaestroInput): Promise<void> 
           events.push({ type: 'player_joined', playerId: id, timestamp: now });
         } else {
           const old = oldMap.get(id)!;
-          // `status_changed` events fire on attachment-phase transitions
-          // post-#176 (the field value drifted from legacy SessionStatus to
-          // AttachmentPhase; the event name is kept for dashboard stability).
-          if (old.status !== player.status) {
+          // `status_changed` events fire on attachment-phase transitions; the
+          // event name is kept for dashboard stability (MaestroEvent wire shape).
+          if (old.phase !== player.phase) {
             events.push({
               type: 'status_changed',
               playerId: id,
               timestamp: now,
-              oldValue: old.status,
-              newValue: player.status,
+              oldValue: old.phase,
+              newValue: player.phase,
             });
           }
           // Part changed
@@ -187,11 +186,10 @@ export async function claudeMaestroWorkflow(input: MaestroInput): Promise<void> 
       players = newPlayers;
 
       // Track last time we saw running sessions — phases the ensemble can
-      // meaningfully coordinate with (post-#176). `status` carries an
-      // attachment-phase value (see MaestroPlayerInfo field-rename TODO).
-      const COORDINATABLE_PHASES = ['attached', 'processing', 'awaiting', 'booting'];
+      // meaningfully coordinate with (attached/processing/awaiting/booting).
+      const COORDINATABLE_PHASES: readonly string[] = ['attached', 'processing', 'awaiting', 'booting'];
       const hasRunningSessions = players.some(
-        (p) => p.status !== undefined && COORDINATABLE_PHASES.includes(p.status),
+        (p) => p.phase !== undefined && COORDINATABLE_PHASES.includes(p.phase),
       );
       if (hasRunningSessions) {
         lastActiveSessionTime = Date.now();
@@ -436,10 +434,9 @@ export async function claudeGlobalMaestroWorkflow(input: GlobalMaestroInput): Pr
             events.push({ type: 'player_joined', playerId: id, timestamp: now });
           } else {
             const old = oldMap.get(id)!;
-            // Post-#176: diffs attachment-phase values (see per-ensemble Maestro
-            // comment for rationale).
-            if (old.status !== player.status) {
-              events.push({ type: 'status_changed', playerId: id, timestamp: now, oldValue: old.status, newValue: player.status });
+            // Diffs attachment-phase values (see per-ensemble Maestro comment).
+            if (old.phase !== player.phase) {
+              events.push({ type: 'status_changed', playerId: id, timestamp: now, oldValue: old.phase, newValue: player.phase });
             }
             if (old.part !== player.part) {
               events.push({ type: 'part_changed', playerId: id, timestamp: now, oldValue: old.part, newValue: player.part });

--- a/test/global-maestro.test.ts
+++ b/test/global-maestro.test.ts
@@ -98,7 +98,7 @@ describe('claudeGlobalMaestroWorkflow', function () {
         workDir: '/tmp/a',
         isConductor: false,
         agentType: 'claude',
-        status: 'active',
+        phase: 'attached',
       };
 
       const player2: MaestroPlayerInfo = {
@@ -109,7 +109,7 @@ describe('claudeGlobalMaestroWorkflow', function () {
         workDir: '/tmp/b',
         isConductor: true,
         agentType: 'claude',
-        status: 'active',
+        phase: 'attached',
       };
 
       await withWorkerAndGlobalMaestroActivities(

--- a/test/maestro.test.ts
+++ b/test/maestro.test.ts
@@ -104,7 +104,7 @@ describe('claudeMaestroWorkflow', function () {
             workDir: '/tmp/test',
             isConductor: false,
             agentType: 'claude',
-            status: 'active',
+            phase: 'attached',
           }];
 
           // Wait for next refresh cycle
@@ -141,7 +141,7 @@ describe('claudeMaestroWorkflow', function () {
         workDir: '/tmp/test',
         isConductor: false,
         agentType: 'claude',
-        status: 'active',
+        phase: 'attached',
       };
 
       let currentPlayers: MaestroPlayerInfo[] = [{ ...initialPlayer }];
@@ -161,7 +161,7 @@ describe('claudeMaestroWorkflow', function () {
           currentPlayers = [{
             ...initialPlayer,
             part: 'Updated part',
-            status: 'stale',
+            phase: 'detached',
           }];
 
           await sleep(2000);
@@ -170,8 +170,8 @@ describe('claudeMaestroWorkflow', function () {
 
           const statusEvents = events.filter(e => e.type === 'status_changed' && e.playerId === 'bob');
           expect(statusEvents).to.have.length.greaterThanOrEqual(1);
-          expect(statusEvents[0].oldValue).to.equal('active');
-          expect(statusEvents[0].newValue).to.equal('stale');
+          expect(statusEvents[0].oldValue).to.equal('attached');
+          expect(statusEvents[0].newValue).to.equal('detached');
 
           const partEvents = events.filter(e => e.type === 'part_changed' && e.playerId === 'bob');
           expect(partEvents).to.have.length.greaterThanOrEqual(1);

--- a/test/tui-format.test.ts
+++ b/test/tui-format.test.ts
@@ -4,7 +4,7 @@
  * Pure function tests — no Temporal, no mocks, runs in milliseconds.
  */
 import { expect } from 'chai';
-import { wordWrap, truncate, formatRelativeTime, formatStatus, formatEventType } from '../src/tui/utils/format';
+import { wordWrap, truncate, formatRelativeTime, phaseToLabel, phaseToColor, phaseToIconName, formatEventType } from '../src/tui/utils/format';
 
 describe('wordWrap', function () {
 
@@ -117,26 +117,85 @@ describe('formatRelativeTime', function () {
 
 });
 
-describe('formatStatus', function () {
+describe('phaseToLabel', function () {
 
-  it('returns "active" for active status', function () {
-    expect(formatStatus('active')).to.equal('active');
+  it('collapses attached + processing to "active"', function () {
+    expect(phaseToLabel('attached')).to.equal('active');
+    expect(phaseToLabel('processing')).to.equal('active');
   });
 
-  it('returns "stale" for stale status', function () {
-    expect(formatStatus('stale')).to.equal('stale');
+  it('maps awaiting to "idle"', function () {
+    expect(phaseToLabel('awaiting')).to.equal('idle');
   });
 
-  it('returns "pending" for pending status', function () {
-    expect(formatStatus('pending')).to.equal('pending');
+  it('collapses detached + draining to "disconnected"', function () {
+    expect(phaseToLabel('detached')).to.equal('disconnected');
+    expect(phaseToLabel('draining')).to.equal('disconnected');
   });
 
-  it('returns "unknown" for undefined status', function () {
-    expect(formatStatus(undefined)).to.equal('unknown');
+  it('maps booting to "pending"', function () {
+    expect(phaseToLabel('booting')).to.equal('pending');
   });
 
-  it('returns the string as-is for unrecognized status', function () {
-    expect(formatStatus('custom-status')).to.equal('custom-status');
+  it('maps gone to "gone"', function () {
+    expect(phaseToLabel('gone')).to.equal('gone');
+  });
+
+  it('returns "unknown" for undefined or unrecognized values', function () {
+    expect(phaseToLabel(undefined)).to.equal('unknown');
+    expect(phaseToLabel('bogus-phase')).to.equal('unknown');
+  });
+
+});
+
+describe('phaseToColor', function () {
+
+  it('returns a non-empty color string for every valid phase', function () {
+    for (const phase of ['attached', 'processing', 'awaiting', 'draining', 'detached', 'booting', 'gone']) {
+      const color = phaseToColor(phase);
+      // Under NO_COLOR, colors become undefined — either the string is a hex
+      // value or it's undefined; both are valid theme values. We assert
+      // the helper doesn't throw and returns a defined-or-undefined result.
+      expect(color === undefined || typeof color === 'string').to.equal(true);
+    }
+  });
+
+  it('picks distinct colors for active vs disconnected vs pending', function () {
+    // Under NO_COLOR these could all be undefined; skip strict inequality
+    // and just assert they map through the label bucket.
+    expect(phaseToColor('attached')).to.equal(phaseToColor('processing'));
+    expect(phaseToColor('detached')).to.equal(phaseToColor('draining'));
+  });
+
+});
+
+describe('phaseToIconName', function () {
+
+  it('returns "active" for attached/processing', function () {
+    expect(phaseToIconName('attached')).to.equal('active');
+    expect(phaseToIconName('processing')).to.equal('active');
+  });
+
+  it('returns "stale" for awaiting (idle)', function () {
+    expect(phaseToIconName('awaiting')).to.equal('stale');
+  });
+
+  it('returns "blocked" for detached/draining (disconnected)', function () {
+    expect(phaseToIconName('detached')).to.equal('blocked');
+    expect(phaseToIconName('draining')).to.equal('blocked');
+  });
+
+  it('returns "pending" for booting', function () {
+    expect(phaseToIconName('booting')).to.equal('pending');
+  });
+
+  it('returns "terminated" for gone', function () {
+    expect(phaseToIconName('gone')).to.equal('terminated');
+  });
+
+  it('returns "blocked" (cautionary) for unknown/undefined', function () {
+    expect(phaseToIconName(undefined)).to.equal('blocked');
+    expect(phaseToIconName('bogus')).to.equal('blocked');
   });
 
 });

--- a/tests/client/fallback.test.ts
+++ b/tests/client/fallback.test.ts
@@ -11,7 +11,7 @@
  */
 import { describe, it, expect, vi } from 'vitest';
 import { createTempoClient } from '../../src/client';
-import type { MaestroPlayerInfo } from '../../src/types';
+import type { AttachmentPhase, MaestroPlayerInfo } from '../../src/types';
 
 // ── Helpers ──
 
@@ -61,7 +61,7 @@ function makeFakeClient(opts: {
   };
 }
 
-function p(id: string, ensemble = 'demo', status = 'active'): MaestroPlayerInfo {
+function p(id: string, ensemble = 'demo', phase: AttachmentPhase = 'attached'): MaestroPlayerInfo {
   return {
     playerId: id,
     ensemble,
@@ -70,7 +70,7 @@ function p(id: string, ensemble = 'demo', status = 'active'): MaestroPlayerInfo 
     workDir: '/tmp',
     isConductor: false,
     agentType: 'claude',
-    status,
+    phase,
   };
 }
 
@@ -140,9 +140,8 @@ describe('TempoClient.getPlayers — fallback precedence', () => {
     const players = await client.getPlayers('demo');
     expect(players).toHaveLength(1);
     expect(players[0].playerId).toBe('dave');
-    // Post-#176: `MaestroPlayerInfo.status` carries the attachment phase value
-    // read from `ClaudeTempoAttachmentState` (mock returns 'attached' above).
-    expect(players[0].status).toBe('attached');
+    // Post-#177: `MaestroPlayerInfo.phase` (renamed from `.status` in #177).
+    expect(players[0].phase).toBe('attached');
   });
 
   it('returns empty array when all three tiers fail', async () => {


### PR DESCRIPTION
## Summary

Third PR in the beta.6 legacy shim-removal epic (parent #174, prior #175 merged as `bc69966`, #176 merged as `3f581ee7`). Migrates the TUI off `MaestroPlayerInfo.status` (Option-B vestigial field carrying phase values) to a properly-named and properly-typed `phase?: AttachmentPhase` field.

## Type surface

- **`MaestroPlayerInfo.status?: string` → `phase?: AttachmentPhase`.** Field name is now honest about its value (the post-#176 drift where the name lied is gone); type prevents stringly-typed regressions.
- **`EnsembleInfo.conductorStatus?: string` kept** — part of the public `TempoClient` interface; the value-drift (phase string) is documented at the population site.

## Centralized mapping helpers — `src/tui/utils/format.ts`

Three module-scope frozen maps + three thin accessor helpers. No per-frame object allocation (docs/tui-performance.md compliance).

| Helper | Purpose |
|---|---|
| `phaseToLabel(phase?)` | Collapse to user-facing label (`active`/`idle`/`disconnected`/`pending`/`gone`/`unknown`) |
| `phaseToColor(phase?)` | Resolve a THEME color hex (or undefined under NO_COLOR) |
| `phaseToIconName(phase?)` | Map to a `statusIcons()` bucket name |

### Option-B mapping (conductor-confirmed + issue #177)

| Phase | Label | Icon | Color |
|---|---|---|---|
| `attached`, `processing` | active | ● | green |
| `awaiting` | idle | ○ | neutral |
| `detached`, `draining` | disconnected | ◐ | yellow |
| `booting` | pending | ◔ | dim |
| `gone` | gone | ✕ | dim |

## TUI migration (6 files)

- **`src/tui/App.tsx`** — chat-target title (1), picker filter (1), picker items (3). Picker icons resolved once via `statusIcons()` per render pass, then keyed by `phaseToIconName` per item (no per-item object allocation).
- **`src/tui/components/MainView.tsx`** — player-list icon + color via helpers
- **`src/tui/components/StatusBar.tsx`** — counters collapsed to the 4 meaningful buckets (`active`/`idle`/`disconnected`/`pending`); `gone` is terminal and excluded from the summary
- **`src/tui/components/StatusOverlay.tsx`** — deleted local `iconMap`/`colorMap`, replaced with central helpers; `statusIcons()` drives unicode/ASCII fallback
- **`src/tui/components/PlayerDetailView.tsx`** — status line uses phase helpers
- **`src/tui/commands.ts`** — TUI broadcast filter uses label check (`active` or `idle` = talkable), mirroring `shouldIncludeInBroadcast` semantics from #176

## Non-TUI cascades (follow from the field rename)

- **`src/activities/maestro.ts`** — `status: s.phase` → `phase: s.phase`
- **`src/workflows/maestro.ts`** — 3 sites (diff for `status_changed` events in both global + per-ensemble maestros, plus the `COORDINATABLE_PHASES` filter). Deterministic string-rename only; workflow bundle regenerates clean at **1.62 MB** (unchanged from #176).
- **`src/client/index.ts`** — MaestroPlayerInfo population writes `phase` (Strategy 3 fallback). `EnsembleInfo.conductorStatus` still populated, now from `conductor?.phase`.

## Wire protocol

**No breaking changes.**
- No signal/query/update renames.
- `MaestroEvent.type === 'status_changed'` kept — the event is an attachment-phase transition now; name is wire-stable for dashboard consumers.
- `TempoClient.EnsembleInfo.conductorStatus` field kept — value semantics drifted to phase strings in #176 (documented at population site).

## Test updates

- **`test/tui-format.test.ts`** — `formatStatus` tests deleted; new suites for `phaseToLabel`, `phaseToColor`, `phaseToIconName` (18 new assertions). `formatStatus` export removed from `format.ts`.
- **`test/maestro.test.ts`** + **`test/global-maestro.test.ts`** — mocks rewritten to use `phase: 'attached' | 'detached'` instead of legacy `status`; diff-event assertions updated to match.
- **`tests/client/fallback.test.ts`** — `p()` helper signature changed to `phase: AttachmentPhase`; reader assertion updated. **Note**: this is the Vitest `tests/` dir (sibling of Mocha's `test/`) — same trap that caught me in #196. This time grep hit both dirs before push.

## Quality gates

- [x] `npm run build` — clean, workflow bundle **1.62 MB** (unchanged from #176, no unintended include)
- [x] `npm test` — **716 passing / 49 pending / 0 failing** (Mocha) + **76 passed / 3 todo** (Vitest). +9 passing vs. #176 baseline accounts for the new phase-helper tests.
- [x] `grep -rn 'MaestroPlayerInfo.*\.status' src/ test/ tests/` — no stragglers
- [x] Performance review (docs/tui-performance.md): new helpers use module-scope frozen constants; no new `<Box>` Yoga nodes; no animation timers; picker icons resolved once per render pass, not per item; no dispatch-on-keystroke patterns touched

## Commits

- `ce5015b` — the migration (15 files, +223/-101)

## Epic sequencing

1. **#175** — workflow + types + resolver ✅ (merged `bc69966`)
2. **#176** — tools + CLI + client + maestro ✅ (merged `3f581ee7`)
3. **#177 (this PR)** — TUI migration + `MaestroPlayerInfo.phase` rename ✅
4. **#178** — rewrite 18 skipped status-assertion tests against `attachmentInfo.phase`; deregister cluster-side `ClaudeTempoStatus` search attribute at `src/cli/commands.ts:834` and `test/fixtures/multi-host/docker-compose.yml`; update `docs/WIRE-PROTOCOL.md` deprecation markers; consider a CLAUDE.md note on the `test/` (Mocha) vs. `tests/` (Vitest) dir split

🤖 Generated with [Claude Code](https://claude.com/claude-code)