### PR TITLE
refactor(test): share TestWorkflowEnvironment across files with per-file namespace (#210 Phase 1)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Keep shell scripts LF-only so they run on Linux CI runners regardless of
+# the developer's core.autocrlf setting on Windows. Without this, Windows
+# clones get CRLF, which makes `bash` choke on `\r` at the end of shebang
+# and `set` / `if` lines.
+*.sh text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  lint-test-ensemble:
+    # Fast grep-based lint — guards against accidental `'test-ensemble'` literals
+    # outside `test/helpers.ts` (#210). Runs first so the matrix doesn't start
+    # three Node versions on a PR that will fail the literal check regardless.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Check for stray `test-ensemble` literals in test/
+        run: bash scripts/check-test-ensemble-literals.sh
+
   build-and-test:
     runs-on: ubuntu-latest
+    needs: lint-test-ensemble
     strategy:
       matrix:
         node-version: [20, 22, 24]

--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,3 +1,5 @@
 spec: dist-test/test/**/*.test.js
 timeout: 30000
 exit: true
+require:
+  - dist-test/test/root-hooks.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Shared `TestWorkflowEnvironment` across Mocha spec files** (#210 Phase 1). The
+  first `setupTestEnv()` call in a test run now builds a process-wide test
+  environment; subsequent calls reuse it and only re-seed a per-file random
+  ensemble prefix (`test-ensemble-<hex>`) so `playerMetadata()` defaults
+  auto-namespace without per-test edits. Real teardown happens once at process
+  exit via a Mocha `mochaGlobalTeardown` hook. Saves ~50-85s on the full Mocha
+  suite. Set `TEMPO_TEST_ISOLATED=1` to restore per-file env lifecycle when
+  debugging cross-file state leaks.
+- Added `afterEach` shutdown safety net to `test/maestro.test.ts` and
+  `test/global-maestro.test.ts` so a failing assertion doesn't leak a running
+  Maestro workflow into the next test under the shared env.
+- New CI lint (`scripts/check-test-ensemble-literals.sh`) fails on stray
+  `'test-ensemble'` literals outside `test/helpers.ts` / `test/root-hooks.ts`.
+
 ### Fixed
 
 - **Adapter reconnect loop always resets its `reconnecting` flag** on every exit path.

--- a/scripts/check-test-ensemble-literals.sh
+++ b/scripts/check-test-ensemble-literals.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+#
+# CI lint — fail if the literal `'test-ensemble'` shows up in a test file.
+#
+# Under the shared `TestWorkflowEnvironment` rollout (#210), test files must
+# derive their ensemble namespace from the per-file random prefix seeded by
+# `setupTestEnv()` (exposed as `getTestEnsemble()` / the `playerMetadata()`
+# default). Literal `'test-ensemble'` re-introduces the cross-file workflow-ID
+# collisions the shared env was designed to avoid — e.g. two files both
+# starting `claude-session-test-ensemble-conductor`.
+#
+# Allowed locations:
+#   - test/helpers.ts — owns the fallback default; one literal kept as safety
+#     net for tests that import helpers without calling setupTestEnv().
+#   - test/root-hooks.ts — imports helpers, no literal of its own, allowed.
+#   - scripts/ — this script and any peers can reference the literal in help text.
+#   - docs/ — design docs and migration guides can reference the literal.
+#
+# Anywhere else inside `test/` is a lint failure.
+#
+# Keep the grep Bash-portable — CI runs on GitHub-hosted Ubuntu, but the same
+# script should work on macOS (bash 3.2) and Git Bash on Windows for local runs.
+
+set -euo pipefail
+
+# Find literal occurrences in test/ except helpers.ts and root-hooks.ts.
+# `|| true` prevents set -e from aborting when grep finds zero matches.
+matches=$(
+  grep -rn --include='*.ts' --include='*.js' \
+    -e "'test-ensemble'" \
+    -e '"test-ensemble"' \
+    test/ 2>/dev/null \
+    | grep -v '^test/helpers\.ts:' \
+    | grep -v '^test/root-hooks\.ts:' \
+    || true
+)
+
+if [[ -n "$matches" ]]; then
+  echo 'FAIL: literal `test-ensemble` found in test/ outside helpers.ts / root-hooks.ts'
+  echo ''
+  echo "$matches"
+  echo ''
+  echo 'Under shared TestWorkflowEnvironment (#210), tests must derive the ensemble'
+  echo 'from playerMetadata() / getTestEnsemble() — not the literal string.'
+  echo 'Replace the literal with the helper-provided default (see test/helpers.ts).'
+  exit 1
+fi
+
+echo 'OK: no stray `test-ensemble` literals in test/'

--- a/test/activities.test.ts
+++ b/test/activities.test.ts
@@ -35,7 +35,7 @@ function mockConfig(overrides: Partial<Config> = {}): Config {
     temporalNamespace: 'default',
     defaultAgent: 'claude',
     taskQueue: 'claude-tempo',
-    ensemble: 'test-ensemble',
+    ensemble: 'test-ensemble-unit-mock',
     ...overrides,
   };
 }
@@ -62,7 +62,7 @@ function mockHandle(opts: {
 
   const defaultMetadata: SessionMetadata = {
     playerId: 'player-1',
-    ensemble: 'test-ensemble',
+    ensemble: 'test-ensemble-unit-mock',
     hostname: 'test-host',
     workDir: '/tmp/work',
     isConductor: false,

--- a/test/ensemble.test.ts
+++ b/test/ensemble.test.ts
@@ -10,6 +10,7 @@ import {
   setupTestEnv,
   teardownTestEnv,
   getClient,
+  getTestEnsemble,
   withWorkerAndActivities,
   startSession,
   playerMetadata,
@@ -28,7 +29,8 @@ import { ScheduleEntry } from '../src/types';
 import { loadLineup } from '../src/ensemble/loader';
 import { listLineups } from '../src/ensemble/saver';
 
-const ENSEMBLE = 'test-ensemble';
+/** Per-file ensemble namespace — seeded in `before()` (see #210). */
+let ENSEMBLE: string;
 const SCHEDULER_TASK_QUEUE = 'test-claude-tempo';
 
 function schedulerWorkflowId(ensemble: string): string {
@@ -48,6 +50,7 @@ describe('ensemble lineups', function () {
   before(async function () {
     this.timeout(60_000);
     await setupTestEnv();
+    ENSEMBLE = getTestEnsemble();
     tmpDir = makeTmpDir();
   });
 

--- a/test/global-maestro.test.ts
+++ b/test/global-maestro.test.ts
@@ -28,6 +28,13 @@ import type { MaestroPlayerInfo } from '../src/types';
 const FAST_POLL_MS = 500;
 let testCounter = 0;
 
+/**
+ * Active handles registered during each `it()` body. Cleared + destroyed in
+ * `afterEach` to prevent Global Maestro instances leaking across files under
+ * the shared `TestWorkflowEnvironment` (#210).
+ */
+const pendingHandles: WorkflowHandle[] = [];
+
 async function startGlobalMaestro(
   client: Client,
   overrides: { knownEnsembles?: string[]; playersByEnsemble?: Record<string, MaestroPlayerInfo[]> } = {},
@@ -38,11 +45,13 @@ async function startGlobalMaestro(
     pollIntervalMs: FAST_POLL_MS,
   };
   const uniqueId = `claude-maestro-global-test-${++testCounter}`;
-  return client.workflow.start('claudeGlobalMaestroWorkflow', {
+  const handle = await client.workflow.start('claudeGlobalMaestroWorkflow', {
     workflowId: uniqueId,
     taskQueue: TASK_QUEUE,
     args: [input],
   });
+  pendingHandles.push(handle);
+  return handle;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -57,6 +66,22 @@ describe('claudeGlobalMaestroWorkflow', function () {
 
   after(async function () {
     await teardownTestEnv();
+  });
+
+  // #210: best-effort shutdown of any Global Maestro handle started this test.
+  // Under the shared env a leaked Global Maestro keeps polling
+  // `discoverEnsembles` / `refreshEnsembleState` after the test's mocked
+  // activity closures have exited, which surfaces as cross-file flakes.
+  afterEach(async function () {
+    const toClean = pendingHandles.splice(0);
+    for (const handle of toClean) {
+      try {
+        await handle.signal(maestroShutdownSignal);
+        await handle.result().catch(() => { /* COMPLETED */ });
+      } catch {
+        // Inline shutdown already happened, or workflow completed. Ignore.
+      }
+    }
   });
 
   describe('initial state and queries', function () {

--- a/test/hard-terminate.test.ts
+++ b/test/hard-terminate.test.ts
@@ -101,8 +101,8 @@ async function spawnTestVictim(opts: {
   tmpDir?: string;
   /**
    * Ensemble name to embed as `--remote-control-session-name-prefix <ensemble>` in
-   * the victim's argv. Defaults to 'test-ensemble' to match the common-case callers
-   * that pass `ensemble: 'test-ensemble'` to `hardTerminateAttachment`. Tests that
+   * the victim's argv. Defaults to 'test-ensemble-hardterm-fixture' to match the common-case callers
+   * that pass `ensemble: 'test-ensemble-hardterm-fixture'` to `hardTerminateAttachment`. Tests that
    * exercise cross-ensemble scoping (#180) pass distinct values per victim.
    */
   ensemble?: string;
@@ -110,7 +110,7 @@ async function spawnTestVictim(opts: {
   pid: number;
   waitForExit: () => Promise<number | null>;
 }> {
-  const ensemble = opts.ensemble ?? 'test-ensemble';
+  const ensemble = opts.ensemble ?? 'test-ensemble-hardterm-fixture';
   // Node one-liner that keeps the event loop alive forever. Process title isn't used
   // for command-line matching — we rely on the `-n <playerName>` marker in argv.
   const nodeScript = `setInterval(() => {}, 60000); process.on('SIGTERM', () => process.exit(0)); process.on('SIGINT', () => process.exit(0));`;
@@ -333,7 +333,7 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
     }
 
     const result = await hardTerminateAttachment({
-      ensemble: 'test-ensemble',
+      ensemble: 'test-ensemble-hardterm-fixture',
       playerName,
       // 'copilot' bypasses the PID-file miss and still falls through to the search path
       // for `node` processes. We use copilot here intentionally: the test victim is `node`,
@@ -355,7 +355,7 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
   it('returns strategy=none + empty killedPids when no matching process exists', async function () {
     const playerName = `nonexistent-${process.pid}-${Date.now()}`;
     const result = await hardTerminateAttachment({
-      ensemble: 'test-ensemble',
+      ensemble: 'test-ensemble-hardterm-fixture',
       playerName,
       agent: 'claude',
       workDir: tmpWorkDir,
@@ -390,7 +390,7 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
       writeFileSync(pidPath, String(wrongPid));
 
       const result = await hardTerminateAttachment({
-        ensemble: 'test-ensemble',
+        ensemble: 'test-ensemble-hardterm-fixture',
         playerName,
         agent: 'copilot',
         workDir: tmpWorkDir,
@@ -443,7 +443,7 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
     const probeBat = join(tmpWorkDir, `probe-${playerName}.bat`);
     // Both the parent cmd.exe and the child node.exe must carry the ensemble
     // sentinel so the per-ensemble scoping (#180) lets hard-terminate match them.
-    const probeEnsemble = 'test-ensemble';
+    const probeEnsemble = 'test-ensemble-hardterm-fixture';
     writeFileSync(
       probeBat,
       [
@@ -542,7 +542,7 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
 
     try {
       const result = await hardTerminateAttachment({
-        ensemble: 'test-ensemble',
+        ensemble: 'test-ensemble-hardterm-fixture',
         playerName,
         // 'copilot' routes to node.exe search (no PID file exists → falls through).
         // The parent-walk applies regardless of binaryName — it only triggers when
@@ -589,7 +589,7 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
     }
 
     const result = await hardTerminateAttachment({
-      ensemble: 'test-ensemble',
+      ensemble: 'test-ensemble-hardterm-fixture',
       playerName,
       agent: 'copilot',
       workDir: tmpWorkDir,
@@ -608,7 +608,7 @@ describe('hardTerminateAttachment — OS kill (#159 Gap 2)', function () {
     // that pass junk should get back an empty result instead of arbitrary command
     // execution via the PowerShell/pgrep pattern.
     const result = await hardTerminateAttachment({
-      ensemble: 'test-ensemble',
+      ensemble: 'test-ensemble-hardterm-fixture',
       playerName: `bad; rm -rf /; $(echo pwned)`,
       agent: 'claude',
       workDir: tmpWorkDir,

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -1,14 +1,29 @@
 /**
  * Test helpers for claude-tempo workflow tests.
  *
- * Provides a shared TestWorkflowEnvironment and convenience functions
- * for common multi-step scenarios (start session, send message, etc.).
+ * **Shared TestWorkflowEnvironment (#210 Phase 1)**:
+ * Environment creation is process-wide singleton. The first `setupTestEnv()`
+ * call builds a `TestWorkflowEnvironment`; subsequent calls reuse it and only
+ * re-seed a per-file random ensemble prefix (`test-ensemble-<suffix>`). The
+ * real teardown runs once at process exit via the global `after` hook in
+ * `test/root-hooks.ts`; per-file `after()` / `teardownTestEnv()` calls are
+ * no-ops in shared mode.
+ *
+ * Auto-namespacing: `playerMetadata()` / `conductorMetadata()` default
+ * `ensemble` to the per-file random prefix, so the 8+ test files that just
+ * call `playerMetadata()` without overriding ensemble automatically get
+ * their own isolated namespace under the shared env — no per-test edits.
+ *
+ * Fallback: set `TEMPO_TEST_ISOLATED=1` to restore per-file environments
+ * (each file creates + tears down its own env). Useful when debugging a
+ * flake you suspect is a cross-file state leak.
  */
 import { TestWorkflowEnvironment } from '@temporalio/testing';
 import { Worker } from '@temporalio/worker';
 import { Client, WorkflowHandle, WorkflowIdConflictPolicy } from '@temporalio/client';
 import * as path from 'path';
 import * as fs from 'fs';
+import * as crypto from 'crypto';
 import { SessionInput, SessionMetadata, MaestroPlayerInfo } from '../src/types';
 import {
   receiveMessageSignal,
@@ -79,8 +94,30 @@ export {
   adapterExitedSignal,
 };
 
-let testEnv: TestWorkflowEnvironment;
-let workflowBundle: { code: string };
+let testEnv: TestWorkflowEnvironment | undefined;
+let workflowBundle: { code: string } | undefined;
+
+/** Opt-out switch — each `setupTestEnv` re-creates a fresh env when set. */
+const ISOLATED_MODE = process.env.TEMPO_TEST_ISOLATED === '1';
+
+/**
+ * Per-file random ensemble prefix. Re-seeded at every `setupTestEnv()` call
+ * (which Mocha invokes once per test file's top-level `before()` hook). Under
+ * shared env this gives each file its own workflow-ID namespace without any
+ * per-test edits. Default falls back to the pre-#210 literal for defensive
+ * safety if someone imports and uses `playerMetadata()` without calling
+ * `setupTestEnv()` first.
+ */
+let currentEnsemblePrefix = 'test-ensemble';
+
+/**
+ * The prefix derived by the most recent `setupTestEnv()` invocation. Exposed
+ * for tests that need to build their own IDs with the same namespace (e.g.
+ * `claude-session-${getTestEnsemble()}-custom-id`).
+ */
+export function getTestEnsemble(): string {
+  return currentEnsemblePrefix;
+}
 
 export const TASK_QUEUE = 'test-claude-tempo';
 
@@ -108,43 +145,98 @@ function findWorkflowBundle(): string {
 }
 
 /**
- * Initialize the shared test environment. Call once in the top-level
- * before() hook.
+ * Initialize the test environment. In shared mode (default), the first call
+ * creates a process-wide `TestWorkflowEnvironment` that all subsequent test
+ * files reuse; later calls only re-seed the per-file random ensemble prefix.
+ * In isolated mode (`TEMPO_TEST_ISOLATED=1`), every call tears down the
+ * previous env and builds a fresh one.
+ *
+ * Call from each test file's top-level `before()` hook — no change to the
+ * existing calling convention.
  */
 export async function setupTestEnv(): Promise<void> {
-  testEnv = await TestWorkflowEnvironment.createLocal({
-    server: {
-      // Register custom search attributes at server startup.
-      // `ClaudeTempoStatus` removed in v0.26 (#175 / #178).
-      extraArgs: [
-        '--search-attribute', 'ClaudeTempoEnsemble=Keyword',
-        '--search-attribute', 'ClaudeTempoPlayerId=Keyword',
-        '--search-attribute', 'ClaudeTempoHostname=Keyword',
-        '--search-attribute', 'ClaudeTempoGitRoot=Keyword',
-        '--search-attribute', 'ClaudeTempoPlayerType=Keyword',
-        '--search-attribute', 'ClaudeTempoIsConductor=Bool',
-        // v0.25 attachment lifecycle search attrs (§9, §11.2)
-        '--search-attribute', 'ClaudeTempoAttachedHost=Keyword',
-        '--search-attribute', 'ClaudeTempoAttachmentState=Keyword',
-        '--search-attribute', 'ClaudeTempoAttachmentId=Keyword',
-      ],
-    },
-  });
-  const bundlePath = findWorkflowBundle();
-  workflowBundle = { code: fs.readFileSync(bundlePath, 'utf-8') };
+  if (ISOLATED_MODE && testEnv) {
+    await testEnv.teardown();
+    testEnv = undefined;
+    workflowBundle = undefined;
+  }
+  if (!testEnv) {
+    testEnv = await TestWorkflowEnvironment.createLocal({
+      server: {
+        // Register custom search attributes at server startup.
+        // `ClaudeTempoStatus` removed in v0.26 (#175 / #178).
+        extraArgs: [
+          '--search-attribute', 'ClaudeTempoEnsemble=Keyword',
+          '--search-attribute', 'ClaudeTempoPlayerId=Keyword',
+          '--search-attribute', 'ClaudeTempoHostname=Keyword',
+          '--search-attribute', 'ClaudeTempoGitRoot=Keyword',
+          '--search-attribute', 'ClaudeTempoPlayerType=Keyword',
+          '--search-attribute', 'ClaudeTempoIsConductor=Bool',
+          // v0.25 attachment lifecycle search attrs (§9, §11.2)
+          '--search-attribute', 'ClaudeTempoAttachedHost=Keyword',
+          '--search-attribute', 'ClaudeTempoAttachmentState=Keyword',
+          '--search-attribute', 'ClaudeTempoAttachmentId=Keyword',
+        ],
+      },
+    });
+    const bundlePath = findWorkflowBundle();
+    workflowBundle = { code: fs.readFileSync(bundlePath, 'utf-8') };
+  }
+  // Re-seed per-file suffix. Short hex keeps workflow IDs readable in Temporal UI.
+  currentEnsemblePrefix = `test-ensemble-${crypto.randomBytes(4).toString('hex')}`;
 }
 
 /**
- * Tear down the shared test environment. Call once in the top-level
- * after() hook.
+ * Tear down the test environment. In isolated mode, tears down immediately.
+ * In shared mode (default), this is a no-op — the real teardown runs once at
+ * process exit via `mochaGlobalTeardown` in `test/root-hooks.ts`.
  */
 export async function teardownTestEnv(): Promise<void> {
-  await testEnv?.teardown();
+  if (ISOLATED_MODE) {
+    await testEnv?.teardown();
+    testEnv = undefined;
+    workflowBundle = undefined;
+  }
+  // Shared mode: intentionally no-op. See `teardownSharedTestEnv()` below.
 }
 
-/** Get the Temporal client from the test environment. */
+/**
+ * Process-wide teardown. Invoked once by the Mocha global `after` hook in
+ * `test/root-hooks.ts` after all spec files have finished. Not part of the
+ * public test API — do not call from individual test files.
+ *
+ * @internal
+ */
+export async function teardownSharedTestEnv(): Promise<void> {
+  if (testEnv) {
+    await testEnv.teardown();
+    testEnv = undefined;
+    workflowBundle = undefined;
+  }
+}
+
+/** Get the Temporal client from the test environment. Call `setupTestEnv()` first. */
 export function getClient(): Client {
+  if (!testEnv) {
+    throw new Error('getClient() called before setupTestEnv() — make sure your before() hook awaits setupTestEnv()');
+  }
   return testEnv.client;
+}
+
+/** Internal — resolves the current test env; for helpers only. */
+function requireTestEnv(): TestWorkflowEnvironment {
+  if (!testEnv) {
+    throw new Error('Test env not initialized — call setupTestEnv() from a before() hook');
+  }
+  return testEnv;
+}
+
+/** Internal — resolves the current workflow bundle. */
+function requireWorkflowBundle(): { code: string } {
+  if (!workflowBundle) {
+    throw new Error('Workflow bundle not loaded — call setupTestEnv() from a before() hook');
+  }
+  return workflowBundle;
 }
 
 /**
@@ -164,7 +256,7 @@ export function getClient(): Client {
  * (e.g. verifying behavior over a bounded duration).
  */
 export async function skipTime(durationMs: number): Promise<void> {
-  await testEnv.sleep(durationMs);
+  await requireTestEnv().sleep(durationMs);
 }
 
 /**
@@ -177,12 +269,12 @@ export async function skipTime(durationMs: number): Promise<void> {
  */
 export async function withWorker<T>(fn: () => Promise<T>): Promise<T> {
   const worker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: TASK_QUEUE,
     workflowBundle,
   });
   const hostWorker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: HOST_TASK_QUEUE,
     activities: {
       hardTerminateAttachment: async () => ({
@@ -212,9 +304,9 @@ export async function withWorker<T>(fn: () => Promise<T>): Promise<T> {
  */
 export async function withWorkerAndActivities<T>(fn: () => Promise<T>): Promise<T> {
   const { createScheduleActivities } = await import('../src/activities/schedule-fire');
-  const scheduleActivities = createScheduleActivities(testEnv.client);
+  const scheduleActivities = createScheduleActivities(requireTestEnv().client);
   const worker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: TASK_QUEUE,
     workflowBundle,
     activities: scheduleActivities,
@@ -222,11 +314,17 @@ export async function withWorkerAndActivities<T>(fn: () => Promise<T>): Promise<
   return worker.runUntil(fn);
 }
 
-/** Default metadata for a player session. Override fields as needed. */
+/**
+ * Default metadata for a player session. Override fields as needed.
+ *
+ * `ensemble` defaults to the per-file random prefix seeded by the most recent
+ * `setupTestEnv()` call — auto-namespaces default callers under the shared
+ * `TestWorkflowEnvironment` (#210).
+ */
 export function playerMetadata(overrides: Partial<SessionMetadata> = {}): SessionMetadata {
   return {
     playerId: `player-${Date.now()}`,
-    ensemble: 'test-ensemble',
+    ensemble: currentEnsemblePrefix,
     hostname: 'test-host',
     workDir: '/tmp/test',
     isConductor: false,
@@ -271,7 +369,7 @@ export async function startSession(
   // cascades when a test fails before its cleanup destroyUpdate runs.
   const workflowId = `claude-session-${metadata.ensemble}-${metadata.playerId}`;
 
-  return testEnv.client.workflow.start('claudeSessionWorkflow', {
+  return requireTestEnv().client.workflow.start('claudeSessionWorkflow', {
     workflowId,
     taskQueue: TASK_QUEUE,
     args: [input],
@@ -398,17 +496,17 @@ export async function withWorkerAndOutboxActivities<T>(fn: () => Promise<T>): Pr
   const { createScheduleActivities } = await import('../src/activities/schedule-fire');
   const { createOutboxActivities } = await import('../src/activities/outbox');
 
-  const scheduleActivities = createScheduleActivities(testEnv.client);
-  const outboxActivities = createOutboxActivities(testEnv.client, {
+  const scheduleActivities = createScheduleActivities(requireTestEnv().client);
+  const outboxActivities = createOutboxActivities(requireTestEnv().client, {
     temporalAddress: '',
     temporalNamespace: 'default',
     taskQueue: TASK_QUEUE,
-    ensemble: 'test-ensemble',
+    ensemble: currentEnsemblePrefix,
     defaultAgent: 'claude',
   });
 
   const worker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: TASK_QUEUE,
     workflowBundle,
     activities: {
@@ -427,7 +525,7 @@ export async function withWorkerAndOutboxActivities<T>(fn: () => Promise<T>): Pr
   });
   // Per-host worker — same stub so activities routed via the per-host queue also resolve.
   const hostWorker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: HOST_TASK_QUEUE,
     activities: {
       spawnProcess: async () => ({ success: true }),
@@ -461,18 +559,18 @@ export async function withWorkerAndRecruitActivities<T>(fn: () => Promise<T>): P
   const { createScheduleActivities } = await import('../src/activities/schedule-fire');
   const { createOutboxActivities } = await import('../src/activities/outbox');
 
-  const scheduleActivities = createScheduleActivities(testEnv.client);
-  const outboxActivities = createOutboxActivities(testEnv.client, {
+  const scheduleActivities = createScheduleActivities(requireTestEnv().client);
+  const outboxActivities = createOutboxActivities(requireTestEnv().client, {
     temporalAddress: '',
     temporalNamespace: 'default',
     taskQueue: TASK_QUEUE,
-    ensemble: 'test-ensemble',
+    ensemble: currentEnsemblePrefix,
     defaultAgent: 'claude',
   });
 
   // Main worker: workflow execution + all outbox + schedule activities
   const mainWorker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: TASK_QUEUE,
     workflowBundle,
     activities: {
@@ -487,7 +585,7 @@ export async function withWorkerAndRecruitActivities<T>(fn: () => Promise<T>): P
   // No workflowBundle — this worker only polls for activity tasks, matching
   // the production per-host worker config in src/worker.ts.
   const hostWorker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: `claude-tempo-test-host`,
     activities: {
       spawnProcess: async () => ({ success: true }),
@@ -522,12 +620,12 @@ export async function withWorkerAndRecruitCapture<T>(
   const { createScheduleActivities } = await import('../src/activities/schedule-fire');
   const { createOutboxActivities } = await import('../src/activities/outbox');
 
-  const scheduleActivities = createScheduleActivities(testEnv.client);
-  const outboxActivities = createOutboxActivities(testEnv.client, {
+  const scheduleActivities = createScheduleActivities(requireTestEnv().client);
+  const outboxActivities = createOutboxActivities(requireTestEnv().client, {
     temporalAddress: '',
     temporalNamespace: 'default',
     taskQueue: TASK_QUEUE,
-    ensemble: 'test-ensemble',
+    ensemble: currentEnsemblePrefix,
     defaultAgent: 'claude',
   });
 
@@ -537,7 +635,7 @@ export async function withWorkerAndRecruitCapture<T>(
   };
 
   const mainWorker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: TASK_QUEUE,
     workflowBundle,
     activities: {
@@ -548,7 +646,7 @@ export async function withWorkerAndRecruitCapture<T>(
   });
 
   const hostWorker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: `claude-tempo-test-host`,
     activities: {
       spawnProcess: capturingSpawn,
@@ -588,10 +686,10 @@ export async function withWorkerAndMaestroActivities<T>(
   const relayedCommands: Array<{ text: string; source: string; replyTo?: string }> = [];
 
   const { createScheduleActivities } = await import('../src/activities/schedule-fire');
-  const scheduleActivities = createScheduleActivities(testEnv.client);
+  const scheduleActivities = createScheduleActivities(requireTestEnv().client);
 
   const worker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: TASK_QUEUE,
     workflowBundle,
     activities: {
@@ -641,10 +739,10 @@ export async function withWorkerAndGlobalMaestroActivities<T>(
   const relayedCommands: Array<{ ensemble: string; text: string; source: string; replyTo?: string }> = [];
 
   const { createScheduleActivities } = await import('../src/activities/schedule-fire');
-  const scheduleActivities = createScheduleActivities(testEnv.client);
+  const scheduleActivities = createScheduleActivities(requireTestEnv().client);
 
   const worker = await Worker.create({
-    connection: testEnv.nativeConnection,
+    connection: requireTestEnv().nativeConnection,
     taskQueue: TASK_QUEUE,
     workflowBundle,
     activities: {
@@ -686,7 +784,7 @@ export async function reconnectSession(
     ? `claude-session-${metadata.ensemble}-conductor`
     : `claude-session-${metadata.ensemble}-${metadata.playerId}`;
 
-  return testEnv.client.workflow.start('claudeSessionWorkflow', {
+  return requireTestEnv().client.workflow.start('claudeSessionWorkflow', {
     workflowId,
     taskQueue: TASK_QUEUE,
     args: [input],

--- a/test/maestro.test.ts
+++ b/test/maestro.test.ts
@@ -11,6 +11,7 @@ import {
   setupTestEnv,
   teardownTestEnv,
   getClient,
+  getTestEnsemble,
   TASK_QUEUE,
   withWorkerAndMaestroActivities,
 } from './helpers';
@@ -23,11 +24,20 @@ import {
 } from '../src/workflows/maestro-signals';
 import type { MaestroPlayerInfo } from '../src/types';
 
-const ENSEMBLE = 'test-ensemble';
+/** Per-file ensemble namespace — seeded in `before()` (see #210). */
+let ENSEMBLE: string;
 /** Fast poll for tests — 500ms instead of the default 10s. */
 const FAST_POLL_MS = 500;
 /** Counter for unique workflow IDs across tests. */
 let testCounter = 0;
+
+/**
+ * Active handles registered during each `it()` body. Cleared + destroyed in
+ * `afterEach` so that even a test failing mid-body doesn't leak a running
+ * Maestro workflow under the shared `TestWorkflowEnvironment` (#210). Happy-
+ * path tests still signal shutdown inline; the hook is a safety net.
+ */
+const pendingHandles: WorkflowHandle[] = [];
 
 async function startMaestro(
   client: Client,
@@ -39,11 +49,13 @@ async function startMaestro(
     pollIntervalMs: FAST_POLL_MS,
   };
   const uniqueId = `claude-maestro-${input.ensemble}-${++testCounter}`;
-  return client.workflow.start('claudeMaestroWorkflow', {
+  const handle = await client.workflow.start('claudeMaestroWorkflow', {
     workflowId: uniqueId,
     taskQueue: TASK_QUEUE,
     args: [input],
   });
+  pendingHandles.push(handle);
+  return handle;
 }
 
 function sleep(ms: number): Promise<void> {
@@ -54,10 +66,29 @@ describe('claudeMaestroWorkflow', function () {
   before(async function () {
     this.timeout(60_000);
     await setupTestEnv();
+    ENSEMBLE = getTestEnsemble();
   });
 
   after(async function () {
     await teardownTestEnv();
+  });
+
+  // #210: best-effort shutdown of any Maestro handle started this test. Most
+  // `it()` bodies shut down inline; this catches the failure path where an
+  // assertion throws before the explicit shutdown runs. Under the shared env
+  // an orphaned running Maestro keeps polling `refreshEnsembleState` and can
+  // drive cross-file flakes (mocked activities throw once the test's fixture
+  // closure exits).
+  afterEach(async function () {
+    const toClean = pendingHandles.splice(0);
+    for (const handle of toClean) {
+      try {
+        await handle.signal(maestroShutdownSignal);
+        await handle.result().catch(() => { /* shutdown returns COMPLETED */ });
+      } catch {
+        // Already shutdown inline, or the workflow already completed. Ignore.
+      }
+    }
   });
 
   describe('initial state and queries', function () {

--- a/test/restart-agent-type-propagation.test.ts
+++ b/test/restart-agent-type-propagation.test.ts
@@ -84,7 +84,7 @@ const testConfig: Config = {
   temporalAddress: 'localhost:7233',
   temporalNamespace: 'default',
   taskQueue: 'claude-tempo',
-  ensemble: 'test-ensemble',
+  ensemble: 'test-ensemble-restart-agent-mock',
   defaultAgent: 'claude',
 };
 
@@ -104,7 +104,7 @@ describe('deliverRestart agent type propagation (#184)', function () {
     const { client, captured } = makeClient({
       workflowId: 'claude-session-test-ensemble-soloist',
       metadata: {
-        ensemble: 'test-ensemble',
+        ensemble: 'test-ensemble-restart-agent-mock',
         playerId: 'soloist',
         hostname: 'test-host',
         workDir: join(tmpdir(), `cw-soloist-${Date.now()}`), // intentionally nonexistent
@@ -116,7 +116,7 @@ describe('deliverRestart agent type propagation (#184)', function () {
 
     const activities = createOutboxActivities(client as any, testConfig);
     const result = await activities.deliverRestart({
-      ensemble: 'test-ensemble',
+      ensemble: 'test-ensemble-restart-agent-mock',
       targetPlayerId: 'soloist',
       invokerPlayerId: 'tempo-conductor',
       fresh: true,
@@ -151,7 +151,7 @@ describe('deliverRestart agent type propagation (#184)', function () {
       const { client, captured } = makeClient({
         workflowId: 'claude-session-test-ensemble-eng',
         metadata: {
-          ensemble: 'test-ensemble',
+          ensemble: 'test-ensemble-restart-agent-mock',
           playerId: 'eng',
           hostname: 'test-host',
           workDir: fixtureRoot, // project-tier seeded here
@@ -163,7 +163,7 @@ describe('deliverRestart agent type propagation (#184)', function () {
 
       const activities = createOutboxActivities(client as any, testConfig);
       const result = await activities.deliverRestart({
-        ensemble: 'test-ensemble',
+        ensemble: 'test-ensemble-restart-agent-mock',
         targetPlayerId: 'eng',
         invokerPlayerId: 'tempo-conductor',
         fresh: true,
@@ -188,7 +188,7 @@ describe('deliverRestart agent type propagation (#184)', function () {
     const { client, captured } = makeClient({
       workflowId: 'claude-session-test-ensemble-plain',
       metadata: {
-        ensemble: 'test-ensemble',
+        ensemble: 'test-ensemble-restart-agent-mock',
         playerId: 'plain',
         hostname: 'test-host',
         workDir: tmpdir(),
@@ -200,7 +200,7 @@ describe('deliverRestart agent type propagation (#184)', function () {
 
     const activities = createOutboxActivities(client as any, testConfig);
     await activities.deliverRestart({
-      ensemble: 'test-ensemble',
+      ensemble: 'test-ensemble-restart-agent-mock',
       targetPlayerId: 'plain',
       invokerPlayerId: 'tempo-conductor',
       fresh: true,

--- a/test/restart-host-routing.test.ts
+++ b/test/restart-host-routing.test.ts
@@ -63,15 +63,15 @@ function makeTargetClient(opts: { attachedHost?: string } = {}): any {
   return {
     workflow: {
       getHandle: () => ({
-        workflowId: 'claude-session-test-ensemble-target',
+        workflowId: 'claude-session-test-ensemble-restart-host-mock-target',
         async query(name: unknown) {
           const n = asName(name);
           if (n === 'attachmentInfo') return info;
-          if (n === 'getMetadata') return { ensemble: 'test-ensemble', playerId: 'target' };
+          if (n === 'getMetadata') return { ensemble: 'test-ensemble-restart-host-mock', playerId: 'target' };
           return undefined;
         },
       }),
-      async *list() { yield { workflowId: 'claude-session-test-ensemble-target' }; },
+      async *list() { yield { workflowId: 'claude-session-test-ensemble-restart-host-mock-target' }; },
     },
   };
 }
@@ -91,7 +91,7 @@ const testConfig = {
   temporalAddress: 'localhost:7233',
   temporalNamespace: 'default',
   taskQueue: 'claude-tempo',
-  ensemble: 'test-ensemble',
+  ensemble: 'test-ensemble-restart-host-mock',
   defaultAgent: 'claude' as const,
 };
 

--- a/test/root-hooks.ts
+++ b/test/root-hooks.ts
@@ -1,0 +1,20 @@
+/**
+ * Mocha global fixtures for the shared `TestWorkflowEnvironment` (#210 Phase 1).
+ *
+ * Loaded via `.mocharc.yml`'s `require:` key. Runs once per Mocha process,
+ * AFTER all spec files have finished — exactly the right place to tear down
+ * the process-wide env that `setupTestEnv()` created on first call.
+ *
+ * Global setup is intentionally NOT exported here: env creation is lazy,
+ * triggered by the first `setupTestEnv()` call inside a spec's `before()`
+ * hook. That keeps single-file invocations (`npx mocha test/foo.test.ts`)
+ * cheap — they only pay for one env, the one they actually use.
+ *
+ * Fallback: set `TEMPO_TEST_ISOLATED=1` to restore per-file env lifecycle.
+ * In that mode this teardown is a no-op (each file tore down its own env).
+ */
+import { teardownSharedTestEnv } from './helpers';
+
+export const mochaGlobalTeardown = async function (): Promise<void> {
+  await teardownSharedTestEnv();
+};

--- a/test/scheduler.test.ts
+++ b/test/scheduler.test.ts
@@ -7,6 +7,7 @@ import {
   setupTestEnv,
   teardownTestEnv,
   getClient,
+  getTestEnsemble,
   startSession,
   playerMetadata,
   updateMetadataSignal,
@@ -24,7 +25,12 @@ import {
 } from '../src/workflows/scheduler-signals';
 import { ScheduleEntry } from '../src/types';
 
-const ENSEMBLE = 'test-ensemble';
+/**
+ * Per-file ensemble namespace. Seeded in `before()` after `setupTestEnv()` so
+ * the value comes from `getTestEnsemble()` (#210 random suffix) and this file's
+ * workflow IDs don't collide with any other file under the shared env.
+ */
+let ENSEMBLE: string;
 const SCHEDULER_TASK_QUEUE = 'test-claude-tempo';
 
 function schedulerWorkflowId(ensemble: string): string {
@@ -71,6 +77,7 @@ describe('claudeSchedulerWorkflow', function () {
   before(async function () {
     this.timeout(60_000);
     await setupTestEnv();
+    ENSEMBLE = getTestEnsemble();
   });
 
   after(async function () {

--- a/test/stages.test.ts
+++ b/test/stages.test.ts
@@ -6,6 +6,7 @@ import {
   setupTestEnv,
   teardownTestEnv,
   getClient,
+  getTestEnsemble,
   startSession,
   conductorMetadata,
   withWorker,
@@ -21,7 +22,8 @@ import {
 } from '../src/workflows/signals';
 import type { StageEntry, Message } from '../src/types';
 
-const ENSEMBLE = 'test-ensemble';
+/** Per-file ensemble namespace — seeded in `before()` (see #210). */
+let ENSEMBLE: string;
 
 /**
  * Poll `assertFn` until it succeeds (no throw) or `timeoutMs` elapses.
@@ -60,6 +62,7 @@ describe('pipeline stages', function () {
   before(async function () {
     this.timeout(60_000);
     await setupTestEnv();
+    ENSEMBLE = getTestEnsemble();
   });
 
   after(async function () {

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -69,7 +69,7 @@ const testConfig: Config = {
   temporalAddress: 'localhost:7233',
   temporalNamespace: 'default',
   taskQueue: 'claude-tempo',
-  ensemble: 'test-ensemble',
+  ensemble: 'test-ensemble-tools-mock',
   defaultAgent: 'claude',
 };
 
@@ -323,7 +323,7 @@ describe('recruit tool force-terminate existing', function () {
         getHandle: (_id: string) => ({
           describe: async () => { throw new Error('workflow not found'); },
           query: async (name: string) => {
-            if (name === 'getMetadata') return { ensemble: 'test-ensemble', playerId: 'existing-player' } as any;
+            if (name === 'getMetadata') return { ensemble: 'test-ensemble-tools-mock', playerId: 'existing-player' } as any;
             return '';
           },
           signal: async () => {},
@@ -354,7 +354,7 @@ describe('recruit tool force-terminate existing', function () {
         getHandle: (_id: string) => ({
           describe: async () => { throw new Error('workflow not found'); },
           query: async (name: string) => {
-            if (name === 'getMetadata') return { ensemble: 'test-ensemble', playerId: 'existing-player' } as any;
+            if (name === 'getMetadata') return { ensemble: 'test-ensemble-tools-mock', playerId: 'existing-player' } as any;
             return '';
           },
           signal: async () => {},
@@ -1178,7 +1178,7 @@ function makeV2Client(opts: {
       if (name === 'getMetadata') {
         return {
           playerId,
-          ensemble: 'test-ensemble',
+          ensemble: 'test-ensemble-tools-mock',
           hostname,
           workDir: '/work',
           isConductor: false,

--- a/test/workflow.test.ts
+++ b/test/workflow.test.ts
@@ -45,7 +45,9 @@ describe('claudeSessionWorkflow', function () {
         const result = await handle.query(getMetadataQuery);
 
         expect(result.playerId).to.equal('lifecycle-1');
-        expect(result.ensemble).to.equal('test-ensemble');
+        // `meta.ensemble` comes from `playerMetadata()` — under #210 shared env
+        // it's a per-file suffix (`test-ensemble-<random>`), otherwise the default.
+        expect(result.ensemble).to.equal(meta.ensemble);
         expect(result.hostname).to.equal('test-host');
         expect(result.isConductor).to.equal(false);
 
@@ -480,9 +482,8 @@ describe('claudeSessionWorkflow', function () {
 
     it('does not overwrite fields not included in the update', async function () {
       await withWorker(async () => {
-        const handle = await startSession({
-          metadata: playerMetadata({ playerId: 'meta-partial' }),
-        });
+        const initialMeta = playerMetadata({ playerId: 'meta-partial' });
+        const handle = await startSession({ metadata: initialMeta });
 
         // Update only hostname
         await handle.signal(updateMetadataSignal, { hostname: 'updated-host' });
@@ -491,7 +492,7 @@ describe('claudeSessionWorkflow', function () {
         expect(meta.hostname).to.equal('updated-host');
         // Original fields should be preserved
         expect(meta.playerId).to.equal('meta-partial');
-        expect(meta.ensemble).to.equal('test-ensemble');
+        expect(meta.ensemble).to.equal(initialMeta.ensemble);
         expect(meta.isConductor).to.equal(false);
 
         await handle.executeUpdate(destroyUpdate, { args: [{}] });
@@ -566,12 +567,10 @@ describe('claudeSessionWorkflow', function () {
 
     it('does not overwrite unrelated metadata when updating playerType', async function () {
       await withWorker(async () => {
-        const handle = await startSession({
-          metadata: playerMetadata({
-            playerId: 'type-partial-update',
-            ensemble: 'test-ensemble',
-          }),
-        });
+        // Drop the explicit ensemble override — #210 default is a per-file
+        // suffix; the assertion below compares against whatever the helper set.
+        const initialMeta = playerMetadata({ playerId: 'type-partial-update' });
+        const handle = await startSession({ metadata: initialMeta });
 
         await handle.signal(updateMetadataSignal, { playerType: 'tempo-tuner' });
 
@@ -579,7 +578,7 @@ describe('claudeSessionWorkflow', function () {
         expect(meta.playerType).to.equal('tempo-tuner');
         // Original fields preserved
         expect(meta.playerId).to.equal('type-partial-update');
-        expect(meta.ensemble).to.equal('test-ensemble');
+        expect(meta.ensemble).to.equal(initialMeta.ensemble);
         expect(meta.isConductor).to.equal(false);
 
         await handle.executeUpdate(destroyUpdate, { args: [{}] });

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -73,7 +73,7 @@ describe('worktree helpers', function () {
   describe('path normalization', function () {
     it('worktree path is under the base path', function () {
       const gitRoot = path.resolve('/repos/project');
-      const basePath = worktreeBasePath(gitRoot, 'test-ensemble');
+      const basePath = worktreeBasePath(gitRoot, 'test-ensemble-worktree-fixture');
       const playerPath = path.join(basePath, 'my-player');
       expect(playerPath.startsWith(basePath)).to.be.true;
     });


### PR DESCRIPTION
## Summary

Closes #210. Phase 1 of the test-parallelization rollout per `docs/design/191-test-parallelization.md` §1.

Ships a **process-wide shared `TestWorkflowEnvironment`** with per-file random ensemble prefixes. One Temporal test server per `npm test` invocation instead of one per spec file (~17 of them), with `playerMetadata()` auto-namespacing default callers and `getTestEnsemble()` for files that need the prefix explicitly.

## What landed (per dispatch)

| Item | Status |
|---|---|
| `test/helpers.ts`: process-wide singleton env + per-file random suffix + `TEMPO_TEST_ISOLATED=1` fallback | ✅ |
| `test/maestro.test.ts` + `test/global-maestro.test.ts`: `afterEach` shutdown safety net | ✅ |
| `scripts/check-test-ensemble-literals.sh`: grep-based CI lint | ✅ |
| CI yaml: lint wired as fast preflight before matrix | ✅ |
| Wire-protocol: no changes | ✅ |
| Closes #210 | ✅ |

## 20-iteration validation (local)

Required by dispatch — **20 consecutive full `npm test` runs, zero flakes** before opening PR.

| Iter | Result | Tests | Wall-clock |
|---|---|---|---|
| 1-20 | ✅ PASS | 730 Mocha + 76 Vitest | 5m per run (range 5:03–5:07) |

Start times (10-min window shown): 14:23:30 → 15:59:47 + 5m completion. **Total ~100 minutes, zero flakes.**

## Wall-clock before/after (same machine, same branch base)

| Configuration | Duration |
|---|---|
| Baseline (per-file env, post-beta.2 + #213) | ~6m |
| **Shared env (this PR)** | **~5m** |
| Savings | ~60s local |

Design doc estimate was 50-85s; local measurement is at the low end. CI is typically slower per-env-startup than local dev machines, so the CI savings should skew higher — we'll measure on first green run.

## Risk register status (per design doc §5)

| Risk | 20-iter observation |
|---|---|
| Search-attribute re-registration on 2nd env invoke | ✅ Not observed — only 1 `createLocal()` per run (`grep -c "Temporal Server:" run.log` = 1) |
| Activity-stub leak across files | ✅ Not observed — 12,400+ test executions clean |
| Scheduler cron / global timer state | ✅ Not observed — scheduler.test.ts is green under shared env AND in isolation |

## Fallback

`TEMPO_TEST_ISOLATED=1 npm test` restores the old per-file env lifecycle. Useful for bisecting a cross-file state leak — shared-env bug isolates to per-file, per-file bug surfaces as consistent failure regardless of run order.

```bash
# Diagnose a suspected cross-file leak:
TEMPO_TEST_ISOLATED=1 npm test
# If it now passes: shared-env leak. Look at the Mocha spec ordering.
# If it still fails: a per-file bug — bisect that file's own state.
```

## CI lint wiring

`scripts/check-test-ensemble-literals.sh` runs as a fast preflight job (`lint-test-ensemble`). The matrix build has `needs: lint-test-ensemble`, so a PR that re-introduces a stray `'test-ensemble'` literal fails in <5s without burning three Node versions × several minutes of matrix time.

Allowed locations for the literal: `test/helpers.ts` (owns the default) and `test/root-hooks.ts` (imports helpers; currently no literal of its own).

## Scope note — audit discrepancy

The static audit predicted 8 Tier-B files with default-ensemble callers. The actual sweep found **~40 stray `'test-ensemble'` literals** across 10 files: the audit missed the `const ENSEMBLE = 'test-ensemble'` top-of-file pattern (scheduler, maestro, stages, ensemble — 4 files) and didn't flag pure-mock unit tests (activities, hard-terminate, tools, restart-agent-type, restart-host-routing, worktree — 6 files).

Both classes are handled with minimal, targeted edits:

- **4 workflow-affecting files**: `const ENSEMBLE = 'test-ensemble'` → `let ENSEMBLE: string` + `ENSEMBLE = getTestEnsemble()` inside the `before()` hook. Preserves all existing usage sites within the file.
- **6 mock-only files**: literal renamed to a file-specific suffix (`-mock`, `-fixture`). These mocks never hit the Temporal server, so the rename is purely to satisfy the lint without carving out permanent exceptions.

Updating the design doc's cost estimate to reflect this would be useful for future audits.

## Files changed

```
.github/workflows/ci.yml                    |  11 ++  (lint-test-ensemble job)
.gitattributes                              | NEW     (LF for *.sh)
.mocharc.yml                                |   2 ++  (require: root-hooks.js)
CHANGELOG.md                                |  14 ++
scripts/check-test-ensemble-literals.sh     | NEW     (grep lint)
test/helpers.ts                             | ~100+/- (shared env + prefix)
test/root-hooks.ts                          | NEW     (mochaGlobalTeardown)
test/maestro.test.ts                        |  35 ++  (getTestEnsemble + afterEach)
test/global-maestro.test.ts                 |  27 ++  (afterEach)
test/scheduler.test.ts                      |   9 ++  (getTestEnsemble)
test/stages.test.ts                         |   5 ++  (getTestEnsemble)
test/ensemble.test.ts                       |   5 ++  (getTestEnsemble)
test/workflow.test.ts                       |  23 ++  (assertion refactor)
test/activities.test.ts                     |   4 ++
test/hard-terminate.test.ts                 |  20 ++
test/tools.test.ts                          |   8 ++
test/restart-agent-type-propagation.test.ts |  14 ++
test/restart-host-routing.test.ts           |   8 ++
test/worktree.test.ts                       |   2 ++
```

## Test plan

- [x] `tsc --noEmit` clean
- [x] `npm run build` rebuilds workflow bundle
- [x] `bash scripts/check-test-ensemble-literals.sh` passes
- [x] `npm test` green — 730 Mocha + 76 Vitest
- [x] **20-iteration loop green** (see above)
- [x] Single Temporal server per run confirmed (grep -c `"Temporal Server:"` run.log = 1)
- [x] Rebased onto current `main` (post-#220)

## After-merge

- Observe 20 CI runs before dispatching Phase 2 (per design doc §4 rollout plan).
- Phase 2 (2-way matrix shard) is separately scoped; no pre-filing here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)