### PR TITLE
docs: wire-protocol reconnect-exhausted + beta2 docs reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sessions now self-heal after laptop sleep / network drop.** `InteractiveAttachment` opts into
+  the new reconnect loop in `BaseAttachment`: when the workflow revokes a lease (heartbeat-timeout
+  or superseded), the adapter re-attempts `claimAttachment` with exponential back-off for up to
+  15 minutes before giving up. Previously, any lease revocation caused permanent shutdown.
+  Adds `DetachReason: 'reconnect-exhausted'` for the terminal case. (#201 / #205)
+
 ### BREAKING CHANGES
 
 - **Dropped Node 18 support.** Minimum is now Node 20.

--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -370,3 +370,4 @@ String union used in `requestDetach`, `adapterExited`, and `forceDetach` to reco
 | `'spawn-failed'` | Spawn activity for a new attachment failed; workflow self-heals to `detached`. |
 | `'destroy'` | Session permanently destroyed via the `destroy` update. |
 | `'force'` | Main loop fired `drainingDeadline` — adapter sent `requestDetach` but never sent `adapterExited` within the grace period. Implementation extension; may merge with `'heartbeat-timeout'` in a future cleanup. |
+| `'reconnect-exhausted'` | **v0.26.** Adapter exhausted its 15-minute reconnect budget without successfully re-claiming the session. Terminal — the adapter shuts down after emitting this reason. Added in #205. |

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -51,7 +51,10 @@ non-`gone` attachment phase (attached, awaiting, processing, draining, detached)
 
 **Detach** / **Destroy** — The two ways to end a session's current run:
 - `detach` gracefully reaps the adapter; the workflow survives in `detached` phase and can be
-  `restart`ed later with full history intact.
+  `restart`ed later with full history intact. Note: `detached` can be transient — adapters that
+  opt into reconnect (`shouldReconnect()`) will attempt to re-claim the session internally before
+  surfacing a permanent detach. If the 15-minute reconnect budget expires without success, the
+  adapter emits `DetachReason: 'reconnect-exhausted'` and shuts down.
 - `destroy` terminally ends the workflow (phase → `gone`), abandoning any in-flight outbox
   entries. Irreversible.
 

--- a/src/adapters/README.md
+++ b/src/adapters/README.md
@@ -39,6 +39,25 @@ Two classes today (design §3.1, §4.1):
 
 Pick the class whose delivery model matches your agent's behavior. If the agent blocks on an LLM turn inside `deliver()`, you want `sdk` and `SdkAttachment` (PR-C centralizes the `processingStart`/`End` wrapping there).
 
+## Reconnect opt-in (`shouldReconnect`)
+
+**Added in #205 (v0.26).** `BaseAttachment` includes a built-in reconnect loop that fires when the phase watcher detects `phase=detached, currentAttachment=undefined` (lease revoked by the workflow — e.g. heartbeat-timeout after a laptop sleep). By default the loop is **disabled**; adapters opt in by overriding `shouldReconnect()`:
+
+```ts
+protected shouldReconnect(reason: DetachReason): boolean {
+  // Return true to attempt re-claim instead of shutting down immediately.
+  return reason === 'superseded' || reason === 'heartbeat-timeout';
+}
+```
+
+**Shipped opt-ins:**
+- `InteractiveAttachment` opts in for `'superseded'` and `'heartbeat-timeout'`.
+- `CopilotSdkAttachment` (SDK adapters generally) does **not** opt in — pull adapters own their own session lifecycle.
+
+**Budget and behaviour:** The loop retries with exponential back-off for up to **15 minutes** of elapsed wall time. On each attempt it calls `attachmentInfo` to verify the session isn't `'gone'` before attempting `claimAttachment`. If the budget expires or the workflow is `gone`, the adapter emits `DetachReason: 'reconnect-exhausted'` and shuts down cleanly.
+
+Adapter authors should only opt in if the adapter can meaningfully re-establish state after a lease gap (i.e., the agent process is still alive and can resume work).
+
 ## Adding a new adapter
 
 1. **Create a directory** under `src/adapters/<your-adapter>/` with `adapter.ts` and `index.ts`.


### PR DESCRIPTION
## Summary

- **`docs/WIRE-PROTOCOL.md`** — adds `'reconnect-exhausted'` to the `DetachReason` enum table (additive, non-breaking on signal wire)
- **`docs/concepts.md`** — notes that `detached` can be transient while `InteractiveAttachment` runs the reconnect loop; reconnect is adapter-local and invisible to the wire protocol
- **`src/adapters/README.md`** — documents the `shouldReconnect()` opt-in hook: 15-min budget, back-off, which adapters opt in (`InteractiveAttachment` for `superseded`/`heartbeat-timeout`), and which skip it (SDK adapters)
- **`CHANGELOG.md`** `[Unreleased]` — adds `### Fixed` entry for #201/#205 (session self-heal after sleep/lease-expired); existing `### BREAKING CHANGES` entry for Node 18 drop reads cleanly

## Verification

- **Node 18 scan**: no stray references found in `docs/`, `examples/`, or `.github/` beyond historical ops docs and CHANGELOG
- **CHANGELOG structure**: `### Fixed` → `### BREAKING CHANGES` order under `[Unreleased]` — no conflicts with tempo-lead's existing section

## Test plan

- [ ] Review `DetachReason` table row for `'reconnect-exhausted'` — matches `src/types.ts` entry added in #205
- [ ] Review concepts.md transient-detached note — accurate per architect's design (no new phase, reconnect is adapter-local)
- [ ] Review adapters/README.md reconnect section — matches `BaseAttachment.shouldReconnect()` and `runReconnectLoop` implementation in #205
- [ ] Review CHANGELOG `### Fixed` entry — user-facing language, references correct PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)