### PR TITLE
chore: release v0.26.0-beta.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-tempo",
-  "version": "0.25.0-beta.4",
+  "version": "0.26.0-beta.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-tempo",
-      "version": "0.25.0-beta.4",
+      "version": "0.26.0-beta.1",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.25.0-beta.5",
+  "version": "0.26.0-beta.1",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## v0.26.0-beta.1 — Shim-removal epic (#174) complete

Completes the five-PR ladder that strips the legacy `ClaudeTempoStatus` / `SessionStatus` compat shim introduced in v0.25. The attachment-phase lifecycle is now the single source of lifecycle truth.

### Included PRs
| PR | Scope |
|----|-------|
| #192 (`bc69966`) | #175 — Remove `SessionStatus` enum + shim from core workflow |
| #196 (`3f581ee7`) | #176 — Migrate ensemble/CLI/client off status shim |
| #197 (`9008763e`) | #177 — Migrate TUI off status shim |
| #198 (`f258be03`) | #178a — Remove `ClaudeTempoStatus` shim tests + cluster registration |
| #199 (`0b111f29`) | #178b — Docs/migration guide tier-1 rewrite; closes #174 |

### Breaking changes (summary)
- **`ClaudeTempoStatus` Temporal search attribute removed** — long-lived clusters must manually drop it (`tcld` / `temporal operator`). See migration guide.
- `SessionStatus` TypeScript enum removed → use `AttachmentPhase`
- `SessionMetadata.status`, `EnsembleSessionInfo.status`, `MaestroPlayerInfo.status` fields removed/renamed
- `BLOCKED_WINDOW_MS` heuristic removed
- `updateMetadata` signal no longer writes `status`
- **End-to-end upgrade required** — v0.25 CLI + v0.26 daemon (or reverse) is not supported

**Full upgrade guide:** [`docs/ops/v0.26-migration.md`](docs/ops/v0.26-migration.md)  
**Epic tracking:** #174

### Version bump
`0.25.0-beta.5` → `0.26.0-beta.1` (minor bump per semver — breaking changes to public SDK surface)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)