### PR TITLE
feat(daemon): self-healing orphan pre-flight check + heartbeat diagnostics (#157 PR B)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ logs/
 *.js.map
 *.d.ts
 !jest.config.js
+# Operational scripts (not built from TS) — one-off manual tools.
+!scripts/*.js
 temporal-data.db
 
 pnpm-lock.yaml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   `reconnect-exhausted` terminal path (previously only covered by the abort-during-sleep
   unit test). (closes #206)
 
+### Added
+
+- **`daemon start` pre-flight orphan check + `--force` escape hatch** (partial fix
+  for #157). Before spawning, the CLI now scans for unexpected claude-tempo daemon
+  processes (command-line match via PR A's `scanClaudeTempoDaemons`) and aborts
+  with exit 1 + orphan list + troubleshooting-docs pointer if any are found. Pass
+  `--force` to bypass the check (and clear a stale pid file as a side effect).
+  Exit-1 default is deliberate: piling a new daemon on top of orphans is the
+  original #157 user-pain scenario; `--force` is the opt-in for CI scripts that
+  want idempotent-start behavior.
+- **Daemon heartbeat file** at `~/.claude-tempo/daemon.heartbeat`. The daemon
+  touches this file every 60 seconds; `daemon status` reports its age, flagging
+  "stale" when the last touch is >120s ago. Disambiguates "pid is alive AND
+  main loop is serving" from "pid is alive but something hung" — informational,
+  doesn't drive any automatic action. (partial fix for #157)
+- **`scripts/verify-daemon-isolation-guard.js`** — one-shot manual verification
+  script for the #157 isolation guard's fail-path. The `daemon-command-isolation`
+  test asserts no forbidden Temporal imports leak into the `require.cache` of
+  the daemon CLI module. This script empirically confirms the detector would
+  FAIL if a forbidden import were injected — belt-and-suspenders paranoia per
+  tempo-qa observation on PR #218. Run before a release or after touching CLI
+  imports.
+
 ## [0.26.0-beta.2] - 2026-04-18
 
 > **Beta release.** Fixes the adapter poller reconnect bug (#201), drops Node 18,

--- a/scripts/verify-daemon-isolation-guard.js
+++ b/scripts/verify-daemon-isolation-guard.js
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * Manual verification script for the #157 isolation guard
+ * (`test/daemon-command-isolation.test.ts`).
+ *
+ * QA observation on PR #218: the isolation test asserts the guard PASSES on
+ * the current daemon-command module, but never empirically verifies the
+ * guard would FAIL if a forbidden import leaked in. This script plugs that
+ * gap — run it as a one-shot sanity check (e.g. before a release or after
+ * touching CLI imports) to confirm the detector's fail-side actually works.
+ *
+ * Usage:
+ *   node scripts/verify-daemon-isolation-guard.js
+ *
+ * How it works:
+ *   Spawns a child `node -e "..."` that (a) requires the compiled
+ *   daemon-command module, then (b) ALSO requires `@temporalio/client` —
+ *   simulating a hypothetical regression where daemon-command grew a
+ *   forbidden import. Runs the same require.cache scan logic as the
+ *   isolation test and asserts it DOES find `@temporalio/*` entries.
+ *
+ * The test in test/daemon-command-isolation.test.ts guards the pass path
+ * (no Temporal leaks via daemon-command's own dep chain). This script
+ * guards the detector itself — it confirms the scan would catch a leak.
+ *
+ * Exit 0 = guard-detector works correctly on a simulated regression.
+ * Exit 1 = guard-detector silently accepted a forbidden import (bug in
+ *          the detector itself, or the test's FORBIDDEN_PATTERNS array is
+ *          missing a case).
+ */
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const { spawnSync } = require('child_process');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const DAEMON_COMMAND_DIST = path.join(REPO_ROOT, 'dist', 'cli', 'daemon-command.js');
+
+if (!fs.existsSync(DAEMON_COMMAND_DIST)) {
+  console.error('dist/cli/daemon-command.js not found. Run `npm run build` before this script.');
+  process.exit(1);
+}
+
+let temporalClientPath;
+try {
+  temporalClientPath = require.resolve('@temporalio/client', { paths: [REPO_ROOT] });
+} catch (err) {
+  console.error('Could not resolve @temporalio/client from repo node_modules. Run `npm install` first.');
+  console.error(err && err.message);
+  process.exit(1);
+}
+
+const detector = `
+  // Step 1: load daemon-command (should leave require.cache clean of Temporal).
+  require(${JSON.stringify(DAEMON_COMMAND_DIST)});
+  // Step 2: simulate a regression — load @temporalio/client directly.
+  // This is what would happen if a future edit to daemon-command (or one of
+  // its deps) accidentally imported something Temporal-adjacent.
+  require(${JSON.stringify(temporalClientPath)});
+  // Step 3: run the same detector as test/daemon-command-isolation.test.ts.
+  const forbidden = [
+    /[\\\\/]@temporalio[\\\\/]/,
+    /[\\\\/]rxjs[\\\\/]/,
+    /[\\\\/]@grpc[\\\\/]/,
+    /[\\\\/]nice-grpc(?:-[^\\\\/]+)?[\\\\/]/,
+    /[\\\\/]long[\\\\/]umd[\\\\/]/,
+  ];
+  const hits = Object.keys(require.cache).filter((k) => forbidden.some((re) => re.test(k)));
+  if (hits.length > 0) {
+    console.log('Detector found ' + hits.length + ' forbidden module(s) in require.cache:');
+    for (const h of hits.slice(0, 3)) console.log('  ' + h);
+    if (hits.length > 3) console.log('  ... (' + (hits.length - 3) + ' more)');
+    process.exit(0);
+  }
+  console.error('BUG: detector did not flag any of the injected forbidden modules.');
+  process.exit(1);
+`;
+
+const result = spawnSync(process.execPath, ['-e', detector], {
+  stdio: ['ignore', 'inherit', 'inherit'],
+  cwd: REPO_ROOT,
+});
+
+if (result.status === 0) {
+  console.log('\n✅ Isolation guard fail-path verified. The detector correctly flags forbidden imports.');
+  console.log('   (The isolation test in test/daemon-command-isolation.test.ts will catch a real regression.)');
+  process.exit(0);
+} else {
+  console.error('\n❌ Isolation guard fail-path NOT verified.');
+  if (result.status === 1) {
+    console.error('   The detector silently accepted injected forbidden imports — regression in the detector itself,');
+    console.error('   OR the FORBIDDEN_PATTERNS array in test/daemon-command-isolation.test.ts is missing a case.');
+  } else {
+    console.error(`   Child exited with status ${result.status}. See output above for the cause.`);
+  }
+  process.exit(1);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -202,6 +202,7 @@ async function main() {
     const { daemon } = await import('./cli/daemon-command');
     await daemon({
       subcommand: args.positional[1],
+      force: args.force,
       ...overrides,
     });
     return;

--- a/src/cli/daemon-command.ts
+++ b/src/cli/daemon-command.ts
@@ -31,9 +31,57 @@ import {
   stopDaemon,
   getDaemonStatus,
   scanClaudeTempoDaemons,
+  selectOrphans,
+  DAEMON_PID_PATH,
   DAEMON_LOG_PATH,
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_STALE_MULTIPLIER,
+  type DaemonProcessInfo,
+  type DaemonStatus,
 } from './daemon';
 import * as out from './output';
+
+/**
+ * Discriminated union describing the outcome of the `daemon start` pre-flight
+ * check. Exported for direct unit testing of the decision logic — the handler
+ * just maps these actions to console output + `process.exit` / spawn.
+ *
+ *   already-running — pid file is valid, no-op (not an error)
+ *   abort           — orphan daemons detected and `force` is false; caller
+ *                     should print the list + exit 1
+ *   spawn           — safe to proceed with `startDaemon`; caller should
+ *                     delete a stale pid file first when `cleanupStalePid`
+ *                     is true (only set on the `force` path)
+ *
+ * @internal
+ */
+export type StartPreflight =
+  | { action: 'already-running'; pid: number }
+  | { action: 'abort'; orphans: DaemonProcessInfo[] }
+  | { action: 'spawn'; cleanupStalePid: boolean };
+
+/**
+ * Pure decision function for `daemon start`. Given a scanner result and the
+ * current daemon status, computes whether to no-op, abort with orphans, or
+ * spawn. `force` bypasses the orphan check and signals that a stale pid file
+ * (if any) should be cleared before the spawn.
+ *
+ * @internal — exported for unit tests in test/daemon-start-orphan-check.test.ts.
+ */
+export function evaluateStartPreflight(
+  scanned: DaemonProcessInfo[],
+  status: DaemonStatus,
+  force: boolean,
+): StartPreflight {
+  if (status.running && typeof status.pid === 'number') {
+    return { action: 'already-running', pid: status.pid };
+  }
+  if (!force) {
+    const orphans = selectOrphans(scanned, status.pid);
+    if (orphans.length > 0) return { action: 'abort', orphans };
+  }
+  return { action: 'spawn', cleanupStalePid: force };
+}
 
 /** Package root is two levels up from dist/cli/ */
 const PACKAGE_ROOT = resolve(__dirname, '..', '..');
@@ -44,6 +92,14 @@ function packagingFile(...segments: string[]): string {
 
 export interface DaemonOpts extends CliOverrides {
   subcommand?: string;
+  /**
+   * Only meaningful for the `start` subcommand. Skips the orphan-process
+   * pre-flight check and spawns a daemon even if scanner-matched processes
+   * are found. Also cleans up a stale pid file if present. Use only when
+   * you've verified no conflicting claude-tempo daemons exist — or in CI
+   * scripts where idempotent-start is required (see `daemon status` first).
+   */
+  force?: boolean;
 }
 
 export async function daemon(opts: DaemonOpts): Promise<void> {
@@ -51,19 +107,49 @@ export async function daemon(opts: DaemonOpts): Promise<void> {
 
   switch (opts.subcommand) {
     case 'start': {
-      if (isDaemonRunning()) {
-        const status = getDaemonStatus();
-        out.success(`Daemon already running (pid ${status.pid})`);
-        return;
-      }
-      out.log('Starting daemon...');
-      try {
-        const pid = await startDaemon(config);
-        out.success(`Daemon started (pid ${pid})`);
-        out.log(`  ${out.dim('Logs: ' + DAEMON_LOG_PATH)}`);
-      } catch (err: any) {
-        out.error(err.message || String(err));
-        process.exit(1);
+      const status = getDaemonStatus();
+      const preflight = evaluateStartPreflight(
+        // Skip the actual OS scan when we're already-running or force is set —
+        // the decision doesn't depend on it. Saves a shell-out on the happy path.
+        status.running || opts.force ? [] : scanClaudeTempoDaemons(),
+        status,
+        Boolean(opts.force),
+      );
+
+      switch (preflight.action) {
+        case 'already-running':
+          out.success(`Daemon already running (pid ${preflight.pid})`);
+          return;
+
+        case 'abort':
+          // Piling a new daemon on top of orphans is the original #157 user-pain
+          // scenario. User must clean up first — see troubleshooting docs.
+          out.error(`Found ${preflight.orphans.length} orphaned claude-tempo daemon process${preflight.orphans.length === 1 ? '' : 'es'} — daemon start aborted.`);
+          for (const p of preflight.orphans) out.log(`  pid ${p.pid}: ${p.commandLine}`);
+          out.log('');
+          out.log(`  ${out.dim('Emergency cleanup: see docs/troubleshooting.md → "Orphaned daemon processes"')}`);
+          out.log(`  ${out.dim('Override (use only after confirming): claude-tempo daemon start --force')}`);
+          process.exit(1);
+          break;
+
+        case 'spawn':
+          if (preflight.cleanupStalePid && existsSync(DAEMON_PID_PATH)) {
+            // Force path — clean up a stale pid file if present.
+            // `getDaemonStatus` already unlinks the file when it detects a
+            // dead pid; this handles the rarer "file exists, contents
+            // unparseable OR fs error" branch.
+            try { unlinkSync(DAEMON_PID_PATH); } catch { /* ignore */ }
+          }
+          out.log('Starting daemon...');
+          try {
+            const pid = await startDaemon(config);
+            out.success(`Daemon started (pid ${pid})`);
+            out.log(`  ${out.dim('Logs: ' + DAEMON_LOG_PATH)}`);
+          } catch (err: any) {
+            out.error(err.message || String(err));
+            process.exit(1);
+          }
+          break;
       }
       break;
     }
@@ -83,10 +169,23 @@ export async function daemon(opts: DaemonOpts): Promise<void> {
 
       if (status.running) {
         out.success(`Daemon running (pid ${status.pid})`);
+        // Heartbeat diagnostic — distinguishes "pid alive AND main loop
+        // serving" from "pid alive but something hung" (#157 PR B).
+        const staleThresholdMs = HEARTBEAT_INTERVAL_MS * HEARTBEAT_STALE_MULTIPLIER;
+        if (status.heartbeatAge !== undefined && status.heartbeatAge !== null) {
+          const ageSec = Math.round(status.heartbeatAge / 1000);
+          if (status.heartbeatAge > staleThresholdMs) {
+            out.warn(`  Last heartbeat: ${ageSec}s ago — STALE (threshold ${staleThresholdMs / 1000}s). The daemon's main loop may be hung.`);
+          } else {
+            out.log(`  ${out.dim(`Last heartbeat: ${ageSec}s ago`)}`);
+          }
+        } else if (status.heartbeatAge === null) {
+          out.log(`  ${out.dim('Last heartbeat: (not yet written — daemon just started or pre-heartbeat version)')}`);
+        }
         // Warn if the scanner reports extras the pid file doesn't know about —
         // orphans from a prior crashed run that never removed its pid file, or
         // a second daemon started by a stale concurrent CLI invocation (#157).
-        const extras = scanned.filter((p) => p.pid !== status.pid);
+        const extras = selectOrphans(scanned, status.pid);
         if (extras.length > 0) {
           out.warn(`Found ${extras.length} additional claude-tempo daemon process${extras.length === 1 ? '' : 'es'} not tracked by the pid file:`);
           for (const p of extras) out.log(`  pid ${p.pid}: ${p.commandLine}`);
@@ -152,12 +251,13 @@ export async function daemon(opts: DaemonOpts): Promise<void> {
 
     default:
       out.error('Usage: claude-tempo daemon <start|stop|status|logs|install|uninstall>');
-      out.log(`\n  ${out.dim('claude-tempo daemon start')}       Start the worker daemon`);
-      out.log(`  ${out.dim('claude-tempo daemon stop')}        Stop the worker daemon`);
-      out.log(`  ${out.dim('claude-tempo daemon status')}      Check daemon status + list any orphans`);
-      out.log(`  ${out.dim('claude-tempo daemon logs')}        Tail daemon log output`);
-      out.log(`  ${out.dim('claude-tempo daemon install')}     Install as a system service`);
-      out.log(`  ${out.dim('claude-tempo daemon uninstall')}   Uninstall the system service`);
+      out.log(`\n  ${out.dim('claude-tempo daemon start [--force]')}  Start the worker daemon`);
+      out.log(`  ${out.dim('                           --force: skip orphan-process check + clear stale pid file')}`);
+      out.log(`  ${out.dim('claude-tempo daemon stop')}              Stop the worker daemon`);
+      out.log(`  ${out.dim('claude-tempo daemon status')}            Check daemon status + heartbeat + orphans`);
+      out.log(`  ${out.dim('claude-tempo daemon logs')}              Tail daemon log output`);
+      out.log(`  ${out.dim('claude-tempo daemon install')}           Install as a system service`);
+      out.log(`  ${out.dim('claude-tempo daemon uninstall')}         Uninstall the system service`);
       process.exit(1);
   }
 

--- a/src/cli/daemon.ts
+++ b/src/cli/daemon.ts
@@ -13,6 +13,23 @@ const log = (...args: unknown[]) => console.error('[claude-tempo:daemon]', ...ar
 
 export const DAEMON_PID_PATH = path.join(CLAUDE_TEMPO_HOME, 'daemon.pid');
 export const DAEMON_LOG_PATH = path.join(CLAUDE_TEMPO_HOME, 'daemon.log');
+/**
+ * Path to the daemon heartbeat file. The running daemon touches this file
+ * on a {@link HEARTBEAT_INTERVAL_MS} cadence so `daemon status` can
+ * distinguish "pid is alive AND main loop is serving" from "pid is alive
+ * but something hung" (#157 diagnostic improvement).
+ */
+export const DAEMON_HEARTBEAT_PATH = path.join(CLAUDE_TEMPO_HOME, 'daemon.heartbeat');
+
+/** How often the daemon touches {@link DAEMON_HEARTBEAT_PATH}. */
+export const HEARTBEAT_INTERVAL_MS = 60_000;
+
+/**
+ * Multiplier applied to {@link HEARTBEAT_INTERVAL_MS} to decide whether a
+ * heartbeat is stale. A 2x buffer tolerates one missed tick (brief GC pause,
+ * synchronous activity) without false-flagging a healthy daemon.
+ */
+export const HEARTBEAT_STALE_MULTIPLIER = 2;
 
 /** Entry point for the daemon process (compiled JS). */
 const DAEMON_ENTRY_PATH = path.resolve(__dirname, '..', 'daemon.js');
@@ -20,6 +37,13 @@ const DAEMON_ENTRY_PATH = path.resolve(__dirname, '..', 'daemon.js');
 export interface DaemonStatus {
   running: boolean;
   pid?: number;
+  /**
+   * Milliseconds since the daemon last touched {@link DAEMON_HEARTBEAT_PATH}.
+   * `null` when no heartbeat file exists (fresh daemon hasn't ticked yet, or
+   * pre-heartbeat daemon). `undefined` when the daemon is not running at all.
+   * See {@link HEARTBEAT_STALE_MULTIPLIER} for the staleness threshold.
+   */
+  heartbeatAge?: number | null;
 }
 
 /**
@@ -66,11 +90,44 @@ export function getDaemonStatus(): DaemonStatus {
   }
 
   if (isPidAlive(pid)) {
-    return { running: true, pid };
+    return { running: true, pid, heartbeatAge: readHeartbeatAge() };
   }
   // Process is dead — clean up stale PID file.
   try { fs.unlinkSync(DAEMON_PID_PATH); } catch { /* ignore */ }
   return { running: false };
+}
+
+/**
+ * Read the heartbeat file and return milliseconds since its mtime, or `null`
+ * if the file doesn't exist. Used by {@link getDaemonStatus} when the daemon
+ * is running — see the `heartbeatAge` field on {@link DaemonStatus}.
+ *
+ * Any other read/stat error is treated as "unknown" (`null`) rather than
+ * propagating — `daemon status` should degrade to silent-unknown rather than
+ * crash on an unexpected filesystem condition.
+ */
+function readHeartbeatAge(): number | null {
+  try {
+    const mtimeMs = fs.statSync(DAEMON_HEARTBEAT_PATH).mtimeMs;
+    const age = Date.now() - mtimeMs;
+    return age >= 0 ? age : 0;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * @internal — exported for unit testing {@link DAEMON_CMDLINE_RE} edge cases
+ * without needing to spin up a real child process. Filters a scanner result
+ * to the "orphan" subset: matching processes that aren't the one the pid
+ * file is tracking. Used by `daemon start`'s pre-flight check (#157 PR B).
+ */
+export function selectOrphans(
+  scanned: DaemonProcessInfo[],
+  trackedPid: number | undefined,
+): DaemonProcessInfo[] {
+  if (trackedPid === undefined) return scanned;
+  return scanned.filter((p) => p.pid !== trackedPid);
 }
 
 /**

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -16,7 +16,7 @@ import { WorkflowIdConflictPolicy } from '@temporalio/client';
 import { getConfig, CLAUDE_TEMPO_HOME, GLOBAL_MAESTRO_WORKFLOW_ID, loadDaemonConfig, isEnsembleAllowed, type DaemonConfig } from './config';
 import { createWorkers } from './worker';
 import { createTemporalConnection } from './connection';
-import { DAEMON_PID_PATH, DAEMON_LOG_PATH } from './cli/daemon';
+import { DAEMON_PID_PATH, DAEMON_LOG_PATH, DAEMON_HEARTBEAT_PATH, HEARTBEAT_INTERVAL_MS } from './cli/daemon';
 import { createTempoClient } from './client';
 import { queryOrphanedSessions, type OrphanCandidate } from './reconcile/orphans';
 import type { GlobalMaestroInput } from './types';
@@ -334,6 +334,27 @@ async function main() {
   log(`PID file: ${DAEMON_PID_PATH}`);
   log(`Log file: ${DAEMON_LOG_PATH}`);
 
+  // Create the heartbeat file synchronously so the first `daemon status`
+  // invocation after startup never races the first interval tick. The
+  // subsequent interval only has to refresh the mtime — no branching on
+  // file-existence each tick (#157 PR B).
+  try {
+    fs.writeFileSync(DAEMON_HEARTBEAT_PATH, '');
+  } catch (err) {
+    // Non-fatal — the daemon still runs, `daemon status` just reports
+    // `heartbeatAge: null`. Log loudly so operators notice.
+    log('Failed to create heartbeat file (non-fatal):', (err as Error)?.message ?? err);
+  }
+  const heartbeatInterval = setInterval(() => {
+    try {
+      const now = Date.now() / 1000; // `fs.utimes` takes seconds since epoch
+      fs.utimesSync(DAEMON_HEARTBEAT_PATH, now, now);
+    } catch {
+      // Swallow — transient fs errors shouldn't take down the daemon.
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+  heartbeatInterval.unref();
+
   // Get config from env vars (passed by startDaemon via spawn env)
   const config = getConfig({});
 
@@ -348,6 +369,7 @@ async function main() {
   const hardExit = () => {
     log('Shutdown timeout — forcing exit');
     try { fs.unlinkSync(DAEMON_PID_PATH); } catch { /* ignore */ }
+    try { fs.unlinkSync(DAEMON_HEARTBEAT_PATH); } catch { /* ignore */ }
     process.exit(1);
   };
   // Mutable ref so the reconcile/cleanup init below can register its
@@ -362,6 +384,8 @@ async function main() {
     const timer = setTimeout(hardExit, 15_000);
     timer.unref();
     stopCleanupLoopRef?.();
+    clearInterval(heartbeatInterval);
+    try { fs.unlinkSync(DAEMON_HEARTBEAT_PATH); } catch { /* ignore */ }
     sharedWorker?.shutdown();
     hostWorker?.shutdown();
   };

--- a/test/daemon-scan.test.ts
+++ b/test/daemon-scan.test.ts
@@ -7,7 +7,7 @@
  * identically on all CI matrix entries regardless of platform.
  */
 import { expect } from 'chai';
-import { scanClaudeTempoDaemons } from '../src/cli/daemon';
+import { scanClaudeTempoDaemons, selectOrphans, type DaemonProcessInfo } from '../src/cli/daemon';
 
 describe('scanClaudeTempoDaemons', function () {
   describe('POSIX (ps) scanner', function () {
@@ -135,5 +135,38 @@ describe('scanClaudeTempoDaemons', function () {
       const result = scanClaudeTempoDaemons(stub, win);
       expect(result).to.deep.equal([]);
     });
+  });
+});
+
+describe('selectOrphans (#157 PR B)', function () {
+  const proc = (pid: number): DaemonProcessInfo => ({
+    pid,
+    commandLine: `node /path/claude-tempo/dist/daemon.js`,
+  });
+
+  it('returns the full scanner result when no tracked pid is provided', function () {
+    const scanned = [proc(111), proc(222), proc(333)];
+    expect(selectOrphans(scanned, undefined).map((p) => p.pid)).to.deep.equal([111, 222, 333]);
+  });
+
+  it('filters out the tracked pid from the scanner result', function () {
+    const scanned = [proc(111), proc(222), proc(333)];
+    expect(selectOrphans(scanned, 222).map((p) => p.pid)).to.deep.equal([111, 333]);
+  });
+
+  it('returns the full list when the tracked pid is not in the scanner result', function () {
+    // Mismatch can happen when pid file is stale — tracked pid is dead + not
+    // reported by scanner; all scanned pids are real orphans.
+    const scanned = [proc(111), proc(222)];
+    expect(selectOrphans(scanned, 999).map((p) => p.pid)).to.deep.equal([111, 222]);
+  });
+
+  it('returns [] when scanner is empty regardless of tracked pid', function () {
+    expect(selectOrphans([], undefined)).to.deep.equal([]);
+    expect(selectOrphans([], 111)).to.deep.equal([]);
+  });
+
+  it('returns [] when the only scanned process is the tracked pid', function () {
+    expect(selectOrphans([proc(111)], 111)).to.deep.equal([]);
   });
 });

--- a/test/daemon-start-orphan-check.test.ts
+++ b/test/daemon-start-orphan-check.test.ts
@@ -1,0 +1,75 @@
+/**
+ * Unit tests for the `daemon start` pre-flight decision (issue #157 PR B).
+ *
+ * Tests the pure `evaluateStartPreflight` helper in `src/cli/daemon-command.ts`.
+ * The handler that wraps this helper maps its output to console writes + `process.exit`
+ * + `startDaemon` — all trivially reviewable; the non-trivial logic lives in this
+ * decision function.
+ */
+import { expect } from 'chai';
+import { evaluateStartPreflight } from '../src/cli/daemon-command';
+import type { DaemonProcessInfo, DaemonStatus } from '../src/cli/daemon';
+
+describe('evaluateStartPreflight (#157 PR B)', function () {
+  // Helper — build a plausible scanner result entry.
+  const proc = (pid: number, suffix = 'repos/claude-tempo/dist/daemon.js'): DaemonProcessInfo => ({
+    pid,
+    commandLine: `node /home/dev/${suffix}`,
+  });
+
+  it('returns "already-running" when the tracked pid is live (no-op)', function () {
+    const status: DaemonStatus = { running: true, pid: 4242, heartbeatAge: 500 };
+    const result = evaluateStartPreflight([proc(4242)], status, /* force */ false);
+    expect(result).to.deep.equal({ action: 'already-running', pid: 4242 });
+  });
+
+  it('returns "already-running" even when force is true — force does not kill a live daemon', function () {
+    const status: DaemonStatus = { running: true, pid: 4242 };
+    const result = evaluateStartPreflight([proc(4242)], status, /* force */ true);
+    expect(result).to.deep.equal({ action: 'already-running', pid: 4242 });
+  });
+
+  it('returns "abort" with the orphan list when scanner finds untracked processes', function () {
+    const status: DaemonStatus = { running: false };
+    const result = evaluateStartPreflight([proc(1111), proc(2222)], status, /* force */ false);
+    expect(result.action).to.equal('abort');
+    if (result.action === 'abort') {
+      expect(result.orphans.map((o) => o.pid).sort()).to.deep.equal([1111, 2222]);
+    }
+  });
+
+  it('returns "abort" listing ONLY untracked pids — the tracked pid is filtered out', function () {
+    // Scenario: stale pid file points at 1111 (somehow still alive), and scanner
+    // also finds 2222 and 3333. Only 2222 + 3333 are orphans for the purpose of
+    // "should I abort".
+    // In practice `status.running` would be true when pid is live, which would hit
+    // the already-running branch first. This test pins selectOrphans' filter
+    // behavior even if the status snapshot lags reality.
+    const status: DaemonStatus = { running: false, pid: 1111 };
+    const result = evaluateStartPreflight([proc(1111), proc(2222), proc(3333)], status, /* force */ false);
+    expect(result.action).to.equal('abort');
+    if (result.action === 'abort') {
+      expect(result.orphans.map((o) => o.pid).sort()).to.deep.equal([2222, 3333]);
+    }
+  });
+
+  it('returns "spawn" with cleanupStalePid=false when scanner is empty and force is false', function () {
+    const status: DaemonStatus = { running: false };
+    const result = evaluateStartPreflight([], status, /* force */ false);
+    expect(result).to.deep.equal({ action: 'spawn', cleanupStalePid: false });
+  });
+
+  it('returns "spawn" with cleanupStalePid=true on the force path — bypasses orphan check', function () {
+    // Even with orphans present, force skips the abort branch.
+    const status: DaemonStatus = { running: false };
+    const result = evaluateStartPreflight([proc(1111), proc(2222)], status, /* force */ true);
+    expect(result).to.deep.equal({ action: 'spawn', cleanupStalePid: true });
+  });
+
+  it('returns "spawn" with cleanupStalePid=true on force path even when scanner is empty', function () {
+    // cleanupStalePid is a consequence of `force`, not of the scanner result.
+    const status: DaemonStatus = { running: false };
+    const result = evaluateStartPreflight([], status, /* force */ true);
+    expect(result).to.deep.equal({ action: 'spawn', cleanupStalePid: true });
+  });
+});

--- a/test/daemon.test.ts
+++ b/test/daemon.test.ts
@@ -19,6 +19,9 @@ import {
   stopDaemon,
   DAEMON_PID_PATH,
   DAEMON_LOCK_PATH,
+  DAEMON_HEARTBEAT_PATH,
+  HEARTBEAT_INTERVAL_MS,
+  HEARTBEAT_STALE_MULTIPLIER,
   STALE_LOCK_MS,
   tryAcquireLockFile,
   checkLockFileStale,
@@ -89,6 +92,57 @@ describe('daemon management', function () {
 
       // Corrupt PID file should have been cleaned up
       expect(fs.existsSync(DAEMON_PID_PATH)).to.be.false;
+    });
+
+    describe('heartbeatAge (#157 PR B)', function () {
+      // Run after any other getDaemonStatus test so we don't interfere with them.
+      afterEach(function () {
+        try { fs.unlinkSync(DAEMON_PID_PATH); } catch { /* ignore */ }
+        try { fs.unlinkSync(DAEMON_HEARTBEAT_PATH); } catch { /* ignore */ }
+      });
+
+      it('reports a fresh heartbeatAge when the heartbeat file exists and is recent', function () {
+        seedPidFile(DAEMON_PID_PATH, process.pid);
+        fs.writeFileSync(DAEMON_HEARTBEAT_PATH, '');
+        // mtime is now — age should be 0 or a few ms
+        const status = getDaemonStatus();
+        expect(status.running).to.be.true;
+        expect(status.heartbeatAge).to.be.a('number');
+        expect(status.heartbeatAge!).to.be.at.least(0);
+        expect(status.heartbeatAge!).to.be.below(1000); // sane upper bound for just-written file
+      });
+
+      it('reports heartbeatAge: null when the heartbeat file is missing (daemon running, pre-first-touch)', function () {
+        seedPidFile(DAEMON_PID_PATH, process.pid);
+        try { fs.unlinkSync(DAEMON_HEARTBEAT_PATH); } catch { /* ignore */ }
+        const status = getDaemonStatus();
+        expect(status.running).to.be.true;
+        expect(status.heartbeatAge).to.equal(null);
+      });
+
+      it('reports a stale heartbeatAge when the file mtime is beyond the stale threshold', function () {
+        seedPidFile(DAEMON_PID_PATH, process.pid);
+        fs.writeFileSync(DAEMON_HEARTBEAT_PATH, '');
+        // Backdate mtime to 5 intervals ago — well beyond the 2x staleness threshold.
+        const staleSecs = (HEARTBEAT_INTERVAL_MS * 5) / 1000;
+        const backdated = Date.now() / 1000 - staleSecs;
+        fs.utimesSync(DAEMON_HEARTBEAT_PATH, backdated, backdated);
+
+        const status = getDaemonStatus();
+        expect(status.running).to.be.true;
+        expect(status.heartbeatAge).to.be.a('number');
+        expect(status.heartbeatAge!).to.be.at.least(HEARTBEAT_INTERVAL_MS * HEARTBEAT_STALE_MULTIPLIER);
+      });
+
+      it('does not populate heartbeatAge when the daemon is not running', function () {
+        try { fs.unlinkSync(DAEMON_PID_PATH); } catch { /* ignore */ }
+        // Even if a stale heartbeat file is lying around, the running=false path
+        // returns early and never reads it — the field should be absent.
+        fs.writeFileSync(DAEMON_HEARTBEAT_PATH, '');
+        const status = getDaemonStatus();
+        expect(status.running).to.be.false;
+        expect(status.heartbeatAge).to.be.undefined;
+      });
     });
   });
 


### PR DESCRIPTION
## Summary

**Partial fix for #157** — PR B of the planned A/B split. PR A merged as [#218](https://github.com/vinceblank/claude-tempo/pull/218) (crash-proof CLI + orphan scanner + docs). PR C (remaining CLI crash-proof audit: `version`/`help`/`config`/`mcp`/`upgrade`/`attachment-info`) to follow.

Completes the issue's "self-healing on startup" + richer-detection asks with the minimum user-facing surface: list-and-bail on orphan detection, `--force` escape hatch, and a heartbeat file for "is this daemon actually serving" diagnostic signal.

## Scope decisions (pre-coded, PO-approved in design review)

| Ask | Decision |
|---|---|
| Temporal task-queue registration marker | **SKIP**. PR A's scanner covers the real-world case; a marker would add a recurring Temporal round-trip and break PR A's crash-proof property. Can revisit as a future opt-in `daemon verify` subcommand if needed. |
| Self-healing "healthy" definition | `isPidAlive(pid)` (already in `src/cli/daemon.ts`). Heartbeat file adds secondary "main loop is serving" signal. |
| Self-healing "should terminate" definition | Scanner-matched + not-the-tracked-pid. Narrow scope respects "don't kill unknown". |
| Auto-kill orphans? | **NO**. List-and-bail with pointer to PR A's docs. User-gated. |
| Heartbeat on `DaemonStatus` | New field `heartbeatAge?: number \| null`. Doesn't break existing `running: boolean` consumers. |
| `version` / `help` / `config` etc. crash-proof | Deferred to PR C. |

## What ships

### 1. `daemon start` pre-flight orphan check

```
$ claude-tempo daemon start
error Found 2 orphaned claude-tempo daemon processes — daemon start aborted.
  pid 12345: node C:\repos\claude-tempo\dist\daemon.js
  pid 67890: node C:\...\AppData\Roaming\npm\...\dist\daemon.js

  Emergency cleanup: see docs/troubleshooting.md → "Orphaned daemon processes"
  Override (use only after confirming): claude-tempo daemon start --force
[exit code: 1]
```

Default behavior: exit 1 if orphans found. User runs the emergency-kill one-liner from PR A's docs, then retries.

### 2. `--force` escape hatch

```
claude-tempo daemon start --force
```

Bypasses the orphan check and spawns anyway. Also clears a stale pid file as a side effect (scoped self-heal). Documented in help text. For CI scripts needing idempotent start.

### 3. Heartbeat file + status display

The daemon touches `~/.claude-tempo/daemon.heartbeat` every 60s via `fs.utimesSync` (mtime-only, atomic). `daemon status` reports:

```
ok Daemon running (pid 12345)
  Last heartbeat: 42s ago
```

Or on stale:

```
warn   Last heartbeat: 600s ago — STALE (threshold 120s). The daemon's main loop may be hung.
```

Informational only — no automatic action. Cleans up on graceful shutdown.

### 4. Pure pre-flight decision function

`evaluateStartPreflight(scanned, status, force)` — discriminated union (`already-running` / `abort` / `spawn + cleanupStalePid`). Extracted for unit-testability; the handler maps union variants to output + exit/spawn.

### 5. Manual verification script (paranoia)

`scripts/verify-daemon-isolation-guard.js` — addresses tempo-qa observation on PR #218: the isolation test guards the PASS path but never empirically proves the FAIL path works. This one-shot script requires `@temporalio/client` alongside `daemon-command.js` and asserts the detector flags the leak. Output:

```
$ node scripts/verify-daemon-isolation-guard.js
Detector found 130 forbidden module(s) in require.cache: ...
✅ Isolation guard fail-path verified. The detector correctly flags forbidden imports.
```

Run before releases or after touching CLI imports. Documented in CHANGELOG.

## Diff

```
 .gitignore                             |   2 +       (allow scripts/*.js)
 CHANGELOG.md                           |  23 ++     ([Unreleased] → ### Added: 3 entries)
 scripts/verify-daemon-isolation-guard.js |  90 ++    (new)
 src/cli.ts                             |   1 +       (pass --force through)
 src/cli/daemon-command.ts              | 140 +++--    (preflight + heartbeat status + help)
 src/cli/daemon.ts                      |  59 +++++    (heartbeat constants, selectOrphans, readHeartbeatAge)
 src/daemon.ts                          |  26 +++      (heartbeat touch loop + shutdown cleanup)
 test/daemon-scan.test.ts               |  35 +++      (+5 selectOrphans cases)
 test/daemon-start-orphan-check.test.ts |  75 +++      (new — 7 evaluateStartPreflight cases)
 test/daemon.test.ts                    |  54 ++++     (+4 heartbeatAge cases)
 10 files changed, 490 insertions(+), 23 deletions(-)
```

Net **+467 LoC** — over my 233 estimate (delta: ~90 LoC verification script added after tempo-qa's PR A feedback, not in original spec; slightly more verbose inline docs than budgeted). Flagged as self-critique.

## Test plan

- [x] `npm run build` — clean; workflow-bundle.js regenerated
- [x] `npm test` — **758 passing, 25 pending, 0 failing** (+16 from PR A's 742 baseline: 5 `selectOrphans` + 7 `evaluateStartPreflight` + 4 `heartbeatAge`)
- [x] `node scripts/verify-daemon-isolation-guard.js` — ✅ detector fail-path verified (130 forbidden module entries caught when `@temporalio/client` is injected)
- [ ] CI green on PR

Partial fix for #157.