### PR TITLE
docs: post-merge sweep — PRs #218/#219/#221 + design doc 191 v4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,15 @@ src/
 ├── cli.ts             # CLI entry point (claude-tempo command)
 ├── daemon.ts          # Daemon entry point — runs Temporal workers as a detached background process
 ├── cli/
-│   ├── commands.ts    # CLI command implementations (up, start, conduct, status, stop, upgrade, …)
-│   ├── config-command.ts # config subcommand (interactive + set/show)
-│   ├── daemon.ts      # Daemon management utilities (start, stop, status, logs, isDaemonRunning)
+│   ├── commands.ts    # CLI command implementations (up, start, conduct, status, stop, …)
+│   ├── config-command.ts # config subcommand (interactive + set/show) — crash-proof for show/set
+│   ├── daemon.ts      # Daemon management utilities (start, stop, status, heartbeat, isDaemonRunning)
+│   ├── daemon-command.ts # daemon subcommand handler — crash-proof, no Temporal deps
+│   ├── help-text.ts   # help output — crash-proof, no Temporal deps
 │   ├── mcp.ts         # MCP server registration helpers (init, global vs project)
 │   ├── output.ts      # Shared CLI output formatting helpers
-│   └── preflight.ts   # Environment preflight checks
+│   ├── preflight.ts   # Environment preflight checks
+│   └── upgrade-command.ts # upgrade subcommand — crash-proof; dynamic-imports Temporal only for active-session warning
 ├── adapters/
 │   ├── README.md      # Adapter contract documentation
 │   ├── index.ts       # Adapter registry bootstrap + barrel exports

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -30,7 +30,7 @@ claude-tempo <command> [options]
 | `resume [ensemble]` | Resume a paused ensemble — unlocks outbox dispatch and restarts the scheduler. Use `--release` to also release any held players in the same call. |
 | `ensemble <sub>` | Manage saved lineups (`save`, `list`, `show`) |
 | `agent-types <sub>` | Manage player types (`list`, `show <name>`, `init`) |
-| `daemon <sub>` | Manage the worker daemon (`start`, `stop`, `status`, `logs`) |
+| `daemon <sub>` | Manage the worker daemon (`start [--force]`, `stop`, `status`, `logs`) |
 | `tui [--ensemble <name>]` | Launch the interactive TUI — chat-focused shell with slash commands for managing players and ensembles |
 | `upgrade [version]` | Graceful self-update — stops daemon, installs new version, restarts daemon |
 | `version` | Print the installed version |

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -5,10 +5,11 @@ The **worker daemon** is a standalone background process that runs Temporal work
 The daemon auto-starts the first time any claude-tempo command needs it. You can also manage it explicitly:
 
 ```bash
-claude-tempo daemon start    # start the daemon (no-op if already running)
-claude-tempo daemon stop     # stop the daemon
-claude-tempo daemon status   # show running state and PID
-claude-tempo daemon logs     # tail daemon logs
+claude-tempo daemon start           # start the daemon (no-op if already running)
+claude-tempo daemon start --force   # bypass orphan check + clear stale pid file
+claude-tempo daemon stop            # stop the daemon
+claude-tempo daemon status          # show running state, PID, and heartbeat age
+claude-tempo daemon logs            # tail daemon logs
 ```
 
 ## How It Works
@@ -19,12 +20,25 @@ claude-tempo daemon logs     # tail daemon logs
 - Logs are written to `~/.claude-tempo/daemon.log`
 - On Linux/macOS, the daemon is stopped via `SIGTERM`; on Windows, the process is killed directly
 
+### Heartbeat
+
+The daemon touches `~/.claude-tempo/daemon.heartbeat` every 60 seconds. `daemon status` reports the age of that file and flags it **stale** when the last touch is more than 120 seconds ago. A stale heartbeat with a live PID indicates the daemon's main loop may be hung — the PID-alive check alone can't distinguish "serving" from "hung".
+
+### Orphan pre-flight (`daemon start`)
+
+Before spawning, `daemon start` scans for unexpected claude-tempo daemon processes and aborts (exit 1) if any are found. This prevents the scenario where a stale or crashed daemon goes undetected and a second one is piled on top of it.
+
+- If orphans are found: the CLI prints the process list and a pointer to [troubleshooting.md](troubleshooting.md).
+- Pass `--force` to skip the check and proceed anyway (also clears a stale pid file). Use only after manually verifying no conflicting daemons exist, or in CI scripts that need idempotent-start behaviour.
+
 ## File Locations
 
 | File | Purpose |
 |------|---------|
 | `~/.claude-tempo/daemon.pid` | PID file written on daemon startup |
 | `~/.claude-tempo/daemon.log` | Daemon log output |
+| `~/.claude-tempo/daemon.heartbeat` | Touched every 60 s by the daemon; age reported by `daemon status` |
+| `~/.claude-tempo/upgrade.log` | Progress log written by `claude-tempo upgrade` |
 | `~/.claude-tempo/config.json` | Connection settings (see [configuration.md](configuration.md)) |
 | `~/.claude-tempo/temporal-data.db` | Temporal dev server data (local dev only) |
 
@@ -34,6 +48,8 @@ claude-tempo daemon logs     # tail daemon logs
 |---------|-----|
 | `workflow execution not found` errors | Restart the daemon: `claude-tempo daemon stop && claude-tempo daemon start` |
 | Sessions not responding to messages | Run `claude-tempo daemon status` — ensure the daemon is running |
+| `daemon start` aborts with "orphaned daemon processes" | Kill orphans manually (see [troubleshooting.md → Orphaned daemon processes](troubleshooting.md)); then `daemon start`. Or `daemon start --force` if you've already confirmed no conflicts. |
+| `daemon status` reports stale heartbeat | The daemon's main loop may be hung — restart: `daemon stop && daemon start` |
 
 See [troubleshooting.md](troubleshooting.md) for more.
 

--- a/docs/design/191-test-parallelization.md
+++ b/docs/design/191-test-parallelization.md
@@ -100,7 +100,7 @@ Researcher flagged 4 workers on 4-core as risky. 2 workers would be safer CPU-wi
 | Phase | Scope | PR title | Ship order | Files touched |
 |---|---|---|---|---|
 | 0 | Fix #209 (35s flake) | `fix(test): ...` | Before Phase 1 | 1 |
-| 1 | Option C — shared `TestWorkflowEnvironment` | `refactor(test): shared env, per-file namespace suffix` | After #209, observe 20 CI runs before Phase 2 | 3 |
+| 1 | Option C — shared `TestWorkflowEnvironment` | `refactor(test): shared env, per-file namespace suffix` | After #209, observe 5 CI runs before Phase 2 (reduced from 20 per v4) | 3 |
 | 2 | Option A — 2-way matrix shard | `feat(ci): shard mocha tests 2-way` | After Phase 1 stabilizes | ~4 (CI yaml, `shard-config.json`, `test/README.md`, scripts/package.json) |
 
 Phasing rationale: each phase is **independently valuable and cleanly revertible**. Phase 1 ships a test-helper refactor with no CI yaml changes. Phase 2 ships a CI yaml change with no test-code churn. If Phase 1 destabilizes, we roll back `test/helpers.ts` and the 2 test files — no CI plumbing to unwind. If Phase 2 misbehaves, we roll back the yaml and `shard-config.json` — test code unchanged.
@@ -109,7 +109,7 @@ Phasing rationale: each phase is **independently valuable and cleanly revertible
 
 | Risk | Likelihood | Impact | Mitigation |
 |---|---|---|---|
-| **Runtime state leak under shared env** (Phase 1) — audit was static-only | Medium | Medium–High | Run 20-iteration local loop pre-merge; canary the PR for 1 week on main before Phase 2. `TEMPO_TEST_ISOLATED=1 npm test` fallback path preserves per-file env for debugging. |
+| **Runtime state leak under shared env** (Phase 1) — audit was static-only | Medium | Medium–High | Run 20-iteration local loop pre-merge; observe 5 clean CI runs on main before Phase 2 (window reduced from 20 per v4 — Phase 1 landed clean with no state-leak signals). `TEMPO_TEST_ISOLATED=1 npm test` fallback path preserves per-file env for debugging. |
 | **Search-attribute re-registration** collides on second suite invocation | Low | Medium | Existing registration is idempotent; verify with explicit test. Document in `test/README.md`. |
 | **Workflow ID collisions** from a caller not using the random-suffix default | Medium during rollout | High (flaky cross-file contamination) | Lint rule or grep-based CI check: fail if `ensemble: 'test-ensemble'` appears as a literal outside `helpers.ts`. |
 | **Shard balance drift** as tests are added (Phase 2) | Medium | Low (one-line rebalance PR) | CI posts per-shard wall-clock; warn if `max/min > 1.3×`. |
@@ -121,7 +121,7 @@ Phasing rationale: each phase is **independently valuable and cleanly revertible
 ## 6. Recommendation
 
 1. Ship **#209** (separate PR) → critical path drops to 300s.
-2. Ship **Phase 1 (Option C shared env)** → critical path drops to **~215s (3m 35s)**. ~1-day refactor; 3 files touched; zero CI yaml changes. Run 20-iteration local loop pre-merge. Observe 20 CI runs post-merge watching for flakes before Phase 2.
+2. Ship **Phase 1 (Option C shared env)** → critical path drops to **~215s (3m 35s)**. ~1-day refactor; 3 files touched; zero CI yaml changes. Run 20-iteration local loop pre-merge. Observe 5 CI runs post-merge watching for flakes before Phase 2 (observation window reduced from 20 per v4).
 3. Ship **Phase 2 (Option A matrix shard)** once Phase 1 stabilizes → critical path drops to **~108s (1m 48s)**. ~50-line yaml + config PR. No test-code churn.
 4. Default **stop here**. Re-evaluate 3rd shard or `mocha --parallel` only if wall-clock creeps back above 2m over time.
 
@@ -137,3 +137,4 @@ Phasing rationale: each phase is **independently valuable and cleanly revertible
 - **v1** (initial): Recommended A → C phasing based on #16 spike estimate that C was ~1-week audit.
 - **v2**: Pivoted to **C → A** after workflow-ID audit reduced C's cost to ~1 day (3 files). Lower-risk first move; stress-tests shared-env stability before adding shard complexity.
 - **v3** (post-implementation, 2026-04-18): Phase 1 implementation (tempo-eng, #210) surfaced an estimation miss in the audit that fed v2. The audit reported **~8 literal `'test-ensemble'` occurrences** as the safety-critical collision surface; the actual full-repo sweep was **40 occurrences** across Tier A/B files. The extras lived in mock-only test files that bypass Temporal entirely, so the **safety property held** — zero collision risk at runtime — but the **cosmetic sweep** (literals to replace for consistency/lint-clean) was 5× larger than the design doc implied. No technical rework was needed; the Phase 1 PR simply had a larger diff than forecast. **Lesson for future audits of this kind**: separate the reported count into two metrics — *safety-relevant* (files that share the collision surface) and *total-sweep* (files the lint/rename touches, including Temporal-free ones). Conflating them understates PR size and risks reviewer surprise.
+- **v4** (2026-04-18 evening): Reduced the post-Phase-1 observation window from 20 → 5 clean CI runs before unlocking Phase 2 (matrix shard). Rationale: initial CI traffic post-merge showed zero flakes and no runtime state-leak signals (search-attribute re-registration, activity-stub leaks, and scheduler cron state all quiet). The v3 20-run bar was conservative — it was set when the shared-env audit was still static-only and runtime behaviour was unconfirmed; with two clean runs at decision time and no signals surfacing, 5 is a sufficient empirical bar. Decision-maker: vinceblank.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -63,6 +63,12 @@ claude-tempo daemon start                                          # spawn a sin
 claude-tempo daemon status                                         # verify orphan count is zero
 ```
 
+Alternatively, once orphans are killed and the pid file is cleared, `daemon start --force` is a one-step shortcut — it bypasses the orphan pre-flight check and removes any stale pid file before spawning:
+
+```bash
+claude-tempo daemon start --force
+```
+
 Pattern match is narrow (`claude-tempo` + `dist/daemon.js` in the command line) so
 these commands won't touch unrelated node processes. Review the list output before
 running the kill variant.


### PR DESCRIPTION
## Summary

Post-merge docs catch-up for three PRs that landed on main without corresponding documentation updates, plus a design doc revision.

- **CLAUDE.md**: add `daemon-command.ts`, `help-text.ts`, `upgrade-command.ts` to the `cli/` structure listing; update `commands.ts` and `daemon.ts` descriptions to reflect what moved where (PR #221)
- **docs/daemon.md**: document `daemon start --force`; add Heartbeat and Orphan pre-flight subsections; add `daemon.heartbeat` and `upgrade.log` to File Locations table; add two troubleshooting rows (PRs #218/#219)
- **docs/cli.md**: note `[--force]` on the `daemon start` entry (PR #218)
- **docs/troubleshooting.md**: add `daemon start --force` shortcut note in the orphan cleanup section (PR #219)
- **docs/design/191-test-parallelization.md**: v4 appendix entry — lower post-Phase-1 observation window from 20 → 5 CI runs; update three in-body references for internal consistency (vinceblank decision 2026-04-18 evening)

No wire-protocol changes. No code changes — docs only.

## Test plan

- [ ] Verify `docs/daemon.md` Heartbeat and Orphan pre-flight sections read clearly
- [ ] Verify `docs/cli.md` daemon row shows `start [--force]`
- [ ] Verify `docs/troubleshooting.md` orphan cleanup section has the `--force` shortcut
- [ ] Verify `CLAUDE.md` cli/ listing now includes `daemon-command.ts`, `help-text.ts`, `upgrade-command.ts`
- [ ] Verify `docs/design/191-test-parallelization.md` appendix has v4 entry and all "20 runs" → "5 runs" references updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)