### PR TITLE
chore: release v0.26.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.0-beta.2] - 2026-04-18
+
+> **Beta release.** Fixes the adapter poller reconnect bug (#201), drops Node 18,
+> and removes the last v0.26 wire-compat vestiges.
+>
+> **Install:** `npm i -g claude-tempo@0.26.0-beta.2`
+> **Rollback:** `npm i -g claude-tempo@0.26.0-beta.1`
+
 ### Fixed
 
 - **Sessions now self-heal after laptop sleep / network drop.** `InteractiveAttachment` opts into
   the new reconnect loop in `BaseAttachment`: when the workflow revokes a lease (heartbeat-timeout
   or superseded), the adapter re-attempts `claimAttachment` with exponential back-off for up to
   15 minutes before giving up. Previously, any lease revocation caused permanent shutdown.
-  Adds `DetachReason: 'reconnect-exhausted'` for the terminal case. (#201 / #205)
+  Adds `DetachReason: 'reconnect-exhausted'` for the terminal case. (closes #201, #205)
 
 ### BREAKING CHANGES
 
@@ -23,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   because npm's engines field is advisory. This change aligns the
   declared supported surface with reality and removes the unsupported
   matrix slot, saving ~6 min per CI run. Users still on Node 18 must
-  upgrade to Node 20 LTS (or later) before installing claude-tempo.
+  upgrade to Node 20 LTS (or later) before installing claude-tempo. (#204)
 - **`updateMetadata` signal no longer accepts `status` field.** The
   legacy `status` field (kept as a TypeScript wire-compat vestige in
   v0.26-beta.1 so older clients wouldn't get a schema-mismatch on
@@ -34,16 +42,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   payloads must drop the field; attachment phase is driven by the V2
   wire surface (`claimAttachment` / `adapterExited` / `forceDetach` /
   `destroyUpdate`), visible via the `attachmentInfo` workflow query and
-  the `ClaudeTempoAttachmentState` search attribute.
+  the `ClaudeTempoAttachmentState` search attribute. (#212)
 - **`createWorker()` factory removed** from `src/worker.ts`. The
   function has thrown-on-call since v0.10. Use `createWorkers()` which
   returns `{ sharedWorker, hostWorker }` — both must be run for
-  cross-machine recruiting to function.
+  cross-machine recruiting to function. (#212)
 - **`src/tui/client.ts` back-compat re-export removed.** The shim
   re-exported `createTempoClient` from `src/client/` for v0.24 TUI
   compatibility. Internal consumers migrated by v0.26-beta.1 (#177).
   Any external importer of `claude-tempo/tui/client` must switch to
-  `claude-tempo/client`.
+  `claude-tempo/client`. (#212)
 
 ## [0.26.0-beta.1] - 2026-04-18
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.1",
+  "version": "0.26.0-beta.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-tempo",
-      "version": "0.26.0-beta.1",
+      "version": "0.26.0-beta.2",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.28.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.1",
+  "version": "0.26.0-beta.2",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

- Bumps version `0.26.0-beta.1` → `0.26.0-beta.2` in `package.json` / `package-lock.json`
- Moves `[Unreleased]` CHANGELOG entries into `## [0.26.0-beta.2] - 2026-04-18`

## What's in this release

**Fixed**
- Sessions self-heal after laptop sleep / network drop — adapter reconnect loop with 15-min backoff (closes #201, #205)

**Breaking Changes**
- Dropped Node 18 — minimum Node 20 (aligns with `@temporalio/core-bridge` 1.15.0 runtime requirement) (#204)
- `updateMetadata` signal TypeScript type drops legacy `status` field (#212)
- `createWorker()` factory removed from `src/worker.ts` — use `createWorkers()` (#212)
- `src/tui/client.ts` back-compat re-export removed — use `claude-tempo/client` (#212)

## Checklist

- [x] `package.json` version bumped to `0.26.0-beta.2`
- [x] `package-lock.json` updated to match
- [x] `CHANGELOG.md` `[Unreleased]` cleared, new `[0.26.0-beta.2]` section added
- [ ] tempo-qa CHANGELOG sanity check
- [ ] Squash merge to main (conductor only)
- [ ] Tag `v0.26.0-beta.2` on merge commit (after merge, NOT before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)