### PR TITLE
perf(test): parametrize scheduler grace period to avoid 35s wall-clock wait

### DIFF
--- a/src/workflows/scheduler.ts
+++ b/src/workflows/scheduler.ts
@@ -25,12 +25,23 @@ const { fireSchedule, computeNextCronFire } = proxyActivities<ScheduleActivities
   retry: { maximumAttempts: 3 },
 });
 
+/** Default self-termination grace period — 30 000 ms (see §scheduler "empty self-terminate"). */
+const DEFAULT_GRACE_PERIOD_MS = 30_000;
+
 export interface SchedulerInput {
   ensemble: string;
   /** Restored from continue-as-new. */
   entries?: ScheduleEntry[];
   /** Restored from continue-as-new: paused state. */
   paused?: boolean;
+  /**
+   * Milliseconds to wait for new entries before the workflow self-terminates when the
+   * entries list is empty. Defaults to {@link DEFAULT_GRACE_PERIOD_MS} — 30s in production.
+   * Tests override (e.g. to 100ms) to keep the "self-terminates when empty" case fast;
+   * `setupTestEnv` uses `createLocal()` so this delay is real wall-clock time.
+   * Always propagated via continue-as-new so behavior stays consistent across re-entries.
+   */
+  gracePeriodMs?: number;
 }
 
 export async function claudeSchedulerWorkflow(input: SchedulerInput): Promise<void> {
@@ -38,6 +49,7 @@ export async function claudeSchedulerWorkflow(input: SchedulerInput): Promise<vo
   let dirty = false; // flag to wake the loop when signals arrive
   let schedulerPaused = input.paused ?? false;
   let skippedWhilePaused = 0;
+  const gracePeriodMs = input.gracePeriodMs ?? DEFAULT_GRACE_PERIOD_MS;
 
   // ── Signal Handlers ──
 
@@ -84,9 +96,11 @@ export async function claudeSchedulerWorkflow(input: SchedulerInput): Promise<vo
   while (true) {
     // Self-terminate when empty
     if (entries.length === 0) {
-      // Wait a short period for new entries to arrive before terminating
+      // Wait `gracePeriodMs` for new entries to arrive before terminating.
+      // Production default is 30s; tests override via `SchedulerInput.gracePeriodMs`
+      // because `TestWorkflowEnvironment.createLocal()` does NOT time-skip.
       dirty = false;
-      await condition(() => dirty, '30 seconds');
+      await condition(() => dirty, gracePeriodMs);
       if (entries.length === 0) break;
     }
 
@@ -165,6 +179,9 @@ export async function claudeSchedulerWorkflow(input: SchedulerInput): Promise<vo
         ensemble: input.ensemble,
         entries,
         paused: schedulerPaused,
+        // Propagate the configured grace period — omitting this would silently
+        // revert tests that set a short window back to the 30s default on re-entry.
+        gracePeriodMs: input.gracePeriodMs,
       });
     }
   }

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -41,14 +41,29 @@ function makeEntry(overrides: Partial<ScheduleEntry> & { name: string; message: 
   };
 }
 
+interface StartSchedulerOptions {
+  /**
+   * Override the empty-entries self-termination grace period. Defaults to the
+   * workflow's production 30 000ms. Tests that assert self-terminate behavior
+   * shrink this to ~100ms so the whole scenario runs in under a second
+   * (`createLocal()` does not time-skip).
+   */
+  gracePeriodMs?: number;
+}
+
 async function startScheduler(
   client: Client,
   entries: ScheduleEntry[] = [],
+  options: StartSchedulerOptions = {},
 ): Promise<WorkflowHandle> {
   return client.workflow.start('claudeSchedulerWorkflow', {
     workflowId: schedulerWorkflowId(ENSEMBLE),
     taskQueue: SCHEDULER_TASK_QUEUE,
-    args: [{ ensemble: ENSEMBLE, entries }],
+    args: [{
+      ensemble: ENSEMBLE,
+      entries,
+      ...(options.gracePeriodMs !== undefined ? { gracePeriodMs: options.gracePeriodMs } : {}),
+    }],
   });
 }
 
@@ -586,17 +601,23 @@ describe('claudeSchedulerWorkflow', function () {
 
   describe('self-termination', function () {
     it('self-terminates when schedule list is empty after grace period', async function () {
-      this.timeout(45_000);
+      // With a 100ms grace period the workflow self-terminates in <1s; the suite
+      // used to wait 35 real seconds on every run (#209).
+      this.timeout(10_000);
 
       await withWorkerAndActivities(async () => {
-        const handle = await startScheduler(getClient());
+        const handle = await startScheduler(getClient(), [], { gracePeriodMs: 100 });
 
-        // Empty scheduler should self-terminate after ~30s
-        // Wait and check status
-        await sleep(35_000);
-
-        const desc = await handle.describe();
-        expect(desc.status.name).to.equal('COMPLETED');
+        // Poll `describe()` until COMPLETED (or timeout via mocha). Real-time
+        // delay is dominated by the 100ms `condition()` + workflow-task dispatch.
+        const deadline = Date.now() + 5_000;
+        let last: Awaited<ReturnType<typeof handle.describe>> | undefined;
+        while (Date.now() < deadline) {
+          last = await handle.describe();
+          if (last.status.name === 'COMPLETED') break;
+          await sleep(50);
+        }
+        expect(last?.status.name).to.equal('COMPLETED');
       });
     });
   });


### PR DESCRIPTION
## Summary

Closes #209. Replaces a 35-second `setTimeout` in the scheduler self-terminate test with a short, overridable grace period — cuts ~33s off every `npm test` run.

## Investigation

Per the conductor's guidance, started with Option 2: is the test already time-skippable? **No** — `setupTestEnv()` uses `TestWorkflowEnvironment.createLocal()`, not `createTimeSkipping()`. The workflow's `condition(..., '30 seconds')` on `src/workflows/scheduler.ts:89` is therefore real wall-clock time.

Went with **Option 1** (parametrize):
- `SchedulerInput` gains an optional `gracePeriodMs` field. Default matches the production constant (30 000ms) so existing callers are unaffected.
- Propagated through `continueAsNew` so a shrunken grace period doesn't silently revert to 30s after a bundle re-entry.
- Test passes `100` and polls `handle.describe()` until `COMPLETED` (cap: 5s).

## Results

| Metric | Before | After |
|---|---|---|
| self-terminate test | 35s | ~2s |
| `test/scheduler.test.ts` file | 76s | 41s |
| `npm test` (full Mocha) | 6m | 5m |

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` rebuilds workflow bundle
- [x] `npx mocha --grep "self-terminates"` — 1 passing (2s)
- [x] `npx mocha test/scheduler.test.ts` — 16 passing (41s)
- [x] `npm test` — 729 Mocha + 76 Vitest green

Wire-protocol: no changes (additive workflow input field).

🤖 Generated with [Claude Code](https://claude.com/claude-code)