### PR TITLE
chore: bump version to v0.26.0-beta.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.0-beta.3] - 2026-04-18
+
+> **Beta release.** Completes the adapter resilience trilogy: reconnect across `continueAsNew`
+> (#226), plus daemon singleton hardening, crash-proof CLI, and shared test environment.
+>
+> **Install:** `npm i -g claude-tempo@0.26.0-beta.3`
+> **Rollback:** `npm i -g claude-tempo@0.26.0-beta.2`
+
 ### Changed
 
 - **Shared `TestWorkflowEnvironment` across Mocha spec files** (#210 Phase 1). The

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   Maestro workflow into the next test under the shared env.
 - New CI lint (`scripts/check-test-ensemble-literals.sh`) fails on stray
   `'test-ensemble'` literals outside `test/helpers.ts` / `test/root-hooks.ts`.
+- Removed dead cleanup pass that called `terminate()` on already-completed workflows
+  (silent error swallow). (#144, #217)
+- `OrphanSummary` now includes `ensemble` and `playerId` fields directly, eliminating a
+  per-orphan lookup round-trip. (#145, #217)
 
 ### Fixed
 
+- **Orphan reconcile mis-parsed player identities** when either the ensemble or player name
+  contained dashes (e.g. `tempo-eng` in ensemble `tempo-impl` was parsed as
+  `ensemble=tempo-impl-tempo, playerId=eng`). Affected the `restore` CLI command and daemon
+  reconcile-on-boot. (#143, #217)
 - **Adapter reconnects across `continueAsNew`** (closes #226). When the session
   workflow continued-as-new, the adapter's heartbeat + phase-watcher ticks on
   the (now-closed) pinned runId hit `WorkflowNotFoundError` with message

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.2",
+  "version": "0.26.0-beta.3",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
## Summary

- Promotes `[Unreleased]` CHANGELOG section → `[0.26.0-beta.3] - 2026-04-18`
- Bumps `package.json` version: `0.26.0-beta.2` → `0.26.0-beta.3`

### What's in beta.3 (since beta.2)

**Fixed**
- Adapter reconnects across `continueAsNew` — closes #226 (PR #229). Completes the adapter resilience trilogy: #201 (lease-revoked reconnect) + #215 (reconnecting-flag hardening) + #226 (CAN rebind).
- CLI crash-proof isolation test was silently skipping in CI — PR #221
- Adapter `reconnecting` flag always resets on every exit path — closes #206 (PR #215)
- Daemon stop crash-proof + orphan daemon detection — closes #157 PR A (PR #218)

**Added**
- `daemon start` pre-flight orphan check + `--force` escape hatch — PR #219
- Daemon heartbeat file at `~/.claude-tempo/daemon.heartbeat` — PR #219
- `version` / `help` / `upgrade` / `config` crash-proof entrypoints — closes #157 PR C (PR #221)
- Shared `TestWorkflowEnvironment` across Mocha spec files — PR #222 (#210 Phase 1)

**After merge**: tag `v0.26.0-beta.3` → GHA publishes to npm + creates GitHub Release automatically.

## Test plan
- [ ] CI green on this PR
- [ ] After merge: tag `v0.26.0-beta.3`, verify GHA release workflow triggers
- [ ] Install locally: `npm i -g claude-tempo@0.26.0-beta.3` and `claude-tempo --version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)