### PR TITLE
fix(adapter): reconnect poller on lease-revoked instead of permanent shutdown

### DIFF
--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -33,12 +33,39 @@ const log = (...args: unknown[]) => console.error('[claude-tempo:adapter]', ...a
 const LOOP_BACKOFF_FACTOR = 1.5;
 const LOOP_BACKOFF_MAX_MS = 30_000;
 
+/**
+ * Reconnect tuning (#201). The loop retries `claimAttachment` with exponential backoff
+ * bounded by a total elapsed-time budget. Elapsed-time bounds beat retry-count bounds
+ * because they map cleanly to user-facing mental models ("waits ~15 min then gives up")
+ * and don't drift when the backoff curve changes. 15 min catches the long tail of
+ * laptop-sleep events without leaving zombie pollers running forever.
+ */
+const RECONNECT_TOTAL_BUDGET_MS = 15 * 60_000;
+const RECONNECT_BASE_MS = 10_000;
+const RECONNECT_MAX_MS = 60_000;
+const RECONNECT_BACKOFF_FACTOR = 1.5;
+
+/**
+ * Override bundle for the reconnect loop timing (#201). Production defaults are
+ * tuned for laptop-sleep cycles (15-min elapsed budget, 10s base, 60s cap). Tests
+ * override to run the whole loop in <1s. Any field omitted falls back to the
+ * production constant.
+ */
+export interface ReconnectTimingOverrides {
+  baseMs?: number;
+  maxMs?: number;
+  budgetMs?: number;
+  backoffFactor?: number;
+}
+
 /** Options shared by every adapter extending `BaseAttachment`. */
 export interface BaseAttachmentOptions {
   /** Temporal client — required for V2 attachment claim + runId pinning. */
   client?: Client;
   /** Hostname to announce in `claimAttachment`. Defaults to `os.hostname()` when omitted. */
   host?: string;
+  /** Test-only: shrink the reconnect backoff/budget. Production callers never set this. */
+  reconnectTiming?: ReconnectTimingOverrides;
 }
 
 /**
@@ -78,9 +105,35 @@ export abstract class BaseAttachment {
   private readonly leaseRevokedListeners: Array<(reason: DetachReason) => void> = [];
   private readonly terminalListeners: Array<(reason: DetachReason) => void> = [];
 
+  /**
+   * Pending `abortableSleep` cancellers (#201). `stopV2Lifecycle` iterates and invokes
+   * each so any in-flight reconnect backoff rejects immediately and the loop unwinds
+   * instead of stalling teardown by up to `RECONNECT_MAX_MS`.
+   */
+  private readonly sleepAborters = new Set<() => void>();
+
+  /**
+   * `true` while `runReconnectLoop` is active. Prevents concurrent reconnect attempts
+   * (e.g. if both the heartbeat and phase-watcher loops observe the same lease expiry
+   * at nearly the same time) and gates heartbeat/watcher ticks from firing new terminals
+   * while the reconnect pre-check is still deciding.
+   */
+  private reconnecting = false;
+
+  /** Reconnect loop timing — production constants unless overridden for tests. */
+  private readonly reconnectBaseMs: number;
+  private readonly reconnectMaxMs: number;
+  private readonly reconnectBudgetMs: number;
+  private readonly reconnectBackoffFactor: number;
+
   constructor(options: BaseAttachmentOptions = {}) {
     this.client = options.client;
     this.host = options.host;
+    const t = options.reconnectTiming ?? {};
+    this.reconnectBaseMs = t.baseMs ?? RECONNECT_BASE_MS;
+    this.reconnectMaxMs = t.maxMs ?? RECONNECT_MAX_MS;
+    this.reconnectBudgetMs = t.budgetMs ?? RECONNECT_TOTAL_BUDGET_MS;
+    this.reconnectBackoffFactor = t.backoffFactor ?? RECONNECT_BACKOFF_FACTOR;
   }
 
   /**
@@ -203,6 +256,11 @@ export abstract class BaseAttachment {
       this.phaseWatcherTimer = null;
     }
 
+    // #201: a user-initiated stop must abort any in-flight reconnect backoff
+    // BEFORE awaiting `adapterExited`, otherwise teardown stalls up to
+    // `RECONNECT_MAX_MS` while the sleep timer runs out naturally.
+    this.abortSleepers();
+
     if (graceful && this.pinnedHandle && this.token) {
       try {
         await this.pinnedHandle.signal(adapterExitedSignal, {
@@ -222,7 +280,7 @@ export abstract class BaseAttachment {
   }
 
   private async tickHeartbeat(): Promise<void> {
-    if (this.stopped || !this.pinnedHandle || !this.token) return;
+    if (this.stopped || this.reconnecting || !this.pinnedHandle || !this.token) return;
     try {
       await this.pinnedHandle.signal(heartbeatSignal, {
         attachmentId: this.token.attachmentId,
@@ -244,7 +302,7 @@ export abstract class BaseAttachment {
       );
       log(`heartbeat transient error (retry in ${Math.round(this.heartbeatBackoff)}ms):`, (err as Error)?.message ?? err);
     }
-    if (!this.stopped) this.scheduleHeartbeat();
+    if (!this.stopped && !this.reconnecting) this.scheduleHeartbeat();
   }
 
   private schedulePhaseWatcher(): void {
@@ -255,7 +313,7 @@ export abstract class BaseAttachment {
   }
 
   private async tickPhaseWatcher(): Promise<void> {
-    if (this.stopped || !this.pinnedHandle || !this.token) return;
+    if (this.stopped || this.reconnecting || !this.pinnedHandle || !this.token) return;
     try {
       const info: AttachmentInfo = await this.pinnedHandle.query(attachmentInfoQuery);
       this.phaseBackoff = 0;
@@ -267,7 +325,7 @@ export abstract class BaseAttachment {
         }
       }
 
-      // Lease revocation — another claimant took over.
+      // Lease revocation (§9.3) — another claimant took over.
       if (
         info.currentAttachment &&
         info.currentAttachment.attachmentId !== this.token.attachmentId
@@ -276,11 +334,26 @@ export abstract class BaseAttachment {
         for (const l of this.leaseRevokedListeners) {
           try { l('superseded'); } catch (err) { log('leaseRevoked listener threw:', err); }
         }
-        this.fireTerminal('superseded');
+        this.fireTerminalOrReconnect('superseded');
         return;
       }
 
-      // Phase `gone` is terminal — workflow destroyed.
+      // #201: the workflow side reaped our lease (main-loop §9.5.a) without anyone
+      // else claiming. This is the laptop-sleep failure mode — `phase=detached` with
+      // `currentAttachment=undefined`. Before #201 this branch was silent and the
+      // poller kept querying a workflow that had already evicted us, so no cues were
+      // delivered until manual `restart`. Now we surface it as a recoverable terminal
+      // that the subclass can choose to reconnect through.
+      if (info.phase === 'detached' && !info.currentAttachment) {
+        log(`lease reaped workflow-side (phase=detached, no current attachment)`);
+        for (const l of this.leaseRevokedListeners) {
+          try { l('heartbeat-timeout'); } catch (err) { log('leaseRevoked listener threw:', err); }
+        }
+        this.fireTerminalOrReconnect('heartbeat-timeout');
+        return;
+      }
+
+      // Phase `gone` is terminal — workflow destroyed. Never recoverable.
       if (info.phase === 'gone') {
         this.fireTerminal('destroy');
         return;
@@ -299,7 +372,7 @@ export abstract class BaseAttachment {
       );
       log(`phase watcher transient error (retry in ${Math.round(this.phaseBackoff)}ms):`, (err as Error)?.message ?? err);
     }
-    if (!this.stopped) this.schedulePhaseWatcher();
+    if (!this.stopped && !this.reconnecting) this.schedulePhaseWatcher();
   }
 
   /**
@@ -327,9 +400,256 @@ export abstract class BaseAttachment {
     this.stopped = true;
     if (this.heartbeatTimer) { clearTimeout(this.heartbeatTimer); this.heartbeatTimer = null; }
     if (this.phaseWatcherTimer) { clearTimeout(this.phaseWatcherTimer); this.phaseWatcherTimer = null; }
+    this.abortSleepers();
     for (const l of this.terminalListeners) {
       try { l(reason); } catch (err) { log('terminal listener threw:', err); }
     }
+  }
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // #201 reconnect machinery. Subclasses opt in by overriding `shouldReconnect`.
+  // ───────────────────────────────────────────────────────────────────────────
+
+  /**
+   * Opt-in reconnect policy. Default: return `false` — the base class behaves
+   * exactly as it did before #201 (fire terminal, tear down). Subclasses that
+   * can safely replay delivery on a fresh lease should override and return
+   * `true` for recoverable reasons (typically `heartbeat-timeout` and
+   * `superseded`; never `destroy`).
+   *
+   * Why opt-in: SDK adapters (e.g. Copilot bridge) have their own subprocess
+   * restart logic; double-reconnecting would race their native poller and
+   * produce duplicate `pendingMessages` queries. Keep them on the old
+   * behavior until we've proven reconnect is safe there.
+   */
+  protected shouldReconnect(_reason: DetachReason): boolean {
+    return false;
+  }
+
+  /**
+   * Called once, just before the reconnect loop enters its first backoff sleep.
+   * Subclasses should tear down any delivery loops that are still polling the
+   * stale pinned handle (it may succeed but `markDelivered` will be ignored by
+   * the workflow because our `attachmentId` is no longer current). The default
+   * is a no-op.
+   */
+  protected async onReconnectStart(_reason: DetachReason): Promise<void> {
+    // Default: nothing to tear down.
+  }
+
+  /**
+   * Called once on a successful re-claim, with the freshly pinned handle.
+   * Subclasses should restart their delivery loop against `handle`. Runs
+   * before the base class reschedules its own heartbeat + phase-watcher
+   * loops, so the subclass sees a quiescent state.
+   *
+   * Note: the runId returned by `claimAttachment` may differ from the previous
+   * pinned handle's runId (the workflow may have `continueAsNew`'d during the
+   * outage), so subclasses MUST use the `handle` argument — never cache a
+   * handle from before the reconnect.
+   */
+  protected async onReconnected(_handle: WorkflowHandle): Promise<void> {
+    // Default: nothing to restart.
+  }
+
+  /**
+   * Sleep `ms` milliseconds, resolving cleanly on timer and rejecting with
+   * `aborted:stopped` if `stopV2Lifecycle` or `fireTerminal` fires mid-wait.
+   * The canonical pattern for any blocking wait inside an adapter loop —
+   * never use bare `setTimeout` + `Promise` in loop code, or teardown stalls.
+   */
+  protected async abortableSleep(ms: number): Promise<void> {
+    if (this.stopped) throw new Error('aborted:stopped');
+    await new Promise<void>((resolve, reject) => {
+      let aborter: (() => void) | null = null;
+      const timer = setTimeout(() => {
+        if (aborter) this.sleepAborters.delete(aborter);
+        resolve();
+      }, ms);
+      aborter = () => {
+        clearTimeout(timer);
+        if (aborter) this.sleepAborters.delete(aborter);
+        reject(new Error('aborted:stopped'));
+      };
+      this.sleepAborters.add(aborter);
+    });
+  }
+
+  /** Reject every in-flight `abortableSleep`. Called on stop + terminal. */
+  private abortSleepers(): void {
+    // Snapshot then clear — each aborter mutates the set during iteration.
+    const aborters = [...this.sleepAborters];
+    this.sleepAborters.clear();
+    for (const abort of aborters) {
+      try { abort(); } catch (err) { log('sleep aborter threw:', err); }
+    }
+  }
+
+  /**
+   * Consult {@link shouldReconnect}; if true, kick off the reconnect loop in
+   * the background (fire-and-forget), otherwise fire terminal synchronously.
+   * Called by the heartbeat / phase-watcher ticks instead of `fireTerminal`
+   * when the reason is potentially recoverable.
+   */
+  private fireTerminalOrReconnect(reason: DetachReason): void {
+    if (this.stopped || this.terminalFired || this.reconnecting) return;
+    if (!this.shouldReconnect(reason)) {
+      this.fireTerminal(reason);
+      return;
+    }
+    // Pause the heartbeat + watcher loops for the duration of the reconnect.
+    this.reconnecting = true;
+    if (this.heartbeatTimer) { clearTimeout(this.heartbeatTimer); this.heartbeatTimer = null; }
+    if (this.phaseWatcherTimer) { clearTimeout(this.phaseWatcherTimer); this.phaseWatcherTimer = null; }
+    log(`reconnect requested (reason=${reason})`);
+    void this.runReconnectLoop(reason).catch((err) => {
+      log(`reconnect loop crashed:`, (err as Error)?.message ?? err);
+      this.reconnecting = false;
+      this.fireTerminal('reconnect-exhausted');
+    });
+  }
+
+  /**
+   * Budget-bounded reconnect loop.
+   *
+   * Strategy:
+   *   1. Sleep (abortable) with exponential backoff from {@link RECONNECT_BASE_MS}
+   *      up to {@link RECONNECT_MAX_MS}, capped by an elapsed-time budget of
+   *      {@link RECONNECT_TOTAL_BUDGET_MS}.
+   *   2. Query `attachmentInfo` via a fresh unpinned handle:
+   *        • workflow gone → fire `destroy`, exit.
+   *        • phase `gone` → fire `destroy`, exit.
+   *        • someone else holds the lease → fire `superseded`, exit (architect §1).
+   *        • phase `draining` → wait another tick (lease about to reap).
+   *        • otherwise → attempt fresh `claimAttachment`.
+   *   3. On successful claim: rebuild `this.pinnedHandle` from the **new** token's
+   *      `runId` (workflow may have `continueAsNew`'d during outage), reset loop
+   *      state, call subclass hooks, restart heartbeat + watcher.
+   *
+   * Fires `reconnect-exhausted` on budget exhaustion. Exits silently (without
+   * firing terminal) on abort — `stopV2Lifecycle` owns teardown messaging.
+   */
+  private async runReconnectLoop(initialReason: DetachReason): Promise<void> {
+    if (!this.client || !this.host || !this.token || !this.pinnedHandle) {
+      log('runReconnectLoop: missing client/host/token/handle — aborting');
+      this.reconnecting = false;
+      this.fireTerminal('reconnect-exhausted');
+      return;
+    }
+
+    const workflowId = this.pinnedHandle.workflowId;
+    const oldAttachmentId = this.token.attachmentId;
+
+    try {
+      await this.onReconnectStart(initialReason);
+    } catch (err) {
+      log('onReconnectStart threw:', (err as Error)?.message ?? err);
+    }
+
+    const deadline = Date.now() + this.reconnectBudgetMs;
+    let backoff = this.reconnectBaseMs;
+    let attempt = 0;
+
+    while (!this.stopped && Date.now() < deadline) {
+      attempt++;
+      log(`reconnect attempt ${attempt} (sleep ${Math.round(backoff)}ms)`);
+      try {
+        await this.abortableSleep(backoff);
+      } catch {
+        // User-initiated stop during sleep — teardown already owns the rest.
+        log('reconnect aborted by stop during backoff');
+        return;
+      }
+      if (this.stopped) return;
+
+      // §Pre-check (architect §1): query attachmentInfo via a fresh unpinned handle.
+      // The old pinned handle's runId may be stale after a continueAsNew.
+      const unpinned = this.client.workflow.getHandle(workflowId);
+      let info: AttachmentInfo;
+      try {
+        info = await unpinned.query(attachmentInfoQuery);
+      } catch (err) {
+        if (this.isWorkflowGone(err)) {
+          log('reconnect: workflow gone during pre-check');
+          this.reconnecting = false;
+          this.fireTerminal('destroy');
+          return;
+        }
+        backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
+        log(`reconnect pre-check transient error (next backoff ${Math.round(backoff)}ms):`, (err as Error)?.message ?? err);
+        continue;
+      }
+
+      if (info.phase === 'gone') {
+        log('reconnect: phase=gone — giving up');
+        this.reconnecting = false;
+        this.fireTerminal('destroy');
+        return;
+      }
+      if (info.currentAttachment && info.currentAttachment.attachmentId !== oldAttachmentId) {
+        log(`reconnect: another adapter holds the lease (${info.currentAttachment.attachmentId}) — bailing`);
+        this.reconnecting = false;
+        this.fireTerminal('superseded');
+        return;
+      }
+      if (info.phase === 'draining') {
+        // About to reap — give the workflow one more tick to finish collapsing.
+        backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
+        log(`reconnect: phase=draining, waiting (next backoff ${Math.round(backoff)}ms)`);
+        continue;
+      }
+
+      // §Claim: attempt a fresh `claimAttachment` (no expectedAttachmentId — our
+      // previous lease is revoked, this is a fresh claim from the workflow's POV).
+      try {
+        const newToken = await unpinned.executeUpdate(claimAttachmentUpdate, {
+          args: [{
+            host: this.host,
+            adapterId: this.descriptor.adapterId,
+            adapterClass: this.descriptor.adapterClass as AdapterClass,
+            leaseMs: 3 * this.descriptor.heartbeatMs,
+          }],
+        });
+
+        // Success — rebuild pinned handle from the NEW runId and hand it to the subclass.
+        this.token = newToken;
+        this.pinnedHandle = this.client.workflow.getHandle(workflowId, newToken.runId);
+        this.knownPhase = null; // force the next phase-watcher tick to re-emit phaseChange
+        this.heartbeatBackoff = 0;
+        this.phaseBackoff = 0;
+        log(
+          `reconnected to ${workflowId} after ${attempt} attempt(s) ` +
+          `(new attachmentId=${newToken.attachmentId}, runId=${newToken.runId})`,
+        );
+
+        try {
+          await this.onReconnected(this.pinnedHandle);
+        } catch (err) {
+          log('onReconnected threw:', (err as Error)?.message ?? err);
+        }
+
+        this.reconnecting = false;
+        if (!this.stopped) {
+          this.scheduleHeartbeat();
+          this.schedulePhaseWatcher();
+        }
+        return;
+      } catch (err) {
+        if (this.isWorkflowGone(err)) {
+          log('reconnect: workflow gone during claim');
+          this.reconnecting = false;
+          this.fireTerminal('destroy');
+          return;
+        }
+        backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
+        log(`reconnect claim failed (next backoff ${Math.round(backoff)}ms):`, (err as Error)?.message ?? err);
+      }
+    }
+
+    // Budget exhausted — give up cleanly.
+    log(`reconnect budget exhausted after ${attempt} attempt(s)`);
+    this.reconnecting = false;
+    this.fireTerminal('reconnect-exhausted');
   }
 }
 

--- a/src/adapters/claude-code/adapter.ts
+++ b/src/adapters/claude-code/adapter.ts
@@ -19,7 +19,7 @@
  */
 import type { Client, WorkflowHandle } from '@temporalio/client';
 import { BaseAttachment, type BaseAttachmentOptions } from '../base';
-import type { AdapterDescriptor } from '../../types';
+import type { AdapterDescriptor, DetachReason } from '../../types';
 import { Message } from '../../types';
 import { ENV } from '../../config';
 
@@ -111,14 +111,29 @@ function startMessagePoller(
  * V2 attachment lifecycle: the adapter calls `claimAttachment` via
  * `startV2Lifecycle()`, pins the runId, and runs the delivery poll on the
  * pinned handle. Base class drives heartbeat + phase watcher in parallel.
- * On lease revocation, `WorkflowNotFound`, or phase `gone`, the adapter
- * stops cleanly without attempting to re-claim.
+ *
+ * Reconnect (#201): the adapter opts into the base class's reconnect loop
+ * via {@link shouldReconnect}. On a recoverable terminal (lease reaped
+ * workflow-side without a competitor, or superseded-then-released), the
+ * base class runs a budget-bounded backoff + fresh-claim flow, then calls
+ * {@link onReconnected} with a freshly pinned handle so the delivery poll
+ * can resume. Truly terminal events (`destroy`, `reconnect-exhausted`)
+ * still tear the adapter down permanently.
  *
  * PR-H (#132): the legacy unpinned-poll fallback (gated on
  * `CLAUDE_TEMPO_LIFECYCLE_V2=0`) has been removed. V2 is the only path.
  */
 export class InteractiveAttachment extends BaseAttachment {
   readonly descriptor: AdapterDescriptor = claudeCodeDescriptor;
+
+  /** Current delivery poller stopper; null when no poll is running (pre-claim, mid-reconnect, post-terminal). */
+  private stopPoller: (() => void) | null = null;
+
+  /** Retained across `onReconnected` calls so the poller can be restarted on a new pinned handle. */
+  private onMessages: ((messages: Message[]) => Promise<void> | void) | null = null;
+
+  /** True once user-initiated `stop()` has fired or the adapter reached a true terminal. */
+  private localStopped = false;
 
   constructor(options: BaseAttachmentOptions = {}) {
     super(options);
@@ -140,42 +155,42 @@ export class InteractiveAttachment extends BaseAttachment {
   }
 
   /**
-   * V2 path: claim the attachment, pin the handle, then run the same
-   * poll/deliver/markDelivered loop against the pinned handle. The base class
-   * simultaneously drives heartbeats and the `attachmentInfo` watcher.
+   * V2 path: claim the attachment, pin the handle, then run the poll/deliver/
+   * markDelivered loop against the pinned handle. The base class simultaneously
+   * drives heartbeats and the `attachmentInfo` watcher, and (via {@link shouldReconnect})
+   * may reclaim on recoverable lease loss without this method firing terminal.
    *
    * Returns a stop function that tears down the delivery poll AND the base
    * class lifecycle. Safe to call multiple times.
    *
-   * **Error handling:** a `claimAttachment` rejection (`AttachmentConflict`,
-   * `WorkflowGone`) propagates up — the caller in `server.ts` treats it like
-   * any other startup failure. Runtime errors on the pinned handle
-   * (`WorkflowNotFound`, lease revocation) are caught by the base class
-   * heartbeat + watcher loops, which fire the `onTerminal` hook; this method
-   * subscribes to that hook to tear down the poll cleanly.
+   * **Error handling:** a `claimAttachment` rejection at startup
+   * (`AttachmentConflict`, `WorkflowGone`) propagates up — the caller in
+   * `server.ts` treats it like any other startup failure. Runtime lease loss
+   * on the pinned handle is first routed through `shouldReconnect`; only truly
+   * terminal reasons (`destroy`, `reconnect-exhausted`) reach `onTerminal`
+   * and tear down the poller permanently.
    */
   private startV2(
     workflowId: string,
     onMessages: (messages: Message[]) => Promise<void> | void,
   ): () => void {
-    let stopPoller: (() => void) | null = null;
-    let stopped = false;
+    this.onMessages = onMessages;
 
     const stop = () => {
-      if (stopped) return;
-      stopped = true;
-      if (stopPoller) { stopPoller(); stopPoller = null; }
+      if (this.localStopped) return;
+      this.localStopped = true;
+      if (this.stopPoller) { this.stopPoller(); this.stopPoller = null; }
       // Fire-and-forget — V2 graceful exit signals adapterExited to the workflow.
       void this.stopV2Lifecycle('user-stop', /* graceful */ true);
     };
 
-    // Terminal events from the base class: WorkflowNotFound, phase `gone`, or
-    // lease revoked. Tear down the delivery poll without calling stopV2Lifecycle
-    // again (base class already fired it via `stopped` flag).
+    // Terminal events from the base class: `destroy`, `reconnect-exhausted`, or any
+    // non-reconnectable reason. By the time this fires, the reconnect loop (if
+    // applicable) has already given up; tear the poller down permanently.
     this.onTerminal((reason) => {
-      log(`terminal (${reason}) — stopping delivery poll`);
-      stopped = true;
-      if (stopPoller) { stopPoller(); stopPoller = null; }
+      log(`terminal (${reason}) — stopping delivery poll permanently`);
+      this.localStopped = true;
+      if (this.stopPoller) { this.stopPoller(); this.stopPoller = null; }
     });
 
     // PR-D: when spawned by `restart` or `migrate`, the workflow has
@@ -189,17 +204,60 @@ export class InteractiveAttachment extends BaseAttachment {
     // the caller's startup bails — we haven't started the poll yet.
     this.startV2Lifecycle(workflowId, expectedAttachmentId)
       .then((pinned) => {
-        if (stopped) return; // caller bailed between await and here
-        stopPoller = startMessagePoller(pinned, onMessages);
+        if (this.localStopped) return; // caller bailed between await and here
+        this.stopPoller = startMessagePoller(pinned, onMessages);
       })
       .catch((err) => {
         log(`startV2Lifecycle failed: ${(err as Error)?.message ?? err}`);
         // Surface via stop — caller's shutdown path sees the error in logs
         // and proceeds with graceful shutdown. We don't re-throw here because
         // start() is synchronous by contract.
-        stopped = true;
+        this.localStopped = true;
       });
 
     return stop;
+  }
+
+  /**
+   * #201: reconnect opt-in. The interactive adapter is stateless wrt in-flight
+   * messages (no processing-signal pairing; `markDelivered` is idempotent), so
+   * both recoverable reasons are safe to replay on a fresh lease:
+   *
+   *   - `heartbeat-timeout`: the workflow reaped our lease (e.g. laptop slept).
+   *     Re-claim and resume — this is the #201 happy path.
+   *   - `superseded`: another adapter currently holds our slot. The reconnect
+   *     loop's pre-check will re-query and bail cleanly if that's still true;
+   *     we enter the loop in case the competitor releases during our backoff.
+   *
+   * Unrecoverable reasons (`destroy`, `gone`, anything else) fall through to
+   * the default `false`, firing terminal directly.
+   */
+  protected shouldReconnect(reason: DetachReason): boolean {
+    return reason === 'heartbeat-timeout' || reason === 'superseded';
+  }
+
+  /**
+   * Tear down the current poller immediately when entering the reconnect loop.
+   * The old pinned handle may still respond to `pendingMessages` queries but
+   * the workflow side will ignore our `markDelivered` signals (our `attachmentId`
+   * is no longer current), so continuing to poll wastes I/O and logs noise.
+   */
+  protected async onReconnectStart(_reason: DetachReason): Promise<void> {
+    if (this.stopPoller) {
+      this.stopPoller();
+      this.stopPoller = null;
+    }
+  }
+
+  /**
+   * Fresh pinned handle is live — restart the delivery poller. The workflow's
+   * `pendingMessages` queue carries everything that landed while we were
+   * detached; the first poll will drain it in one batch.
+   */
+  protected async onReconnected(handle: WorkflowHandle): Promise<void> {
+    if (this.localStopped || !this.onMessages) return;
+    // Belt-and-suspenders: if onReconnectStart was skipped somehow, don't leak.
+    if (this.stopPoller) { this.stopPoller(); this.stopPoller = null; }
+    this.stopPoller = startMessagePoller(handle, this.onMessages);
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,11 @@ export interface AdapterDescriptor {
  * Kept alongside the spec values so the workflow has a non-empty reason to record even
  * when the graceful drain path never acked. Safe to merge into `heartbeat-timeout` in a
  * future cleanup if the semantics converge.
+ *
+ * `reconnect-exhausted` is fired adapter-side by `BaseAttachment.runReconnectLoop` (#201)
+ * when the reconnect budget elapsed without recovering a live lease. Distinct from
+ * `heartbeat-timeout` so post-mortems can tell "lease expired once" from "poller tried
+ * to recover and gave up" — workflow-side reap accounting treats them identically.
  */
 export type DetachReason =
   | 'user-stop'
@@ -64,7 +69,8 @@ export type DetachReason =
   | 'agent-exited'
   | 'spawn-failed'
   | 'destroy'
-  | 'force';
+  | 'force'
+  | 'reconnect-exhausted';
 
 /**
  * Workflow-emitted directive to the attached adapter. Delivered via {@link AttachmentInfo}

--- a/test/adapter-reconnect.test.ts
+++ b/test/adapter-reconnect.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Adapter reconnect tests (#201).
+ *
+ * Covers the `BaseAttachment` reconnect loop and `InteractiveAttachment`'s
+ * opt-in policy. The production bug (pre-#201) was: when the workflow reaped
+ * our lease on the laptop-sleep path, the adapter's phase watcher silently
+ * observed `phase=detached, currentAttachment=undefined` and never fired
+ * terminal. Messages piled up in `pendingMessages` for hours.
+ *
+ * Tests here pin down the four branches that matter:
+ *   1. `shouldReconnect` opt-in values (unit).
+ *   2. `abortableSleep` resolves / rejects (unit).
+ *   3. Adapter reconnects after a workflow-side `forceDetach` reap (integration).
+ *   4. Adapter fires `destroy` terminal when the workflow is destroyed mid-reconnect.
+ *
+ * Integration tests use a short-heartbeat subclass + shrunk reconnect-timing overrides
+ * so the full detach → reap → detect → re-claim → resume-delivery cycle runs in <3s.
+ */
+import { expect } from 'chai';
+import type { WorkflowHandle } from '@temporalio/client';
+import {
+  setupTestEnv,
+  teardownTestEnv,
+  withWorker,
+  startSession,
+  playerMetadata,
+  getClient,
+  receiveMessageSignal,
+  allMessagesQuery,
+  destroyUpdate,
+  forceDetachUpdate,
+  attachmentInfoQuery,
+} from './helpers';
+import type { AttachmentInfo, Message, DetachReason } from '../src/types';
+import { InteractiveAttachment } from '../src/adapters/claude-code/adapter';
+import type { BaseAttachmentOptions } from '../src/adapters/base';
+
+/**
+ * Short-heartbeat subclass. Production uses 60 000ms; here we use 400ms so the
+ * phase watcher ticks every 2s (5 × heartbeatMs) and `leaseMs = 3 × heartbeatMs
+ * = 1200ms` — the minimum `claimAttachment` allows is 1000ms (see
+ * session.ts `claimAttachmentUpdate` validator). Reconnect timing is shrunk
+ * via `options.reconnectTiming` so the full reclaim cycle runs inside a 15s test.
+ */
+class FastInteractiveAttachment extends InteractiveAttachment {
+  readonly descriptor = {
+    adapterId: 'claude-code',
+    adapterClass: 'interactive' as const,
+    blocksOnLLMTurn: false,
+    heartbeatMs: 400,
+  };
+
+  /** Test introspection for `shouldReconnect` — the base class method is protected. */
+  public reconnectDecides(reason: DetachReason): boolean {
+    return this.shouldReconnect(reason);
+  }
+
+  /** Test introspection for `abortableSleep`. */
+  public sleepAndRace(ms: number): Promise<void> {
+    return this.abortableSleep(ms);
+  }
+
+  /** Expose teardown so tests can drive lifecycle. */
+  public async publicStopV2(reason: DetachReason = 'user-stop'): Promise<void> {
+    return this.stopV2Lifecycle(reason, false);
+  }
+}
+
+/** Poll until `pred(info)` is true or timeout. Returns the final info snapshot. */
+async function waitForAttachmentInfo(
+  handle: WorkflowHandle,
+  pred: (info: AttachmentInfo) => boolean,
+  timeoutMs = 5000,
+  label = '<predicate>',
+): Promise<AttachmentInfo> {
+  const deadline = Date.now() + timeoutMs;
+  let last: AttachmentInfo | undefined;
+  while (Date.now() < deadline) {
+    last = await handle.query(attachmentInfoQuery);
+    if (pred(last)) return last;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    `Timed out waiting for ${label}; last info=${JSON.stringify(last)}`,
+  );
+}
+
+/** Poll until at least one message has been delivered. Used to confirm delivery post-reconnect. */
+async function waitForDelivered(
+  handle: WorkflowHandle,
+  atLeast = 1,
+  timeoutMs = 5000,
+): Promise<Message[]> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const all: Message[] = await handle.query(allMessagesQuery);
+    const delivered = all.filter((m) => m.delivered);
+    if (delivered.length >= atLeast) return delivered;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  const snapshot: Message[] = await handle.query(allMessagesQuery);
+  throw new Error(
+    `Timed out waiting for ${atLeast} delivered message(s); got ${JSON.stringify(snapshot)}`,
+  );
+}
+
+describe('adapter reconnect (#201)', function () {
+  before(async function () {
+    this.timeout(60_000);
+    await setupTestEnv();
+  });
+
+  after(async function () {
+    await teardownTestEnv();
+  });
+
+  describe('shouldReconnect policy', () => {
+    it('InteractiveAttachment opts into reconnect for lease-loss reasons only', () => {
+      const adapter = new FastInteractiveAttachment();
+      // Recoverable — the workflow is still live, we just lost the lease.
+      expect(adapter.reconnectDecides('heartbeat-timeout')).to.equal(true);
+      expect(adapter.reconnectDecides('superseded')).to.equal(true);
+      // Non-recoverable — workflow truly gone or user explicitly stopped.
+      expect(adapter.reconnectDecides('destroy')).to.equal(false);
+      expect(adapter.reconnectDecides('user-stop')).to.equal(false);
+      expect(adapter.reconnectDecides('agent-exited')).to.equal(false);
+      expect(adapter.reconnectDecides('force')).to.equal(false);
+      expect(adapter.reconnectDecides('reconnect-exhausted')).to.equal(false);
+    });
+  });
+
+  describe('abortableSleep', () => {
+    it('resolves after the requested duration', async () => {
+      const adapter = new FastInteractiveAttachment();
+      const started = Date.now();
+      await adapter.sleepAndRace(120);
+      const elapsed = Date.now() - started;
+      expect(elapsed).to.be.at.least(100, 'should not resolve early');
+      // Generous upper bound — timers are imprecise on loaded runners.
+      expect(elapsed).to.be.at.most(1000, 'should resolve near the requested time');
+    });
+
+    it('rejects with aborted:stopped when stopV2Lifecycle fires during sleep', async () => {
+      const adapter = new FastInteractiveAttachment();
+      const sleeping = adapter.sleepAndRace(5000);
+      // Give the timer a moment to register with `sleepAborters`.
+      await new Promise((r) => setTimeout(r, 20));
+      await adapter.publicStopV2();
+      let err: Error | undefined;
+      try {
+        await sleeping;
+      } catch (e) {
+        err = e as Error;
+      }
+      expect(err, 'sleep should have rejected').to.exist;
+      expect(err!.message).to.equal('aborted:stopped');
+    });
+  });
+
+  describe('workflow-side lease reap triggers automatic reconnect', () => {
+    it('adapter re-claims and resumes delivery after forceDetach', async function () {
+      // Budget: initial claim (<1s) + phase-watcher tick (1s = 5 * 200ms) +
+      // reconnect backoff (100ms) + re-claim (<1s) + delivery (<1s) ≈ 4s comfortable.
+      this.timeout(15_000);
+
+      await withWorker(async () => {
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: `reconnect-ok-${Date.now()}` }),
+        });
+
+        const received: Message[][] = [];
+        const terminals: DetachReason[] = [];
+        const options: BaseAttachmentOptions = {
+          client: getClient(),
+          host: 'test-host',
+          // Shrink the reconnect loop so a full cycle runs in ~300ms.
+          reconnectTiming: { baseMs: 100, maxMs: 500, budgetMs: 10_000, backoffFactor: 1.5 },
+        };
+        const adapter = new FastInteractiveAttachment(options);
+        adapter.onTerminal((r) => { terminals.push(r); });
+        const stop = adapter.start(handle, async (msgs) => { received.push(msgs); });
+
+        try {
+          // 1. Initial claim lands.
+          const attached = await waitForAttachmentInfo(
+            handle,
+            (i) => i.phase === 'attached' && !!i.currentAttachment,
+            5000,
+            'initial attached',
+          );
+          const firstAttachmentId = attached.currentAttachment!.attachmentId;
+
+          // 2. Workflow-side reap — simulates laptop-sleep lease expiry but immediate.
+          //    `forceDetach` with gracePeriodMs=0 clears currentAttachment + sets phase=detached.
+          await handle.executeUpdate(forceDetachUpdate, {
+            args: [{ reason: 'heartbeat-timeout', gracePeriodMs: 0 }],
+          });
+          await waitForAttachmentInfo(
+            handle,
+            (i) => i.phase === 'detached' && !i.currentAttachment,
+            3000,
+            'workflow reaped attachment',
+          );
+
+          // 3. Adapter's phase watcher observes the reap and the reconnect loop
+          //    re-claims. Phase returns to `attached` with a DIFFERENT attachmentId.
+          const reattached = await waitForAttachmentInfo(
+            handle,
+            (i) =>
+              i.phase === 'attached' &&
+              !!i.currentAttachment &&
+              i.currentAttachment.attachmentId !== firstAttachmentId,
+            10_000,
+            'adapter reconnected with fresh attachment',
+          );
+          expect(reattached.currentAttachment!.hostname).to.equal('test-host');
+
+          // 4. Terminal must NOT have fired — recovery was clean.
+          expect(terminals).to.deep.equal([]);
+
+          // 5. Delivery works on the new pinned handle.
+          await handle.signal(receiveMessageSignal, {
+            from: 'tester',
+            text: 'post-reconnect cue',
+          });
+          await waitForDelivered(handle, 1);
+          const flat = received.flat();
+          expect(flat.map((m) => m.text)).to.include('post-reconnect cue');
+        } finally {
+          stop();
+          await handle.executeUpdate(destroyUpdate, { args: [{}] });
+          await handle.result().catch(() => { /* expected */ });
+        }
+      });
+    });
+
+    it('fires `destroy` terminal if the workflow is destroyed mid-reconnect', async function () {
+      this.timeout(15_000);
+
+      await withWorker(async () => {
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: `reconnect-destroy-${Date.now()}` }),
+        });
+
+        const terminals: DetachReason[] = [];
+        const options: BaseAttachmentOptions = {
+          client: getClient(),
+          host: 'test-host',
+          // Longer backoff so destroy lands while the loop is still waiting.
+          reconnectTiming: { baseMs: 400, maxMs: 800, budgetMs: 5_000, backoffFactor: 1.5 },
+        };
+        const adapter = new FastInteractiveAttachment(options);
+        adapter.onTerminal((r) => { terminals.push(r); });
+        const stop = adapter.start(handle, async () => { /* no-op */ });
+
+        try {
+          // Initial claim
+          await waitForAttachmentInfo(
+            handle,
+            (i) => i.phase === 'attached',
+            5000,
+            'initial attached',
+          );
+
+          // Reap — kicks the reconnect loop in the adapter.
+          await handle.executeUpdate(forceDetachUpdate, {
+            args: [{ reason: 'heartbeat-timeout', gracePeriodMs: 0 }],
+          });
+          await waitForAttachmentInfo(
+            handle,
+            (i) => i.phase === 'detached',
+            3000,
+            'workflow reaped',
+          );
+
+          // Destroy before the adapter gets a chance to re-claim.
+          await handle.executeUpdate(destroyUpdate, { args: [{}] });
+
+          // Adapter's reconnect pre-check should see phase=gone / WorkflowGone
+          // and fire `destroy` terminal. Exact wake-up time depends on where
+          // the loop is in its backoff cycle.
+          const deadline = Date.now() + 8000;
+          while (Date.now() < deadline && terminals.length === 0) {
+            await new Promise((r) => setTimeout(r, 50));
+          }
+          expect(terminals, 'terminal should have fired').to.have.lengthOf(1);
+          expect(terminals[0]).to.equal('destroy');
+        } finally {
+          stop();
+          await handle.result().catch(() => { /* expected */ });
+        }
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #201. Adapter now attempts a budget-bounded re-claim when the workflow reaps its lease, instead of silently stopping the message poller forever.

- **Root cause**: `InteractiveAttachment`'s `onTerminal` handler (and the phase watcher's missing branch for "lease reaped with no competitor") would leave the poller running against a workflow that had already evicted us, so cues piled up in `pendingMessages` indefinitely. Repeatable on every laptop-sleep event.
- **Fix**: new opt-in reconnect path on `BaseAttachment` — `shouldReconnect(reason)` hook + `runReconnectLoop()` with abortable backoff, pre-reclaim state check, and new-runId handle rebuild. `InteractiveAttachment` opts in for `heartbeat-timeout` + `superseded`. Copilot SDK adapter keeps the old behavior until reconnect is proven safe there.
- **New `DetachReason`**: `reconnect-exhausted` — fired when the 15-min elapsed budget elapses without recovering a live lease. Distinct from `heartbeat-timeout` so post-mortems can tell "lease expired once" from "adapter tried to recover and gave up".
- **Wire-protocol**: no changes. Read-only consumer of existing `claimAttachment` / `attachmentInfo` surfaces.

## Test plan

- [x] `npm run build` clean
- [x] `npx mocha --no-config --require ts-node/register test/adapter-reconnect.test.ts` — 5 passing in ~6s
- [x] `npm test` — full suite (729 Mocha + 76 Vitest) green
- [x] `npx tsc --noEmit` clean
- [ ] QA: verify a real laptop-sleep recovery cycle once merged (out of CI scope — needs real detach/reattach)

New test cases in `test/adapter-reconnect.test.ts`:
1. `shouldReconnect` returns `true` only for `heartbeat-timeout` + `superseded`.
2. `abortableSleep` resolves on timer.
3. `abortableSleep` rejects with `aborted:stopped` when `stopV2Lifecycle` fires during sleep.
4. **Integration**: adapter re-claims and resumes delivery after a `forceDetach` reap; new attachmentId differs from the pre-reap one; terminal listener is NOT fired.
5. **Integration**: if the workflow is destroyed mid-reconnect, the adapter fires `destroy` terminal (not `reconnect-exhausted`).

Closes #201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)