### PR TITLE
docs: v0.26-beta shim-removal tier-1 rewrite + migration guide (#178b) — closes #174

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,96 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [0.26.0-beta.1] - 2026-04-18
+
+> **Beta release.** Completes the #174 legacy-shim removal epic (PRs
+> [#175](https://github.com/vinceblank/claude-tempo/pull/192),
+> [#176](https://github.com/vinceblank/claude-tempo/pull/196),
+> [#177](https://github.com/vinceblank/claude-tempo/pull/197),
+> #178). The attachment-phase lifecycle (shipped in v0.25) is now the
+> single source of lifecycle truth; the compat shim that let adapters
+> migrate at their own pace through v0.25.x is gone.
+>
+> **Upgrade guide:** [`docs/ops/v0.26-migration.md`](docs/ops/v0.26-migration.md).
+>
+> **Install:** `npm i -g claude-tempo@0.26.0-beta.1`
+> **Rollback:** `npm i -g claude-tempo@0.25.0-beta.5`
+
+### BREAKING CHANGES
+
+- **`ClaudeTempoStatus` search attribute removed.** Long-lived Temporal
+  clusters must manually drop the attribute — Temporal does not
+  auto-unregister. See the migration guide for `tcld` / `temporal
+  operator` commands. Lifecycle truth now lives on
+  `ClaudeTempoAttachmentState` (seven-phase values) and the
+  `attachmentInfo` query.
+- **`SessionStatus` TypeScript enum removed** from the public SDK
+  surface. Use `AttachmentPhase` (`booting | attached | processing |
+  awaiting | draining | detached | gone`) for lifecycle-typed code.
+- **`SessionMetadata.status` field removed.** Query `attachmentInfo`
+  on the workflow handle for phase instead.
+- **`EnsembleSessionInfo.status` field removed**; replaced by
+  `EnsembleSessionInfo.phase?: AttachmentPhase`. `scanEnsembleSessions`
+  reads the new field from `ClaudeTempoAttachmentState`.
+- **`MaestroPlayerInfo.status` renamed to `phase?: AttachmentPhase`.**
+  External `TempoClient` consumers reading `player.status` must
+  migrate to `player.phase`.
+- **`BLOCKED_WINDOW_MS` / `SessionStatus` removed** from
+  `src/utils/validation.ts`.
+- **`updateMetadata` signal no longer writes `status`.** The field
+  remains on the signal wire-shape for backward compat (prevents older
+  clients from crashing on schema-mismatch) but has no observable
+  effect — phase transitions happen through the V2 wire surface
+  (`claimAttachment` / `adapterExited` / `forceDetach` /
+  `destroyUpdate`).
+- **Ensemble / CLI / TUI output labels collapsed.** Where v0.25
+  rendered `(stale)` / `(blocked)` / `(pending)` / `(terminated)`
+  tags, v0.26 renders `(pending)` / `(disconnected)` / `(gone)` — the
+  Option-B mapping from the seven underlying phases to five
+  user-facing buckets.
+- **End-to-end upgrade required.** A v0.25 CLI / TUI paired with a
+  v0.26 daemon (or the reverse) is not supported. Upgrade both sides
+  together.
+
+### Removed
+
+- Legacy `_heartbeat` / `_ping` probe messages (the workflow used to
+  inject these after 1 hour of idle) — the adapter `heartbeat` signal
+  is the real liveness channel.
+- 3-minute stale detection heuristic and 5-minute blocked-window
+  heuristic — replaced by adapter lease expiry and
+  `processingDeadline`.
+- `docs/ops/v0.25-beta1-release-checklist.md` — marked as historical
+  / superseded by the v0.26 migration guide.
+- `test/blocked-detection.test.ts` — obsolete (heuristics removed).
+- 9 other shim-era skipped tests (deleted or rewritten against
+  attachment phase assertions).
+
+### Fixed
+
+- **Node 24 CI flake on `test/stages.test.ts`.** Bumped the
+  `retry()` helper's default timeout from 5 s → 10 s to absorb
+  Node 24 scheduler variance; the "completes stage when all players
+  report result" test flaked on first CI run during #196 / #197 and
+  passed on rerun.
+
+### Docs
+
+- New [`docs/ops/v0.26-migration.md`](docs/ops/v0.26-migration.md) —
+  operator-facing migration guide with cluster-side attribute-drop
+  commands, SDK consumer-update checklist, and rollback steps.
+- Rewrote `docs/concepts.md`, `docs/troubleshooting.md`, and
+  `CLAUDE.md` "Attachment phase" section to describe the seven
+  phases in place of the removed `ClaudeTempoStatus`.
+- Added editor's note to `docs/design/session-lifecycle-rebuild-v2.md`
+  marking the design as realized.
+- Added § 11 to
+  `docs/design/session-lifecycle-rebuild-v2-sequencing.md` capturing
+  the PR-H shim-removal ladder (PRs #175–#178).
+- New `CLAUDE.md` callout on the `test/` (Mocha) vs `tests/`
+  (Vitest) directory split — both are first-class test targets and
+  must be grepped together during call-site migrations.
+
 ## [0.25.0-beta.5] - 2026-04-18
 
 > **Beta release.** Three daemon and outbox stability fixes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,12 @@ npm test
 > **Always run `npm run build` after changing workflow code (`src/workflows/`).** The build
 > pre-bundles workflows into `workflow-bundle.js` so all workers use identical code.
 
+> **Two test directories.** Mocha tests live in `test/` (Temporal workflow integration
+> suites, wire-protocol drift detector). Vitest tests live in `tests/` (TUI components,
+> TempoClient fallback paths). Both are first-class targets — when doing call-site
+> surveys or migrations, always grep **both** `test/` and `tests/` or you will miss
+> mocks and assertions that only live in one directory.
+
 See [docs/development.md](docs/development.md) for full setup (Temporal dev server command,
 daemon worker notes, `npx ts-node` dev runner).
 
@@ -106,7 +112,7 @@ daemon worker notes, `npx ts-node` dev runner).
 - **Cue**: A message sent to a player by name via Temporal signal
 - **Part**: A player's description of what it's working on
 - **Outbox**: Outbound requests (cue, report, recruit, restart, detach, destroy, …) go through the session's workflow outbox instead of directly signaling other workflows. The dispatch loop processes entries via activities, decoupling tools from cross-workflow signaling.
-- **Session status**: `pending → active → stale | blocked` (tracked via `ClaudeTempoStatus` search attribute). See [docs/concepts.md](docs/concepts.md) for full status mechanics.
+- **Attachment phase** (v0.26): Seven phases tracked on the session workflow — `booting → attached → processing | awaiting → draining → detached → gone`. The phase is authoritative for lifecycle truth: adapters drive it via `claimAttachment` / `adapterExited` / `forceDetach` / `destroy`, and the workflow publishes it on the `ClaudeTempoAttachmentState` search attribute. Replaced the v0.25 `ClaudeTempoStatus` heuristic (removed in v0.26). See [docs/concepts.md](docs/concepts.md) for the phase table and [docs/ops/v0.26-migration.md](docs/ops/v0.26-migration.md) for the upgrade path.
 - **Per-host task queues**: `host` param on `recruit`/`restart`/`migrate` routes to `claude-tempo-{hostname}` task queue. See [docs/concepts.md](docs/concepts.md) for cross-machine recruiting details.
 - **Wire protocol**: All signal/query/update names are documented in [`docs/WIRE-PROTOCOL.md`](docs/WIRE-PROTOCOL.md) and are stable — renaming or removing any is a breaking change. **Process**: update `docs/WIRE-PROTOCOL.md` in the same commit as any new signal, query, or update.
 - **Daemon**: Standalone background process (`src/daemon.ts`) that runs all Temporal workers. Auto-started by any `claude-tempo` command. PID at `~/.claude-tempo/daemon.pid`; logs at `~/.claude-tempo/daemon.log`.

--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -208,12 +208,17 @@ Workflow updates on a `claudeGlobalMaestroWorkflow` instance (transactional, ret
 
 The following custom Temporal search attributes are written by `claudeSessionWorkflow` and used for session discovery.
 
+> **v0.26-beta breaking change** — `ClaudeTempoStatus` has been removed. Lifecycle truth
+> now lives on `ClaudeTempoAttachmentState` (search attribute) and the `attachmentInfo`
+> query. Operators on long-lived Temporal clusters must manually drop the legacy
+> attribute — Temporal does not auto-unregister search attributes.
+> See [`docs/ops/v0.26-migration.md`](ops/v0.26-migration.md) for the upgrade steps.
+
 | Attribute | Type | Description |
 |-----------|------|-------------|
 | `ClaudeTempoEnsemble` | `Keyword` | Ensemble namespace (from `CLAUDE_TEMPO_ENSEMBLE` env var). Scopes sessions to a named group. |
 | `ClaudeTempoPlayerId` | `Keyword` | Human-readable player name (or hex ID before `set_name` is called). |
 | `ClaudeTempoHostname` | `Keyword` | Hostname of the machine running the session. Used to route spawn activities to the correct per-host task queue. |
-| `ClaudeTempoStatus` | `Keyword` | Session lifecycle state: `pending` → `active` → `stale` \| `blocked` \| `terminated`. `blocked` means the session is alive (delivering messages) but has produced no outbound activity for 5+ minutes — it may be stuck or spinning. Auto-recovers to `active` on next outbound. |
 | `ClaudeTempoGitRoot` | `Keyword` | Absolute path to the git repository root on the session's host. |
 | `ClaudeTempoPlayerType` | `Keyword` | Agent type name (e.g. `tempo-soloist`), set from the player's agent definition. |
 | `ClaudeTempoIsConductor` | `Bool` | `true` for conductor workflows, absent or `false` for regular players. Set via `upsertSearchAttributes` in `claudeSessionWorkflow` at startup and after `continueAsNew`. Enables efficient conductor discovery without scanning all session workflows. |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -12,16 +12,29 @@
 updates the `ClaudeTempoPlayerId` search attribute to a human-readable name. The name is how
 other players address you via `cue`.
 
-**Session status** — Each session tracks a lifecycle status via the `ClaudeTempoStatus` search
-attribute:
+**Attachment phase** (v0.26) — Each session workflow tracks a lifecycle phase via the
+`ClaudeTempoAttachmentState` search attribute. The phase is driven by the adapter lifecycle
+(see `src/adapters/`), not by a polling heuristic:
 
-- `pending` — Workflow pre-created; process not yet connected
-- `active` — Process connected and delivering messages
-- `stale` — Messages have gone undelivered for 3+ minutes (process may be idle or hung)
-- `blocked` — Session is alive (delivering messages) but has produced no response to a
-  `responseRequested: true` message for 5+ minutes. Blocked status auto-recovers to `active`
-  on next outbound. Informational messages (broadcasts, schedule-fires, heartbeats, system
-  notifications) set `responseRequested: false` and do not trigger blocked detection.
+- `booting` — Workflow exists, no adapter has claimed it yet (the state after `recruit`
+  creates the workflow but before the spawned process calls `claimAttachment`)
+- `attached` — An adapter holds a valid attachment and is idle-ready
+- `processing` — Attached AND at least one inbound message is in-flight in the adapter
+  (set via `processingStart` update; cleared via `processingEnd`)
+- `awaiting` — Attached, idle, outbox empty (presentation refinement of `attached`)
+- `draining` — Attachment requested detach; flushing outbox and awaiting `adapterExited`
+- `detached` — Workflow RUNNING, no attachment; outbox dispatch paused (`stop`/`destroy` bypass)
+- `gone` — Terminal; workflow COMPLETES after `destroy`
+
+Phase transitions are deterministic and recorded as workflow history events. External
+observers (the TUI, the CLI `ensemble` tool, the Maestro dashboard, the daemon
+`reconcileOnBoot` path) read the current phase from `ClaudeTempoAttachmentState` or the
+`attachmentInfo` query — both are authoritative.
+
+> **Historical note** — Before v0.26, sessions carried a `ClaudeTempoStatus` search attribute
+> with values `pending | active | stale | blocked | terminated`, driven by a 3-min stale and
+> 5-min blocked heuristic. That shim was removed in v0.26 (#174–#178 epic). See
+> [`docs/ops/v0.26-migration.md`](ops/v0.26-migration.md) for the upgrade path.
 
 ---
 

--- a/docs/design/session-lifecycle-rebuild-v2-sequencing.md
+++ b/docs/design/session-lifecycle-rebuild-v2-sequencing.md
@@ -436,4 +436,25 @@ Decisions recorded here so the implementing engineer has a single source of trut
 
 ---
 
+## 11. PR-H: Legacy shim removal (v0.26-beta, post-GA cleanup)
+
+Between v0.25.0 GA and v0.26-beta, the legacy `SessionStatus` / `ClaudeTempoStatus` /
+`BLOCKED_WINDOW_MS` shim was held in place so adapters could migrate at their own pace.
+The shim was removed in a four-PR epic (#174 parent) after the attachment-phase lifecycle
+had soaked for a full beta cycle:
+
+| PR | Scope | Commit |
+|----|-------|--------|
+| **#175** | workflow + types + resolver: delete `SessionStatus` enum, `ClaudeTempoStatus` writes, `BLOCKED_WINDOW_MS` heuristic, `_heartbeat`/`_ping` probe; add `phase` read in resolver. Keep `SessionMetadata.status?: string` / `EnsembleSessionInfo.status?: string` as vestigial Option-B bridges. | `bc69966` |
+| **#176** | tools + CLI + client + maestro: delete the two vestigial `status` fields, migrate every consumer to attachment phase (tags via Option-B bucket collapse). Leave `MaestroPlayerInfo.status?: string` as last vestigial bridge for TUI. | `3f581ee7` |
+| **#177** | TUI migration: introduce central `phaseToLabel` / `phaseToColor` / `phaseToIconName` helpers (module-scope frozen maps — zero per-frame allocation per `tui-performance.md`). Rename `MaestroPlayerInfo.status?: string` → `phase?: AttachmentPhase` with cascading rename through maestro activity + workflow + client. | `9008763e` |
+| **#178** | Tests + docs cleanup: delete `blocked-detection.test.ts`; rewrite 5 tests against `attachmentInfo.phase` / `ClaudeTempoAttachmentState` search attr; delete dead exports; deregister `ClaudeTempoStatus` from the daemon, docker-compose, and test helpers; update tier-1 docs; create `docs/ops/v0.26-migration.md`. | _this PR_ |
+
+All `patched()` markers preserved across the ladder — no workflow-replay breaking changes.
+The wire protocol (signals / queries / updates) was unaffected; `ClaudeTempoStatus` is a
+search attribute and its removal is an operator-visible cluster change rather than an MCP
+wire break. See `docs/ops/v0.26-migration.md` for the migration path.
+
+---
+
 **End of sequencing memo.**

--- a/docs/design/session-lifecycle-rebuild-v2.md
+++ b/docs/design/session-lifecycle-rebuild-v2.md
@@ -1,5 +1,14 @@
 # Session Lifecycle & Multi-Host Architecture — Rebuild v2
 
+> **Editor's note (2026-04-18, v0.26-beta):** This design is now fully realized in code.
+> The legacy `ClaudeTempoStatus` / `SessionStatus` shim that the rebuild ladder left in
+> place for migration compatibility was removed in the **#174–#178 shim-removal epic**
+> (PRs #175, #176, #177, #178). Attachment phase (`ClaudeTempoAttachmentState`) is the
+> single source of lifecycle truth. The sections below describe the target state; where
+> they reference the legacy shim, read them as "historical context" for the v0.25
+> transition window. See [`docs/ops/v0.26-migration.md`](../ops/v0.26-migration.md) for
+> the operator upgrade path.
+
 > **Status**: Design proposal (v2, revision of Rebuild B after panel review)
 > **Author**: tempo-architect-2
 > **Branch**: `design/session-rebuild-v2`

--- a/docs/development.md
+++ b/docs/development.md
@@ -21,7 +21,6 @@ temporal server start-dev \
   --search-attribute ClaudeTempoEnsemble=Keyword \
   --search-attribute ClaudeTempoPlayerId=Keyword \
   --search-attribute ClaudeTempoHostname=Keyword \
-  --search-attribute ClaudeTempoStatus=Keyword \
   --search-attribute ClaudeTempoGitRoot=Keyword \
   --search-attribute ClaudeTempoPlayerType=Keyword \
   --search-attribute ClaudeTempoIsConductor=Bool \
@@ -29,6 +28,9 @@ temporal server start-dev \
   --search-attribute ClaudeTempoAttachmentState=Keyword \
   --search-attribute ClaudeTempoAttachmentId=Keyword
 ```
+
+> `ClaudeTempoStatus` was removed in v0.26. If you're upgrading a long-lived cluster,
+> see [`docs/ops/v0.26-migration.md`](ops/v0.26-migration.md) for the operator-side drop.
 
 > **Note**: The `claude-tempo up` CLI command handles this automatically for production use.
 > The manual command above is the fallback for development environments where you want

--- a/docs/ops/v0.25-beta1-release-checklist.md
+++ b/docs/ops/v0.25-beta1-release-checklist.md
@@ -1,8 +1,13 @@
 # Ops Runbook — v0.25.0-beta.1 Release Checklist
 
-> **Owner:** tempo-devops  
-> **Status:** Pre-prep (PRs C–G not yet merged — this is a living document)  
-> **Reference:** `docs/design/session-lifecycle-rebuild-v2-sequencing.md` §10  
+> **Superseded by v0.26** — this checklist targets the v0.25 release shape, which still
+> referenced the legacy `ClaudeTempoStatus` search attribute. For upgrades **to v0.26+**,
+> see [`./v0.26-migration.md`](v0.26-migration.md) which includes the operator-side drop
+> of `ClaudeTempoStatus` and the breaking-change call-outs.
+>
+> **Owner:** tempo-devops
+> **Status:** Historical — kept for v0.25 → v0.25.x upgrades.
+> **Reference:** `docs/design/session-lifecycle-rebuild-v2-sequencing.md` §10
 > **Last updated:** 2026-04-12
 
 ---
@@ -131,12 +136,12 @@ temporal operator search-attribute create --namespace <PROD_NS> --name ClaudeTem
 temporal operator search-attribute list --namespace <PROD_NS> | grep ClaudeTempo
 ```
 
-Expected output (10 rows):
+Expected output (10 rows — as of v0.25; **v0.26 drops `ClaudeTempoStatus`**, reducing to 9):
 ```
 ClaudeTempoEnsemble         Keyword
 ClaudeTempoPlayerId         Keyword
 ClaudeTempoHostname         Keyword
-ClaudeTempoStatus           Keyword
+ClaudeTempoStatus           Keyword   # removed in v0.26 — see v0.26-migration.md
 ClaudeTempoGitRoot          Keyword
 ClaudeTempoPlayerType       Keyword
 ClaudeTempoIsConductor      Bool

--- a/docs/ops/v0.25-search-attribute-registration.md
+++ b/docs/ops/v0.25-search-attribute-registration.md
@@ -166,7 +166,6 @@ temporal server start-dev \
   --search-attribute ClaudeTempoEnsemble=Keyword \
   --search-attribute ClaudeTempoPlayerId=Keyword \
   --search-attribute ClaudeTempoHostname=Keyword \
-  --search-attribute ClaudeTempoStatus=Keyword \
   --search-attribute ClaudeTempoGitRoot=Keyword \
   --search-attribute ClaudeTempoPlayerType=Keyword \
   --search-attribute ClaudeTempoIsConductor=Bool \
@@ -175,7 +174,13 @@ temporal server start-dev \
   --search-attribute ClaudeTempoAttachmentId=Keyword
 ```
 
-The three new attributes are the last three lines. This command is the full set as of v0.25.
+The three attachment-lifecycle attributes are the last three lines. This command is the
+full set as of v0.26.
+
+> **v0.26 retirement note** — `ClaudeTempoStatus` was removed in v0.26 (#174–#178 shim
+> removal epic). The `--search-attribute ClaudeTempoStatus=Keyword` line is no longer
+> needed; upgrading clusters must manually drop the attribute. See
+> [`./v0.26-migration.md`](v0.26-migration.md).
 
 ---
 

--- a/docs/ops/v0.26-migration.md
+++ b/docs/ops/v0.26-migration.md
@@ -1,0 +1,219 @@
+# v0.26-beta Migration Guide
+
+> **Audience**: operators upgrading an existing claude-tempo deployment from v0.25.x
+> to v0.26.0-beta.1 or later. If you're starting fresh, ignore this file — the
+> `claude-tempo up` command registers the current search-attribute set automatically.
+>
+> **Epic reference**: #174 (parent). Four-PR ladder: #175, #176, #177, #178.
+
+---
+
+## TL;DR — Three things you need to know
+
+1. **Breaking search-attribute change.** `ClaudeTempoStatus` is removed. Long-lived
+   Temporal clusters must manually drop it — Temporal does not auto-unregister
+   search attributes.
+2. **Breaking SDK-type change.** `SessionStatus`, `SessionMetadata.status`,
+   `EnsembleSessionInfo.status`, and `MaestroPlayerInfo.status` are removed or
+   renamed. External consumers of `TempoClient` that read those fields need updates
+   (see the consumer section below).
+3. **End-to-end upgrade required.** An older CLI/TUI paired with a v0.26 daemon — or
+   an older daemon with a v0.26 CLI/TUI — is **not supported**. Upgrade both sides
+   together.
+
+---
+
+## What changed
+
+The #174 shim-removal epic finished the v0.25 attachment-phase lifecycle migration.
+The legacy lifecycle model — sessions tracked a `status` field (`pending` → `active`
+→ `stale | blocked | terminated`) driven by a 3-min stale and 5-min blocked heuristic
+— was held in place through v0.25.x as a compatibility shim. v0.26-beta removes it.
+
+### Removed surface
+
+| Removed | Replaced by |
+|---|---|
+| `ClaudeTempoStatus` search attribute | `ClaudeTempoAttachmentState` (seven-phase values) |
+| `SessionStatus` TypeScript enum | `AttachmentPhase` type (`booting | attached | processing | awaiting | draining | detached | gone`) |
+| `SessionMetadata.status` field | `attachmentInfo` query on the workflow |
+| `EnsembleSessionInfo.status` field | `EnsembleSessionInfo.phase?: AttachmentPhase` |
+| `MaestroPlayerInfo.status` (rename) | `MaestroPlayerInfo.phase?: AttachmentPhase` |
+| `BLOCKED_WINDOW_MS` export | *no replacement — heuristic deleted* |
+| `_heartbeat` / `_ping` internal probe messages | adapter `heartbeat` signal (v0.25) |
+| 3-min stale / 5-min blocked heuristics | lease-expiry + `processingDeadline` (adapter-driven) |
+
+### Ensemble tool output
+
+`ensemble` and `claude-tempo status` now render **five** user-facing labels (collapsed
+from the seven underlying phases per the Option-B mapping locked in #176 / #177):
+
+| Label | Underlying phases | Color |
+|---|---|---|
+| `active` | `attached`, `processing` | green |
+| `idle` | `awaiting` | neutral |
+| `disconnected` | `draining`, `detached` | yellow |
+| `pending` | `booting` | dim |
+| `gone` | `gone` | dim |
+
+Where you previously saw `(stale)` or `(blocked)` tags, you now see `(disconnected)`.
+Where you previously saw `(pending)`, the tag is unchanged but the underlying phase
+is `booting`. Where you previously saw `(terminated)`, the tag is now `(gone)`.
+
+### TUI status chips
+
+The TUI's `StatusBar` summary collapses to the same five labels. `gone` sessions are
+excluded from the bar's breakdown (they're terminal, not part of the working
+ensemble); the `PlayerDetailView` still shows `gone` if you drill in on a session.
+
+---
+
+## Upgrade steps
+
+### 1. Upgrade the daemon and CLI together
+
+```bash
+npm install -g claude-tempo@0.26.0-beta.1
+```
+
+Stop any running daemon **before** upgrading — the workflow bundle changed, and a
+mixed-version fleet will fail on replay:
+
+```bash
+claude-tempo daemon stop
+# verify:
+claude-tempo daemon status
+# then upgrade, then:
+claude-tempo up
+```
+
+### 2. Drop the legacy search attribute from your Temporal cluster
+
+Temporal does **not** auto-unregister search attributes. You need to drop
+`ClaudeTempoStatus` by hand once — new session workflows won't write to it, but old
+workflow histories will still reference it, and the attribute itself will linger
+unless you remove it.
+
+**Temporal Cloud** — drop via the cloud admin UI or `tcld`:
+
+```bash
+tcld namespace search-attributes remove \
+  --namespace <YOUR_NAMESPACE> \
+  --sa ClaudeTempoStatus
+```
+
+**Self-hosted Temporal (OSS)** — use the `temporal operator` CLI:
+
+```bash
+temporal operator search-attribute remove \
+  --namespace <YOUR_NAMESPACE> \
+  --name ClaudeTempoStatus
+```
+
+**Dev server / fixtures** — rebuild. The `claude-tempo up` command no longer
+registers `ClaudeTempoStatus`, and the `test/fixtures/multi-host/docker-compose.yml`
+fixture has been updated. Bring the fixture down and up:
+
+```bash
+docker compose -f test/fixtures/multi-host/docker-compose.yml down
+docker compose -f test/fixtures/multi-host/docker-compose.yml up -d
+```
+
+### 3. Verify
+
+```bash
+# Attribute is gone:
+temporal operator search-attribute list --namespace <YOUR_NAMESPACE> | grep ClaudeTempo
+# Expected: 9 rows (previously 10). No `ClaudeTempoStatus` line.
+
+# Sessions expose phase via the new search attr:
+temporal workflow list --namespace <YOUR_NAMESPACE> \
+  --query 'WorkflowType = "claudeSessionWorkflow" AND ExecutionStatus = "Running"' \
+  --fields long | grep ClaudeTempoAttachmentState
+
+# CLI renders phase-based tags:
+claude-tempo status
+```
+
+### 4. Update external TempoClient consumers (if any)
+
+If you have code importing from `claude-tempo`, check for:
+
+```ts
+// Remove — types no longer exported:
+import type { SessionStatus } from 'claude-tempo';
+```
+
+```ts
+// Update reads:
+session.status        // → session.phase (on MaestroPlayerInfo / EnsembleSessionInfo)
+metadata.status       // → (removed — query `attachmentInfo` for phase)
+```
+
+```ts
+// Field rename on MaestroPlayerInfo (v0.26):
+player.status   // → player.phase
+```
+
+The `TempoClient.EnsembleInfo.conductorStatus` field name is **kept** for public API
+compatibility, but its value is now an `AttachmentPhase` string instead of a legacy
+`SessionStatus` string.
+
+---
+
+## Rollback plan
+
+If v0.26-beta surfaces blockers, roll the CLI and daemon back together:
+
+```bash
+claude-tempo daemon stop
+npm install -g claude-tempo@0.25.1  # last shim-era release
+claude-tempo up
+```
+
+You do **not** need to re-register `ClaudeTempoStatus` on your Temporal cluster.
+Older daemon versions will not write to it; new session workflows on the rolled-back
+version will still omit it (the rollback daemon shares the same post-removal
+workflow bundle). Only re-register if you need to inspect old workflow histories via
+the Temporal UI's search-attribute filter.
+
+---
+
+## FAQ
+
+**Do I need to destroy running sessions before upgrading?**
+No. The workflow itself is forward-compatible — `patched()` markers are preserved
+across the entire #174 epic, so running sessions replay cleanly on the new bundle.
+What you **must** do is stop the daemon before upgrading so the old and new bundles
+don't collide on the same task queue.
+
+**My `ensemble` output shows `(disconnected)` for a session I expect to be
+live — what changed?**
+`(disconnected)` maps to the `draining` or `detached` phase. The session is alive
+(its workflow is still running) but either no adapter has claimed it, or the
+adapter is in the middle of detaching. In v0.25 this bucket was split across
+`(stale)` (3-min undelivered messages) and `(blocked)` (5-min no-response). The
+underlying behavior of the adapter hasn't changed; the label is more accurate now.
+
+**A session is stuck in `booting` — is that a bug?**
+`booting` means the workflow exists but no adapter has called `claimAttachment`
+yet. On a successful `recruit`, you'd expect the adapter to claim within a few
+seconds (the terminal or Copilot bridge has to launch and connect). If it stays
+there for more than ~30 seconds, the spawn likely failed — check
+`~/.claude-tempo/daemon.log` for the `spawnProcess` activity result.
+
+**Why is `gone` counted separately from `disconnected`?**
+`gone` is terminal — the workflow has completed after `destroy`. `disconnected`
+(`draining` / `detached`) is alive — the workflow is still running and waiting for
+a fresh `claimAttachment`. Restart / migrate on a `gone` session is an error; on a
+`detached` session it's the happy path.
+
+---
+
+## Related
+
+- Epic issue: [#174](https://github.com/vinceblank/claude-tempo/issues/174)
+- Design: [`docs/design/session-lifecycle-rebuild-v2.md`](../design/session-lifecycle-rebuild-v2.md)
+- Sequencing memo: [`docs/design/session-lifecycle-rebuild-v2-sequencing.md`](../design/session-lifecycle-rebuild-v2-sequencing.md) §11
+- Concepts glossary: [`docs/concepts.md`](../concepts.md) § "Attachment phase"
+- Wire protocol: [`docs/WIRE-PROTOCOL.md`](../WIRE-PROTOCOL.md) § "Search Attributes"

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,30 +12,41 @@
 
 When a session crashes or closes without graceful shutdown, Temporal detects it automatically:
 
-- If a message to a dead session remains undelivered for **3 minutes**, the workflow self-completes
-- Before exiting, it notifies the conductor with the undelivered message so work can be reassigned
-- Idle sessions with no pending messages are probed after 1 hour of inactivity via a heartbeat ping; if the ping goes undelivered, the session self-completes
+Liveness is now tracked via the attachment-phase lifecycle (see below) instead of the
+pre-v0.26 time-based heuristics (3-min stale, 5-min blocked). The adapter itself reports
+liveness to the workflow via the `heartbeat` signal; the workflow reaps the attachment
+if the lease expires. No message is force-undelivered or auto-re-routed — sessions that
+lose their adapter transition to `detached` and wait for a fresh `claimAttachment`.
 
-No manual cleanup needed — `cue` a dead player and the system handles the rest.
+## Attachment Phase Lifecycle (v0.26+)
 
-## Session Status Lifecycle
+Each session workflow has an attachment phase tracked on the `ClaudeTempoAttachmentState`
+search attribute and returned by the `attachmentInfo` query. The five user-facing buckets
+the CLI and TUI render are derived from the seven underlying phases:
 
-Each session has a status that tracks its connection state:
+| Label | Phases | When you see it |
+|-------|--------|-----------------|
+| `active` (green) | `attached`, `processing` | Session is connected and responsive |
+| `idle` (neutral) | `awaiting` | Attached, no work in flight, outbox drained |
+| `pending` (dim) | `booting` | Workflow created, adapter hasn't claimed yet |
+| `disconnected` (yellow) | `draining`, `detached` | Attachment reaped or in the middle of detaching; session is alive but unreachable until a fresh `claimAttachment` |
+| `gone` (gray) | `gone` | Terminal — `destroy` has run, workflow is complete |
 
-| Status | Meaning |
-|--------|---------|
-| `pending` | Workflow created by `recruit`, but the Claude Code process hasn't connected yet |
-| `active` | Session is running and responsive |
-| `stale` | Messages have gone undelivered for 3+ minutes — the session is likely disconnected |
-| `blocked` | Messages are being delivered but the session has produced no outbound activity for 5+ minutes — it may be stuck or spinning |
+Phase transitions are deterministic and adapter-driven:
+- **`booting → attached`** on first `claimAttachment` from the spawned adapter
+- **`attached → processing`** on `processingStart` update (blocking LLM/tool call)
+- **`processing → attached`** (or `awaiting`) on `processingEnd`
+- **`attached → draining`** on `requestDetach` signal (graceful reap)
+- **`draining → detached`** on `adapterExited` signal or `drainingDeadline` timeout
+- **`detached → attached`** on a fresh `claimAttachment` (restart / migrate / recovery)
+- **any → `gone`** on `destroyUpdate`
 
-Status transitions:
-- **`pending` → `active`** — when the spawned session connects and sends its `updateMetadata` signal
-- **`active` → `stale`** — when undelivered messages exceed the stale threshold (3 minutes)
-- **`active` → `blocked`** — when delivered messages produce no outbound response for 5+ minutes; auto-recovers to `active` on next outbound activity
-- Any status → **terminated** — on graceful shutdown or `stop`
+`claude-tempo status` shows `(pending)` / `(disconnected)` / `(gone)` labels next to player
+names. Filter sessions in the Temporal UI via `ClaudeTempoAttachmentState = "detached"`.
 
-`claude-tempo status` shows `(pending)` and `(stale)` indicators next to player names. The `ClaudeTempoStatus` search attribute is also set, so you can filter sessions by status in the Temporal UI (e.g., `ClaudeTempoStatus = "stale"`).
+> **Historical** — The pre-v0.26 `ClaudeTempoStatus` attribute (values `pending | active |
+> stale | blocked | terminated`) was removed in v0.26. See
+> [`docs/ops/v0.26-migration.md`](ops/v0.26-migration.md) for the operator upgrade path.
 
 ## Known Limitations
 


### PR DESCRIPTION
## Summary

Fourth PR in the beta.6 legacy shim-removal epic, **part 2 of 2** (parent #174, priors #175 / #176 / #177 merged; **178a** pending as PR #198). 178b is **docs-only** — 178a already shipped the test cleanup + cluster dereg + flake fix.

**Closes #174** when both 178a and 178b merge.

## Tier-1 docs rewritten

| File | Change |
|---|---|
| `CLAUDE.md` | "Session status" key-concept bullet → "Attachment phase (v0.26)" with seven-phase list + migration-guide pointer. Added `test/` (Mocha) vs `tests/` (Vitest) directory-split callout (bit me + QA during #196/#197). |
| `docs/concepts.md` | "Session status" glossary entry replaced with "Attachment phase"; seven phases, phase-transition triggers, authoritative sources. |
| `docs/troubleshooting.md` | "Session Status Lifecycle" section rewritten for Option-B five-label mapping + deterministic phase transitions; dead-messages/retry sections updated for adapter-driven liveness. |
| `docs/WIRE-PROTOCOL.md` | Added v0.26 breaking-change header note to "Search Attributes" section (`ClaudeTempoStatus` row was already deleted in 178a to unblock the drift detector test). |

## Legacy lines removed / retirement-noted

- `docs/development.md` — dropped `ClaudeTempoStatus=Keyword` from the `temporal server start-dev` command, added migration pointer.
- `docs/ops/v0.25-search-attribute-registration.md` — same; added v0.26 retirement note at the bottom.
- `docs/ops/v0.25-beta1-release-checklist.md` — marked as historical / superseded; annotated the 10-row expected-output block with the `ClaudeTempoStatus` removal callout.

## Design docs (dated editor's notes)

- `docs/design/session-lifecycle-rebuild-v2.md` — top-of-file editor's note marking the design as realized; pointer to migration guide. **Body preserved verbatim** so readers of the v0.25 history see it unchanged.
- `docs/design/session-lifecycle-rebuild-v2-sequencing.md` — new **§ 11 "PR-H: Legacy shim removal (v0.26-beta, post-GA cleanup)"** with the #175 / #176 / #177 / #178 ladder table + commit references.

## New file

**`docs/ops/v0.26-migration.md`** — operator-facing migration guide. Covers:

- **Breaking-change TL;DR** (3 bullets — search attr, SDK types, end-to-end upgrade)
- **What changed** — removed surface table + ensemble/TUI label collapse + Option-B label→phase mapping
- **Upgrade steps** — CLI/daemon co-upgrade, `tcld` + `temporal operator` cluster-side attribute drop, Docker-fixture rebuild, verification commands
- **SDK consumer migration** — `SessionStatus` import removal, `.status → .phase` field renames
- **Rollback plan** — CLI/daemon co-rollback to `0.25.1`, attribute re-registration notes
- **FAQ** — destroying running sessions upgrade-safety, `(disconnected)` label reading, `booting` diagnostic, `gone` vs `disconnected` semantic

## CHANGELOG

New `v0.26.0-beta.1` section with:

- `### BREAKING CHANGES` — search attribute removal, SDK type surface changes, field renames, label collapse, end-to-end upgrade requirement, `updateMetadata.status` wire-shape preservation (no-op)
- `### Removed` — heuristic probe messages, stale/blocked windows, deprecated v0.25 checklist, `blocked-detection.test.ts`, 9 other shim-era tests
- `### Fixed` — Node 24 `retry()` flake fix (178a)
- `### Docs` — cross-references to the 5 rewritten files + the new migration guide

**Historical entries unchanged** (per dispatch).

## Ordering note

178b is based on `main` (`9008763`), **not stacked on 178a**. When 178a merges first, 178b will rebase cleanly — the `WIRE-PROTOCOL.md` row deletion is idempotent (both PRs remove the same row), and all other files are independent.

## Quality gates

- **Docs-only** — `npm run build` and `npm test` are no-ops (no code files touched). Intentional — 178a validated the build + test surface end-to-end.
- Internal doc-doc links verified manually; `docs/ops/v0.26-migration.md` is the central hub linked from all rewritten pages.

## Commits

- `f098b92` — the rewrite + migration guide (11 files, +430/-44 including new `v0.26-migration.md`)

## Epic close-out

1. **#175** — workflow + types + resolver ✅ (merged `bc69966`)
2. **#176** — tools + CLI + client + maestro ✅ (merged `3f581ee7`)
3. **#177** — TUI migration + `MaestroPlayerInfo.phase` rename ✅ (merged `9008763e`)
4. **#178a** — tests + cluster dereg + flake fix (PR #198, pending review)
5. **#178b (this PR)** — tier-1 docs + v0.26 migration guide + CHANGELOG

Once both 178a and 178b merge, parent #174 closes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)