### PR TITLE
fix(adapter): guarantee reconnecting flag resets on every reconnect-loop exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Adapter reconnect loop always resets its `reconnecting` flag** on every exit path.
+  `BaseAttachment.runReconnectLoop` is now wrapped in `try/finally`, so aborts during
+  backoff sleep, success, terminal bails, and unexpected throws all clean up state.
+  Before this, a user-initiated `stopV2Lifecycle` racing a reconnect backoff could leave
+  `reconnecting=true` — harmless in practice (`stopped=true` gated all ticks) but the
+  leaked state masked diagnostics. Also adds an integration test for the
+  `reconnect-exhausted` terminal path (previously only covered by the abort-during-sleep
+  unit test). (closes #206)
+
 ## [0.26.0-beta.2] - 2026-04-18
 
 > **Beta release.** Fixes the adapter poller reconnect bug (#201), drops Node 18,

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -530,126 +530,141 @@ export abstract class BaseAttachment {
    * firing terminal) on abort — `stopV2Lifecycle` owns teardown messaging.
    */
   private async runReconnectLoop(initialReason: DetachReason): Promise<void> {
-    if (!this.client || !this.host || !this.token || !this.pinnedHandle) {
-      log('runReconnectLoop: missing client/host/token/handle — aborting');
-      this.reconnecting = false;
-      this.fireTerminal('reconnect-exhausted');
-      return;
-    }
-
-    const workflowId = this.pinnedHandle.workflowId;
-    const oldAttachmentId = this.token.attachmentId;
-
+    // Single try/finally so `reconnecting` always resets no matter how we exit
+    // — success path, any fireTerminal, abort-during-sleep, or an unexpected
+    // throw. #206 fixed the prior abort-catch path that leaked `reconnecting=true`
+    // if `stopV2Lifecycle` aborted the backoff sleep.
     try {
-      await this.onReconnectStart(initialReason);
-    } catch (err) {
-      log('onReconnectStart threw:', (err as Error)?.message ?? err);
-    }
-
-    const deadline = Date.now() + this.reconnectBudgetMs;
-    let backoff = this.reconnectBaseMs;
-    let attempt = 0;
-
-    while (!this.stopped && Date.now() < deadline) {
-      attempt++;
-      log(`reconnect attempt ${attempt} (sleep ${Math.round(backoff)}ms)`);
-      try {
-        await this.abortableSleep(backoff);
-      } catch {
-        // User-initiated stop during sleep — teardown already owns the rest.
-        log('reconnect aborted by stop during backoff');
+      if (!this.client || !this.host || !this.token || !this.pinnedHandle) {
+        log('runReconnectLoop: missing client/host/token/handle — aborting');
+        this.fireTerminal('reconnect-exhausted');
         return;
       }
-      if (this.stopped) return;
 
-      // §Pre-check (architect §1): query attachmentInfo via a fresh unpinned handle.
-      // The old pinned handle's runId may be stale after a continueAsNew.
-      const unpinned = this.client.workflow.getHandle(workflowId);
-      let info: AttachmentInfo;
+      const workflowId = this.pinnedHandle.workflowId;
+      const oldAttachmentId = this.token.attachmentId;
+
       try {
-        info = await unpinned.query(attachmentInfoQuery);
+        await this.onReconnectStart(initialReason);
       } catch (err) {
-        if (this.isWorkflowGone(err)) {
-          log('reconnect: workflow gone during pre-check');
-          this.reconnecting = false;
-          this.fireTerminal('destroy');
-          return;
-        }
-        backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
-        log(`reconnect pre-check transient error (next backoff ${Math.round(backoff)}ms):`, (err as Error)?.message ?? err);
-        continue;
+        log('onReconnectStart threw:', (err as Error)?.message ?? err);
       }
 
-      if (info.phase === 'gone') {
-        log('reconnect: phase=gone — giving up');
-        this.reconnecting = false;
-        this.fireTerminal('destroy');
-        return;
-      }
-      if (info.currentAttachment && info.currentAttachment.attachmentId !== oldAttachmentId) {
-        log(`reconnect: another adapter holds the lease (${info.currentAttachment.attachmentId}) — bailing`);
-        this.reconnecting = false;
-        this.fireTerminal('superseded');
-        return;
-      }
-      if (info.phase === 'draining') {
-        // About to reap — give the workflow one more tick to finish collapsing.
-        backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
-        log(`reconnect: phase=draining, waiting (next backoff ${Math.round(backoff)}ms)`);
-        continue;
-      }
+      const deadline = Date.now() + this.reconnectBudgetMs;
+      let backoff = this.reconnectBaseMs;
+      let attempt = 0;
 
-      // §Claim: attempt a fresh `claimAttachment` (no expectedAttachmentId — our
-      // previous lease is revoked, this is a fresh claim from the workflow's POV).
-      try {
-        const newToken = await unpinned.executeUpdate(claimAttachmentUpdate, {
-          args: [{
-            host: this.host,
-            adapterId: this.descriptor.adapterId,
-            adapterClass: this.descriptor.adapterClass as AdapterClass,
-            leaseMs: 3 * this.descriptor.heartbeatMs,
-          }],
-        });
-
-        // Success — rebuild pinned handle from the NEW runId and hand it to the subclass.
-        this.token = newToken;
-        this.pinnedHandle = this.client.workflow.getHandle(workflowId, newToken.runId);
-        this.knownPhase = null; // force the next phase-watcher tick to re-emit phaseChange
-        this.heartbeatBackoff = 0;
-        this.phaseBackoff = 0;
-        log(
-          `reconnected to ${workflowId} after ${attempt} attempt(s) ` +
-          `(new attachmentId=${newToken.attachmentId}, runId=${newToken.runId})`,
-        );
-
+      while (!this.stopped && Date.now() < deadline) {
+        attempt++;
+        log(`reconnect attempt ${attempt} (sleep ${Math.round(backoff)}ms)`);
         try {
-          await this.onReconnected(this.pinnedHandle);
+          await this.abortableSleep(backoff);
+        } catch {
+          // User-initiated stop during sleep — teardown already owns the rest.
+          // The finally block still resets `reconnecting` so a subsequent
+          // reclaim attempt (hypothetical — stop normally ends the adapter) would
+          // find clean state. #206.
+          log('reconnect aborted by stop during backoff');
+          return;
+        }
+        if (this.stopped) return;
+
+        // §Pre-check (architect §1): query attachmentInfo via a fresh unpinned handle.
+        // The old pinned handle's runId may be stale after a continueAsNew.
+        const unpinned = this.client.workflow.getHandle(workflowId);
+        let info: AttachmentInfo;
+        try {
+          info = await unpinned.query(attachmentInfoQuery);
         } catch (err) {
-          log('onReconnected threw:', (err as Error)?.message ?? err);
+          if (this.isWorkflowGone(err)) {
+            log('reconnect: workflow gone during pre-check');
+            this.fireTerminal('destroy');
+            return;
+          }
+          backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
+          log(`reconnect pre-check transient error (next backoff ${Math.round(backoff)}ms):`, (err as Error)?.message ?? err);
+          continue;
         }
 
-        this.reconnecting = false;
-        if (!this.stopped) {
-          this.scheduleHeartbeat();
-          this.schedulePhaseWatcher();
-        }
-        return;
-      } catch (err) {
-        if (this.isWorkflowGone(err)) {
-          log('reconnect: workflow gone during claim');
-          this.reconnecting = false;
+        if (info.phase === 'gone') {
+          log('reconnect: phase=gone — giving up');
           this.fireTerminal('destroy');
           return;
         }
-        backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
-        log(`reconnect claim failed (next backoff ${Math.round(backoff)}ms):`, (err as Error)?.message ?? err);
-      }
-    }
+        if (info.currentAttachment && info.currentAttachment.attachmentId !== oldAttachmentId) {
+          log(`reconnect: another adapter holds the lease (${info.currentAttachment.attachmentId}) — bailing`);
+          this.fireTerminal('superseded');
+          return;
+        }
+        if (info.phase === 'draining') {
+          // About to reap — give the workflow one more tick to finish collapsing.
+          backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
+          log(`reconnect: phase=draining, waiting (next backoff ${Math.round(backoff)}ms)`);
+          continue;
+        }
 
-    // Budget exhausted — give up cleanly.
-    log(`reconnect budget exhausted after ${attempt} attempt(s)`);
-    this.reconnecting = false;
-    this.fireTerminal('reconnect-exhausted');
+        // §Claim: attempt a fresh `claimAttachment` (no expectedAttachmentId — our
+        // previous lease is revoked, this is a fresh claim from the workflow's POV).
+        try {
+          const newToken = await unpinned.executeUpdate(claimAttachmentUpdate, {
+            args: [{
+              host: this.host,
+              adapterId: this.descriptor.adapterId,
+              adapterClass: this.descriptor.adapterClass as AdapterClass,
+              leaseMs: 3 * this.descriptor.heartbeatMs,
+            }],
+          });
+
+          // Success — rebuild pinned handle from the NEW runId and hand it to the subclass.
+          this.token = newToken;
+          this.pinnedHandle = this.client.workflow.getHandle(workflowId, newToken.runId);
+          this.knownPhase = null; // force the next phase-watcher tick to re-emit phaseChange
+          this.heartbeatBackoff = 0;
+          this.phaseBackoff = 0;
+          log(
+            `reconnected to ${workflowId} after ${attempt} attempt(s) ` +
+            `(new attachmentId=${newToken.attachmentId}, runId=${newToken.runId})`,
+          );
+
+          try {
+            await this.onReconnected(this.pinnedHandle);
+          } catch (err) {
+            log('onReconnected threw:', (err as Error)?.message ?? err);
+          }
+
+          // Clear the reconnecting flag BEFORE rescheduling so the first
+          // heartbeat/watcher tick after reconnect doesn't short-circuit on
+          // its own `this.reconnecting` guard. The finally block reasserts
+          // `reconnecting=false` after return; this early assignment is the
+          // one that matters for loop wiring.
+          this.reconnecting = false;
+          if (!this.stopped) {
+            this.scheduleHeartbeat();
+            this.schedulePhaseWatcher();
+          }
+          return;
+        } catch (err) {
+          if (this.isWorkflowGone(err)) {
+            log('reconnect: workflow gone during claim');
+            this.fireTerminal('destroy');
+            return;
+          }
+          backoff = Math.min(backoff * this.reconnectBackoffFactor, this.reconnectMaxMs);
+          log(`reconnect claim failed (next backoff ${Math.round(backoff)}ms):`, (err as Error)?.message ?? err);
+        }
+      }
+
+      // Budget exhausted — give up cleanly.
+      log(`reconnect budget exhausted after ${attempt} attempt(s)`);
+      this.fireTerminal('reconnect-exhausted');
+    } finally {
+      // Guarantee state reset regardless of which path we exited on. Safe to
+      // assign unconditionally — a successful reconnect also ends up here after
+      // the early assignment inside the success path (the early one is needed
+      // so tick reschedulers see `reconnecting=false`; this one is belt-and-
+      // suspenders for the abort/throw/terminal paths).
+      this.reconnecting = false;
+    }
   }
 }
 

--- a/test/adapter-reconnect.test.ts
+++ b/test/adapter-reconnect.test.ts
@@ -234,6 +234,66 @@ describe('adapter reconnect (#201)', function () {
       });
     });
 
+    it('fires `reconnect-exhausted` terminal when the budget elapses without re-claim', async function () {
+      // #206 follow-up: pre-#206 this path only had unit coverage via the abort-during-sleep case.
+      // We now assert the loop's budget-exhaustion exit fires the distinct terminal reason.
+      //
+      // Strategy: set `budgetMs: 0` so the loop's `while (!stopped && Date.now() < deadline)`
+      // guard evaluates to false immediately on entry — no claim attempts, straight to
+      // the budget-exhausted branch. The phase-watcher + forceDetach machinery is unchanged
+      // from the happy-path reconnect test, only the budget differs.
+      this.timeout(15_000);
+
+      await withWorker(async () => {
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: `reconnect-exhausted-${Date.now()}` }),
+        });
+
+        const terminals: DetachReason[] = [];
+        const options: BaseAttachmentOptions = {
+          client: getClient(),
+          host: 'test-host',
+          // budgetMs=0 → zero-ms deadline → the while-guard rejects on first check →
+          // no claim attempts → fires `reconnect-exhausted`. Base/max are arbitrary
+          // (never slept on) but set small so if the test ever regresses into running
+          // the loop body, it still finishes within the 15s timeout.
+          reconnectTiming: { baseMs: 100, maxMs: 200, budgetMs: 0, backoffFactor: 1.5 },
+        };
+        const adapter = new FastInteractiveAttachment(options);
+        adapter.onTerminal((r) => { terminals.push(r); });
+        const stop = adapter.start(handle, async () => { /* no-op */ });
+
+        try {
+          // Initial claim succeeds (budgetMs only affects the reconnect loop).
+          await waitForAttachmentInfo(
+            handle,
+            (i) => i.phase === 'attached',
+            5000,
+            'initial attached',
+          );
+
+          // Reap workflow-side. Phase watcher will detect `phase=detached, currentAttachment=undefined`
+          // and enter the reconnect loop — which, with budgetMs=0, bails out immediately.
+          await handle.executeUpdate(forceDetachUpdate, {
+            args: [{ reason: 'heartbeat-timeout', gracePeriodMs: 0 }],
+          });
+
+          // Wait for the terminal — single event, should land within one phase-watcher
+          // tick (descriptor.heartbeatMs * 5 = 2000ms) plus a few ms of loop bailout.
+          const deadline = Date.now() + 8000;
+          while (Date.now() < deadline && terminals.length === 0) {
+            await new Promise((r) => setTimeout(r, 50));
+          }
+          expect(terminals, 'terminal should have fired').to.have.lengthOf(1);
+          expect(terminals[0]).to.equal('reconnect-exhausted');
+        } finally {
+          stop();
+          await handle.executeUpdate(destroyUpdate, { args: [{}] });
+          await handle.result().catch(() => { /* expected */ });
+        }
+      });
+    });
+
     it('fires `destroy` terminal if the workflow is destroyed mid-reconnect', async function () {
       this.timeout(15_000);
 


### PR DESCRIPTION
## Summary

Closes #206 — QA follow-ups from the #201 review (both were flagged as non-blocking, so they land in a single small PR now).

1. **`reconnecting` flag leak on abort-during-sleep path**: `BaseAttachment.runReconnectLoop` had six separate `this.reconnecting = false` assignments sprinkled at each early-return site, but the abort-during-backoff `catch` returned without clearing the flag. Wrapped the whole loop in `try/finally` so the flag always resets — success, bail, abort, or throw. Dropped the redundant explicit assignments; only kept the one in the success path (it must run BEFORE the heartbeat/watcher reschedulers, which guard on the flag).
2. **Missing `reconnect-exhausted` integration test**: the terminal existed in the code (#205) but was only exercised by the abort-during-sleep unit test, which didn't actually hit the budget-guard exit. New test sets `budgetMs: 0` so the `while (!stopped && Date.now() < deadline)` short-circuits on entry — no claim attempts, straight to `reconnect-exhausted`. Deterministic in <1s.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` rebuilds workflow bundle
- [x] `npx mocha test/adapter-reconnect.test.ts` — 6 passing (was 5; new `reconnect-exhausted` case lands)
- [x] `npm test` — 730 Mocha + 76 Vitest green (was 729 Mocha + 76 Vitest before this change — the one new test)
- [x] Rebased onto current `main` at `d5ec715d` (post-beta.2 release)

## Files

- `src/adapters/base.ts` — `runReconnectLoop` wrapped in `try/finally`, redundant flag assignments removed.
- `test/adapter-reconnect.test.ts` — new `reconnect-exhausted` integration test.
- `CHANGELOG.md` — `[Unreleased] / ### Fixed` entry.

Wire-protocol: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)