### PR TITLE
fix(test): wait for visibility on integration scenarios

### DIFF
--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -9,7 +9,6 @@ import {
   sendMessage,
   playerMetadata,
   conductorMetadata,
-  listEnsemble,
   waitForEnsembleMembers,
   resolveByName,
   isConductorRunning,
@@ -186,7 +185,7 @@ describe('multi-session integration', function () {
         });
 
         // 4. Verify both sessions are visible in the ensemble
-        const members = await listEnsemble(getClient(), ensemble);
+        const members = await waitForEnsembleMembers(getClient(), ensemble, 2);
         expect(members).to.have.lengthOf(2);
 
         const conductor = members.find((m) => m.isConductor);
@@ -285,7 +284,7 @@ describe('multi-session integration', function () {
         await handles[2].signal(setPartSignal, 'Configuring Terraform');
 
         // List and verify
-        const members = await listEnsemble(getClient(), ensemble);
+        const members = await waitForEnsembleMembers(getClient(), ensemble, 3);
         expect(members).to.have.lengthOf(3);
 
         // Verify each can be resolved and has correct part
@@ -375,7 +374,7 @@ describe('multi-session integration', function () {
         expect(deliveredMsg!.delivered).to.be.true;
 
         // 5. Verify the resumed session is visible in ensemble
-        const members = await listEnsemble(getClient(), ensemble);
+        const members = await waitForEnsembleMembers(getClient(), ensemble, 1);
         const conductor = members.find((m) => m.isConductor);
         expect(conductor).to.exist;
 
@@ -530,7 +529,7 @@ describe('multi-session integration', function () {
         await hCond.signal(setNameSignal, 'lead');
 
         // All three should still be visible
-        const members = await listEnsemble(getClient(), ensemble);
+        const members = await waitForEnsembleMembers(getClient(), ensemble, 3);
         expect(members).to.have.lengthOf(3);
 
         const cond = members.find((m) => m.isConductor);


### PR DESCRIPTION
## Summary

Temporal's visibility store is eventually consistent. After starting or
resuming sessions, `listEnsemble` may not immediately return all members,
causing flakes on the Node 22 CI matrix.

Same family as [#190](https://github.com/vinceblank/claude-tempo/issues/190)
(pipeline-stages flake hardening).

## Scope

Scanned `test/` and `tests/` for unprotected `listEnsemble` call sites that
assert "members present." Found **four** in `integration.test.ts`:

| Line | Scenario | Expected count |
|---:|---|---:|
| 189 | Scenario 1 — conductor + player visible | 2 |
| 288 | Three-player ensemble with parts | 3 |
| 378 | Conductor resume — asserts conductor visible | 1 |
| 533 | Three-player ensemble with conductor rename | 3 |

All four flipped to `waitForEnsembleMembers(..., expectedCount)` — the
same helper already used at six other sites in this file (56, 75, 96,
123, 466, 496). Removed now-unused `listEnsemble` import.

Defensive `expect(...lengthOf(n))` assertions kept intact — matches the
convention at the existing protected sites.

## Diff

```
 test/integration.test.ts | 9 ++++-----
 1 file changed, 4 insertions(+), 5 deletions(-)
```

No production code touched. No workflow bundle change.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 724 Mocha passing, 76 Vitest passing, 0 failing (5m local)
- [ ] CI green on PR