### PR TITLE
ci!: drop Node 18 from CI matrix (minimum Node 20 per core-bridge 1.15.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20, 22, 24]
+        node-version: [20, 22, 24]
 
     steps:
       - uses: actions/checkout@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/),
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### BREAKING CHANGES
+
+- **Dropped Node 18 support.** Minimum is now Node 20.
+  `@temporalio/core-bridge` 1.15.0 already required Node 20 at runtime
+  (its `engines.node` is `">= 20.0.0"`); the Node 18 CI job only passed
+  because npm's engines field is advisory. This change aligns the
+  declared supported surface with reality and removes the unsupported
+  matrix slot, saving ~6 min per CI run. Users still on Node 18 must
+  upgrade to Node 20 LTS (or later) before installing claude-tempo.
+
 ## [0.26.0-beta.1] - 2026-04-18
 
 > **Beta release.** Completes the #174 legacy-shim removal epic (PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ claude-tempo is an MCP server that enables multiple Claude Code sessions to coor
 
 ## Tech Stack
 
-- **Runtime**: Node.js 18+ with TypeScript
+- **Runtime**: Node.js 20+ with TypeScript
 - **MCP**: `@modelcontextprotocol/sdk` (stdio transport)
 - **Temporal**: `@temporalio/client`, `@temporalio/worker`, `@temporalio/workflow`, `@temporalio/activity`
 - **croner** — cron expression parsing and next-fire computation (used by `schedule` tool)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to claude-tempo! This guide will hel
 
 ### Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - A running [Temporal](https://temporal.io/) dev server
 
 ### Getting Started

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Each session registers as a **player** in Temporal. Players discover each other 
 npm install -g claude-tempo
 ```
 
-**Prerequisites**: [Node.js](https://nodejs.org/) 20 LTS, 22 LTS, or 24 LTS (18+ minimum), [Temporal CLI](https://docs.temporal.io/cli), [Claude Code](https://claude.ai/code)
+**Prerequisites**: [Node.js](https://nodejs.org/) 20 LTS, 22 LTS, or 24 LTS, [Temporal CLI](https://docs.temporal.io/cli), [Claude Code](https://claude.ai/code)
 
 ## Quick Start
 

--- a/docs/copilot.md
+++ b/docs/copilot.md
@@ -54,7 +54,7 @@ COPILOT_BRIDGE_MODEL=gpt-4o claude-tempo start myband --agent copilot
 - Headless only — bridge sessions respond to cues, no interactive terminal
 - ~2-second polling latency (vs instant for Claude Code sessions)
 - `@github/copilot-sdk` adds ~243MB to node_modules
-- Node 20+ required (rest of claude-tempo works on Node 18+)
+- Node 20+ required
 
 ## Related
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-- Node.js 18+
+- Node.js 20+
 - A running Temporal server (see below)
 
 ## Install

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "README.md"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "license": "MIT",
   "trustedDependencies": [

--- a/src/cli/preflight.ts
+++ b/src/cli/preflight.ts
@@ -31,9 +31,9 @@ export async function runPreflight(opts: CliOverrides & {
 
   // 1. Node.js version
   const major = parseInt(process.version.slice(1), 10);
-  const nodeOk = major >= 18;
-  out.check('Node.js >= 18', nodeOk, process.version);
-  if (!nodeOk) errors.push(`Node.js 18+ required, found ${process.version}`);
+  const nodeOk = major >= 20;
+  out.check('Node.js >= 20', nodeOk, process.version);
+  if (!nodeOk) errors.push(`Node.js 20+ required, found ${process.version}`);
 
   // 2. Temporal reachable
   let temporalOk = false;


### PR DESCRIPTION
## Summary

Drops Node 18 from the CI matrix and raises the declared minimum Node to 20.

`@temporalio/core-bridge` 1.15.0 declares `engines: { node: ">= 20.0.0" }`.
Our Node 18 CI job only passed because npm's `engines` field is advisory at
install time — not a runtime guarantee. This PR aligns the **declared**
supported surface with the **actual** runtime requirement.

Related follow-up: #191 (shared Temporal env across test suites — further CI
speedup).

## BREAKING CHANGE

Node 18 is no longer supported. Users must upgrade to Node 20 LTS or later
before installing claude-tempo.

CHANGELOG BREAKING entry added under `[Unreleased]`.

## Changes

| File | Change |
|---|---|
| `.github/workflows/ci.yml` | matrix `[18, 20, 22, 24]` → `[20, 22, 24]` |
| `package.json` | `engines.node`: `">=18"` → `">=20"` |
| `src/cli/preflight.ts` | Node version gate + check label + error message: 18 → 20 |
| `CHANGELOG.md` | New `[Unreleased]` section with BREAKING entry |
| `CLAUDE.md`, `CONTRIBUTING.md`, `docs/development.md` | "Node.js 18+" → "Node.js 20+" |
| `docs/copilot.md` | Dropped now-false parenthetical "(rest of claude-tempo works on Node 18+)" |
| `README.md` | Dropped "(18+ minimum)" qualifier from prereqs |

Total: 9 files, +22/-10.

### Left alone

- `docs/ops/v0.25-beta1-release-checklist.md` — historical release checklist,
  describes the v0.25 CI state at that release moment. Not a current
  supported-surface claim.
- `assets/logo-*.svg` — `font-size="18"` is a pixel value, unrelated.

### CI savings

Dropping one matrix job saves ~6 min per CI run (matrix goes 4 → 3).

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 724 Mocha passing, 76 Vitest passing, 0 failing (local, ~5 min)
- [ ] CI green on PR (will now run on Node 20/22/24 only)