### PR TITLE
ci: make Create GitHub Release step idempotent (#216)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,8 +79,7 @@ jobs:
           script: |
             const tag = context.ref.replace('refs/tags/', '');
             const body = (process.env.CHANGELOG_NOTES || '').trim();
-
-            await github.rest.repos.createRelease({
+            const params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
               tag_name: tag,
@@ -88,4 +87,35 @@ jobs:
               body: body || `Release ${tag}`,
               draft: false,
               prerelease: tag.includes('-'),
-            });
+            };
+
+            try {
+              await github.rest.repos.createRelease(params);
+              core.info(`GitHub Release created for ${tag}`);
+            } catch (err) {
+              // 422 Validation Failed: tag_name already_exists
+              // This happens when the workflow is re-run after a partial failure
+              // (e.g. the GH Release step failed but npm publish already succeeded).
+              // npm publish is the source of truth — treat an existing release as success.
+              const alreadyExists =
+                err.status === 422 &&
+                err.response?.data?.errors?.some(e => e.code === 'already_exists' && e.field === 'tag_name');
+
+              if (alreadyExists) {
+                core.warning(`GitHub Release for ${tag} already exists — updating body instead of failing.`);
+                const { data: existing } = await github.rest.repos.getReleaseByTag({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  tag: tag,
+                });
+                await github.rest.repos.updateRelease({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  release_id: existing.id,
+                  body: params.body,
+                });
+                core.info(`GitHub Release for ${tag} updated.`);
+              } else {
+                throw err;
+              }
+            }


### PR DESCRIPTION
## Summary

- Wraps `createRelease` in a try/catch in `.github/workflows/release.yml`
- On HTTP 422 `tag_name already_exists`: fetches the existing release and updates its body with the current changelog notes, then exits 0
- Any other error is re-thrown (unchanged behavior)

## Motivation

The v0.26.0-beta.1 release run (`24598750801`) failed on the final "Create GitHub Release" step with:

```
HttpError: Validation Failed: {"resource":"Release","code":"already_exists","field":"tag_name"}
```

npm publish had already succeeded (step 8 runs before step 10). The workflow failed because a prior partial run left a GH Release in place for the same tag. Re-running without this fix would have hit the same error every time.

**npm publish is the source of truth for "release shipped."** A pre-existing GH Release should never abort the workflow.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Fresh tag, no existing release | ✅ creates release | ✅ creates release |
| Tag with existing release (retry scenario) | ❌ 422 → workflow failure | ✅ updates release body → success |
| Other GitHub API error | ❌ workflow failure | ❌ workflow failure (re-thrown) |

## Testing

Pure YAML / `actions/github-script` change. The logic is straightforward — no test harness needed. Can be manually verified by re-running the release workflow for `v0.26.0-beta.2` (existing release) once this lands.

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)