### PR TITLE
refactor(wire)!: drop v0.26 updateMetadata.status compat shim + vestigial surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   declared supported surface with reality and removes the unsupported
   matrix slot, saving ~6 min per CI run. Users still on Node 18 must
   upgrade to Node 20 LTS (or later) before installing claude-tempo.
+- **`updateMetadata` signal no longer accepts `status` field.** The
+  legacy `status` field (kept as a TypeScript wire-compat vestige in
+  v0.26-beta.1 so older clients wouldn't get a schema-mismatch on
+  TypeScript type-check) has been removed from the signal's TypeScript
+  payload type. Runtime behavior is unchanged — the handler has ignored
+  the field since #175. Callers passing
+  `status: 'active' | 'pending' | 'terminated'` in `updateMetadata`
+  payloads must drop the field; attachment phase is driven by the V2
+  wire surface (`claimAttachment` / `adapterExited` / `forceDetach` /
+  `destroyUpdate`), visible via the `attachmentInfo` workflow query and
+  the `ClaudeTempoAttachmentState` search attribute.
+- **`createWorker()` factory removed** from `src/worker.ts`. The
+  function has thrown-on-call since v0.10. Use `createWorkers()` which
+  returns `{ sharedWorker, hostWorker }` — both must be run for
+  cross-machine recruiting to function.
+- **`src/tui/client.ts` back-compat re-export removed.** The shim
+  re-exported `createTempoClient` from `src/client/` for v0.24 TUI
+  compatibility. Internal consumers migrated by v0.26-beta.1 (#177).
+  Any external importer of `claude-tempo/tui/client` must switch to
+  `claude-tempo/client`.
 
 ## [0.26.0-beta.1] - 2026-04-18
 

--- a/src/adapters/copilot/adapter.ts
+++ b/src/adapters/copilot/adapter.ts
@@ -420,9 +420,8 @@ export class CopilotSdkAttachment extends SdkAttachment {
     // loss can't drop the event.
     this.onTerminal((reason) => {
       log(`V2 terminal (${reason}) — triggering cleanup`);
-      // Fire-and-forget: `cleanup` is idempotent and `signalTermination=false`
-      // because the workflow is either gone, destroyed, or about to reap us.
-      cleanup(false).catch((err) => log('terminal cleanup error:', err?.message ?? err));
+      // Fire-and-forget: `cleanup` is idempotent.
+      cleanup().catch((err) => log('terminal cleanup error:', err?.message ?? err));
     });
     try {
       // PR-D: read pre-claimed attachmentId (set by the spawn activity when
@@ -482,10 +481,8 @@ export class CopilotSdkAttachment extends SdkAttachment {
     let interval: ReturnType<typeof setInterval> | undefined;
 
     // Shared cleanup — disconnects session, removes PID file, stops client.
-    // `_signalTermination` is retained for call-site compatibility but no longer
-    // drives any workflow signal (PR-C commit 4 retired the legacy status signal).
     let shuttingDown = false;
-    const cleanup = async (_signalTermination: boolean) => {
+    const cleanup = async () => {
       if (shuttingDown) return;
       shuttingDown = true;
       polling = false;
@@ -584,7 +581,7 @@ export class CopilotSdkAttachment extends SdkAttachment {
           const wfStatus = desc.status.name;
           if (wfStatus !== 'RUNNING') {
             log(`Workflow status is ${wfStatus} — exiting cleanly`);
-            await cleanup(false); // workflow already gone, don't signal
+            await cleanup();
             process.exit(0);
           }
           // Also check the in-workflow destroy flag — the workflow may still be RUNNING
@@ -594,14 +591,14 @@ export class CopilotSdkAttachment extends SdkAttachment {
             const isDestroyed: boolean = await handle.query('isDestroyed');
             if (isDestroyed) {
               log('Workflow destroyed — exiting cleanly');
-              await cleanup(false);
+              await cleanup();
               process.exit(0);
             }
           } catch { /* isDestroyed query unavailable pre-upgrade — safe to ignore */ }
         } catch (err: any) {
           // If we can't describe (e.g., workflow not found), it was likely terminated
           log(`Workflow describe failed: ${err?.message} — treating as terminated`);
-          await cleanup(false);
+          await cleanup();
           process.exit(0);
         }
       }
@@ -697,7 +694,7 @@ export class CopilotSdkAttachment extends SdkAttachment {
           const recovered = await recreateSession();
           if (!recovered) {
             log('ERROR: Session recovery failed. Shutting down bridge.');
-            await cleanup(true);
+            await cleanup();
             process.exit(2);
           }
         }
@@ -710,7 +707,7 @@ export class CopilotSdkAttachment extends SdkAttachment {
     // Graceful shutdown on SIGINT/SIGTERM — signal the workflow before exiting
     const shutdown = async () => {
       log('Shutting down (signal received)...');
-      await cleanup(true);
+      await cleanup();
       process.exit(0);
     };
 

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -459,7 +459,6 @@ export function createTempoClient(client: Client): TempoClient {
           hostname: 'dashboard',
           workDir: process.cwd(),
           isConductor: false,
-          status: 'active',
           agentType: 'claude',
           playerType: 'maestro',
           playerTypeDescription: 'TUI dashboard — human operator interface',

--- a/src/server.ts
+++ b/src/server.ts
@@ -194,12 +194,12 @@ async function main() {
   }
 
   // If the workflow was pre-created by a recruiter, update it with real metadata
-  // and mark the session as active now that it's connected.
+  // now that it's connected. Attachment phase (not the removed `status` field)
+  // is driven by the V2 wire surface — see claimAttachment / adapterExited.
   await handle.signal('updateMetadata', {
     hostname: os.hostname(),
     gitRoot,
     gitBranch,
-    status: 'active',
     enableStaleDetection: true,
     ...(playerType ? { playerType } : {}),
     ...(playerTypeDescription ? { playerTypeDescription } : {}),

--- a/src/tui/client.ts
+++ b/src/tui/client.ts
@@ -1,6 +1,0 @@
-/**
- * Re-export TempoClient from src/client/ for backward compatibility.
- * All new consumers should import from '../client' directly.
- */
-export { createTempoClient } from '../client';
-export type { TempoClient, EnsembleSummary } from '../client';

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -96,14 +96,3 @@ export async function createWorkers(config: Config): Promise<DualWorkers> {
 
   return { sharedWorker, hostWorker };
 }
-
-/**
- * @deprecated Removed in v0.10 — use `createWorkers()` instead.
- * The old single-worker API silently leaked the hostWorker and broke
- * cross-machine recruiting.
- */
-export async function createWorker(_config: Config): Promise<never> {
-  throw new Error(
-    'createWorker() has been removed. Use createWorkers() instead — it returns { sharedWorker, hostWorker } and both must be run.',
-  );
-}

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -396,11 +396,9 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
     if (update.sessionId != null || (update as any).claudeSessionId != null) {
       input.metadata.sessionId = update.sessionId ?? (update as any).claudeSessionId;
     }
-    // `update.status` / `update.enableStaleDetection` are silently dropped.
-    // Status tracking was removed in #175–#176 — attachment phase (set by the
-    // V2 wire surface: claimAttachment / adapterExited / forceDetach / destroy)
-    // is authoritative. The signal wire shape keeps these optional fields for
-    // backward compat with older clients; their values are no-ops.
+    // `update.enableStaleDetection` is silently dropped — attachment phase
+    // (driven by the V2 wire surface: claimAttachment / adapterExited /
+    // forceDetach / destroy) is authoritative for lifecycle state.
     upsertSearchAttributes({
       ClaudeTempoEnsemble: [input.metadata.ensemble],
       ClaudeTempoPlayerId: [input.metadata.playerId],

--- a/src/workflows/signals.ts
+++ b/src/workflows/signals.ts
@@ -65,7 +65,7 @@ export const recordSentMessageSignal = defineSignal<[{ to: string; text: string 
 export const setPartSignal = defineSignal<[string]>('setPart');
 export const markDeliveredSignal = defineSignal<[string[]]>('markDelivered');
 export const setNameSignal = defineSignal<[string]>('setName');
-export const updateMetadataSignal = defineSignal<[{ hostname?: string; gitBranch?: string; gitRoot?: string; status?: string; terminatedBy?: string; enableStaleDetection?: boolean; playerType?: string; playerTypeDescription?: string; worktreePath?: string; sessionId?: string }]>('updateMetadata');
+export const updateMetadataSignal = defineSignal<[{ hostname?: string; gitBranch?: string; gitRoot?: string; terminatedBy?: string; enableStaleDetection?: boolean; playerType?: string; playerTypeDescription?: string; worktreePath?: string; sessionId?: string }]>('updateMetadata');
 
 // ── Player Queries ──
 

--- a/test/activities.test.ts
+++ b/test/activities.test.ts
@@ -60,9 +60,6 @@ function mockHandle(opts: {
   const signals: Array<{ name: string; args: unknown }> = [];
   const updates: Array<{ name: string; args: unknown }> = [];
 
-  // `status` field removed from `SessionMetadata` in #176; strip it off any
-  // `opts.metadata` override that still carries it (most tests predate the removal).
-  const { status: _legacyStatus, ...mdOverrides } = (opts.metadata ?? {}) as Partial<SessionMetadata> & { status?: string };
   const defaultMetadata: SessionMetadata = {
     playerId: 'player-1',
     ensemble: 'test-ensemble',
@@ -70,7 +67,7 @@ function mockHandle(opts: {
     workDir: '/tmp/work',
     isConductor: false,
     agentType: 'claude',
-    ...mdOverrides,
+    ...(opts.metadata ?? {}),
   };
 
   // Normalize: callers may pass either a string or a typed constant from
@@ -271,7 +268,6 @@ describe('scanEnsembleSessions', function () {
         isConductor: true,
         agentType: 'copilot',
         playerType: 'tempo-conductor',
-        status: 'active',
       },
     });
     const client = mockClient([h]);
@@ -533,9 +529,9 @@ describe('fireSchedule', function () {
   });
 
   it('delivers to all non-conductor sessions when target is "all"', async function () {
-    const player1 = mockHandle({ metadata: { playerId: 'p1', ensemble: 'e1', isConductor: false, status: 'active' } });
-    const player2 = mockHandle({ metadata: { playerId: 'p2', ensemble: 'e1', isConductor: false, status: 'active' } });
-    const conductor = mockHandle({ metadata: { playerId: 'cond', ensemble: 'e1', isConductor: true, status: 'active' } });
+    const player1 = mockHandle({ metadata: { playerId: 'p1', ensemble: 'e1', isConductor: false } });
+    const player2 = mockHandle({ metadata: { playerId: 'p2', ensemble: 'e1', isConductor: false } });
+    const conductor = mockHandle({ metadata: { playerId: 'cond', ensemble: 'e1', isConductor: true } });
     const client = mockClient([player1, player2, conductor]);
     const activities = createScheduleActivities(client as any);
 
@@ -609,7 +605,6 @@ describe('maestro activities', function () {
           isConductor: false,
           agentType: 'claude',
           playerType: 'tempo-soloist',
-          status: 'active',
         },
         part: 'coding features',
       });

--- a/test/destroy.test.ts
+++ b/test/destroy.test.ts
@@ -54,7 +54,7 @@ describe('destroy verb — fixes #102 (graceful stop → resurrection loop)', fu
       const ensemble = `destroy-attach-${Date.now()}`;
       // Start a live session, destroy it, then try to sneak in a processingStart update.
       const handle = await startSession({
-        metadata: playerMetadata({ playerId: 'destroy-attach', ensemble, status: 'active' }),
+        metadata: playerMetadata({ playerId: 'destroy-attach', ensemble }),
       });
 
       await handle.executeUpdate(destroyUpdate, { args: [{ reason: 'test' }] });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -222,20 +222,8 @@ export async function withWorkerAndActivities<T>(fn: () => Promise<T>): Promise<
   return worker.runUntil(fn);
 }
 
-/**
- * Options accepted by {@link playerMetadata}.
- *
- * `status` is not a `SessionMetadata` field anymore (removed in #176) — but many
- * pre-existing test cases still pass a legacy `status: 'pending' | 'active'` etc.
- * The helper accepts it for test ergonomics and silently drops it; those tests
- * are either already skipped (#175 followup) or will be rewritten against
- * `attachmentInfo.phase` in #178.
- */
-export type TestMetadataOverrides = Partial<SessionMetadata> & { status?: string };
-
 /** Default metadata for a player session. Override fields as needed. */
-export function playerMetadata(overrides: TestMetadataOverrides = {}): SessionMetadata {
-  const { status: _legacyStatus, ...rest } = overrides;
+export function playerMetadata(overrides: Partial<SessionMetadata> = {}): SessionMetadata {
   return {
     playerId: `player-${Date.now()}`,
     ensemble: 'test-ensemble',
@@ -243,12 +231,12 @@ export function playerMetadata(overrides: TestMetadataOverrides = {}): SessionMe
     workDir: '/tmp/test',
     isConductor: false,
     agentType: 'claude',
-    ...rest,
+    ...overrides,
   };
 }
 
 /** Default metadata for a conductor session. Override fields as needed. */
-export function conductorMetadata(overrides: TestMetadataOverrides = {}): SessionMetadata {
+export function conductorMetadata(overrides: Partial<SessionMetadata> = {}): SessionMetadata {
   return playerMetadata({
     playerId: 'conductor',
     isConductor: true,

--- a/test/hold-release.test.ts
+++ b/test/hold-release.test.ts
@@ -285,7 +285,7 @@ describe('hold and release (warm hold)', function () {
 
         // Create an active (non-held) session
         const activeHandle = await startSession({
-          metadata: playerMetadata({ playerId: 'active-player', ensemble, status: 'active' }),
+          metadata: playerMetadata({ playerId: 'active-player', ensemble }),
         });
 
         const handle = await startSession({

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -739,7 +739,9 @@ function makeClientWithPlayers(
     playerId: string;
     ensemble?: string;
     playerType?: string;
-    status?: string;
+    /** Attachment phase exposed via `ClaudeTempoAttachmentState` search attribute.
+     *  Defaults to `'attached'` (the "live, deliverable" phase) when omitted. */
+    phase?: 'booting' | 'attached' | 'processing' | 'awaiting' | 'draining' | 'detached' | 'gone';
   }>,
 ): Client {
   return {
@@ -768,23 +770,13 @@ function makeClientWithPlayers(
       }),
       start: async () => ({ runId: 'fake-run-id' }),
       list: async function* () {
-        // Post-#176: broadcast/ensemble filtering reads phase from the
-        // `ClaudeTempoAttachmentState` search attribute. Synthesize phase
-        // values here from the test's legacy `status` field so existing
-        // tests continue to exercise the filter logic:
-        //   active → attached, stale → detached, pending → booting,
-        //   terminated → gone, blocked → detached, undefined → attached.
-        const statusToPhase = (status: string | undefined): string => {
-          if (status === 'stale' || status === 'blocked') return 'detached';
-          if (status === 'pending') return 'booting';
-          if (status === 'terminated') return 'gone';
-          return 'attached';
-        };
+        // Broadcast/ensemble filtering reads phase from the
+        // `ClaudeTempoAttachmentState` search attribute (v0.26).
         for (const p of players) {
           yield {
             workflowId: `claude-session-${testConfig.ensemble}-${p.playerId}`,
             searchAttributes: {
-              ClaudeTempoAttachmentState: [statusToPhase(p.status)],
+              ClaudeTempoAttachmentState: [p.phase ?? 'attached'],
             },
           };
         }
@@ -848,8 +840,8 @@ describe('broadcast tool validation', function () {
       registerBroadcastTool(
         server,
         makeClientWithPlayers([
-          { playerId: 'stale-player', status: 'stale' },
-          { playerId: 'active-player', status: 'active' },
+          { playerId: 'stale-player', phase: 'detached' },
+          { playerId: 'active-player', phase: 'attached' },
         ]),
         testConfig,
         getPlayerId,
@@ -867,7 +859,7 @@ describe('broadcast tool validation', function () {
       registerBroadcastTool(
         server,
         makeClientWithPlayers([
-          { playerId: 'stale-player', status: 'stale' },
+          { playerId: 'stale-player', phase: 'detached' },
         ]),
         testConfig,
         getPlayerId,
@@ -884,8 +876,8 @@ describe('broadcast tool validation', function () {
       registerBroadcastTool(
         server,
         makeClientWithPlayers([
-          { playerId: 'pending-player', status: 'pending' },
-          { playerId: 'active-player', status: 'active' },
+          { playerId: 'pending-player', phase: 'booting' },
+          { playerId: 'active-player', phase: 'attached' },
         ]),
         testConfig,
         getPlayerId,
@@ -903,8 +895,8 @@ describe('broadcast tool validation', function () {
       registerBroadcastTool(
         server,
         makeClientWithPlayers([
-          { playerId: 'terminated-player', status: 'terminated' },
-          { playerId: 'active-player', status: 'active' },
+          { playerId: 'terminated-player', phase: 'gone' },
+          { playerId: 'active-player', phase: 'attached' },
         ]),
         testConfig,
         getPlayerId,
@@ -922,9 +914,9 @@ describe('broadcast tool validation', function () {
       registerBroadcastTool(
         server,
         makeClientWithPlayers([
-          { playerId: 'pending-player', status: 'pending' },
-          { playerId: 'terminated-player', status: 'terminated' },
-          { playerId: 'stale-player', status: 'stale' },
+          { playerId: 'pending-player', phase: 'booting' },
+          { playerId: 'terminated-player', phase: 'gone' },
+          { playerId: 'stale-player', phase: 'detached' },
         ]),
         testConfig,
         getPlayerId,
@@ -1191,7 +1183,6 @@ function makeV2Client(opts: {
           workDir: '/work',
           isConductor: false,
           agentType,
-          status: 'active',
           adapterId: agentType === 'copilot' ? 'copilot' : 'claude-code',
           sessionId: 'sess-uuid',
         };

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -338,7 +338,7 @@ describe('claudeSessionWorkflow', function () {
       await withWorker(async () => {
         // Simulate what recruit does: start workflow with pre-loaded messages
         const handle = await startSession({
-          metadata: playerMetadata({ playerId: 'precreated-1', status: 'pending' }),
+          metadata: playerMetadata({ playerId: 'precreated-1' }),
           messages: [{
             id: 'pre-msg-1',
             from: 'conductor',
@@ -368,7 +368,7 @@ describe('claudeSessionWorkflow', function () {
     it('pre-loaded message can be delivered alongside new messages', async function () {
       await withWorker(async () => {
         const handle = await startSession({
-          metadata: playerMetadata({ playerId: 'precreated-2', status: 'pending' }),
+          metadata: playerMetadata({ playerId: 'precreated-2' }),
           messages: [{
             id: 'pre-msg-2',
             from: 'conductor',


### PR DESCRIPTION
## Summary

Finishes the v0.26 wire-compat cleanup epic (closes out #174–#178 residuals). Drops dead code that served as v0.25 → v0.26 migration bridges and is no longer exercised by any internal caller.

## BREAKING CHANGE

`updateMetadata` signal's **TypeScript payload** no longer accepts a `status` field. **Runtime behavior is unchanged** — the handler has ignored the field since #175. TypeScript callers passing `status: 'active' | 'pending' | 'terminated'` must drop it. Attachment phase is driven by the V2 wire surface (`claimAttachment` / `adapterExited` / `forceDetach` / `destroyUpdate`), readable via the `attachmentInfo` query and the `ClaudeTempoAttachmentState` search attribute.

CHANGELOG `[Unreleased]` → `### BREAKING CHANGES` updated (4 new entries alongside the existing Node 18 drop).

## Verification notes for QA

**The Zod-strict question** (raised pre-commit): `updateMetadataSignal` uses `@temporalio/workflow` `defineSignal<T>()` — a **compile-time TypeScript generic only**. Temporal does NOT validate signal argument shapes at runtime (no Zod, no strict mode). An older client sending `status: 'active'` will still reach the handler; the handler simply ignores the field (as it has since #175).

**The "BREAKING" classification is a TypeScript-consumer contract break, not a wire break.** Wire protocol (`docs/WIRE-PROTOCOL.md`) is unaffected. QA: worth confirming on the signal-receive side, but the production `setHandler(updateMetadataSignal, ...)` at `src/workflows/session.ts:389` has never read `update.status`.

**`ClaudeTempoStatus` search attribute check**: verified zero code references post-#178 — all remaining hits are migration-guide documentation breadcrumbs.

## Scope breakdown

### Bucket A — zero-caller removals (3 items)

| Surface | Action | Rationale |
|---|---|---|
| `src/tui/client.ts` | Delete file (7-line re-export shim) | Zero importers (migrated in #177). CLAUDE.md flagged as shim. |
| `src/worker.ts:createWorker()` | Remove throw-stub function (~10 lines) | `@deprecated Removed in v0.10`. Throws on call; zero internal callers. |
| `src/adapters/copilot/adapter.ts` | Remove unused `_signalTermination` param from internal `cleanup()` + update 6 call sites | Dead parameter per stale comment. |

### Bucket B — coordinated `status` field removal

**Production code** (4 files):
- `src/workflows/signals.ts` — drop `status?: string` from `updateMetadataSignal` payload type
- `src/workflows/session.ts` — simplify handler comment
- `src/server.ts` — drop dead `status: 'active'` write on workflow connect
- `src/client/index.ts` — drop dead `status: 'active'` on maestro sessionInput

**Test code** (6 files):
- `test/helpers.ts` — remove `TestMetadataOverrides` type + `_legacyStatus` destruct
- `test/activities.test.ts` — remove `_legacyStatus` destruct; drop `status:` from 5 fixture sites
- `test/destroy.test.ts`, `test/hold-release.test.ts`, `test/workflow.test.ts` — drop `status:` from 4 `playerMetadata()` calls
- `test/tools.test.ts` — refactor `makeClientWithPlayers` fixture: legacy `status` input → `phase` input, delete `statusToPhase()` synthesizer, update 9 broadcast-tool call sites

### Bucket C — left alone (with reasoning)

- All `v0.25` / `PR-*` / "legacy" JSDoc history breadcrumbs (design-history docs)
- `docs/ops/v0.25-beta1-release-checklist.md` (historical release record)
- `src/tools/broadcast.ts:includeStale` arg name (public MCP tool API, docstring notes intentional)
- Pre-v0.25 legacy surfaces (`v0.24` numeric timestamps, pre-PR-B `agent` field, pre-v0.25 `adapterId` defaulting) — out of scope per conductor's "v0.26 specifically" guidance
- Unrelated `status` fields: `QualityGateCriterion`, `QualityGate`, `PlayerReport`, `StageEntry`, `OutboxEntry`, `MaestroRelayMessage`, `Splash`, `SET_SPLASH_STATUS` TUI action (different concept)

## Diff

```
 CHANGELOG.md                    | 20 ++++++++++++++++++++
 src/adapters/copilot/adapter.ts | 19 ++++++++-----------
 src/client/index.ts             |  1 -
 src/server.ts                   |  4 ++--
 src/tui/client.ts               |  6 ------ (deleted)
 src/worker.ts                   | 11 -----------
 src/workflows/session.ts        |  8 +++-----
 src/workflows/signals.ts        |  2 +-
 test/activities.test.ts         | 13 ++++---------
 test/destroy.test.ts            |  2 +-
 test/helpers.ts                 | 18 +++---------------
 test/hold-release.test.ts       |  2 +-
 test/tools.test.ts              | 41 ++++++++++++++++-------------------------
 test/workflow.test.ts           |  4 ++--
 14 files changed, 61 insertions(+), 90 deletions(-)
```

Net **-29 LoC** (including +20 for CHANGELOG BREAKING entries).

## Test plan

- [x] `npm run build` — clean (workflow-bundle.js regenerated per Temporal rebuild requirement)
- [x] `npm test` — **729 passing, 23 pending, 0 failing** (Mocha + Vitest, ~6 min local)
- [ ] CI green on PR

## Follow-ups (out of scope)

- `updateMetadataSignal` payload also carries `terminatedBy?` and `enableStaleDetection?` — same-category vestiges the handler ignores. Candidate for a follow-up PR.
- Stray garbage file at repo root: `Creposclaude-tempomaestro-history.json` — daemon path-construction bug, logged by conductor as separate issue.