### PR TITLE
refactor(workflow): extract CAN-boundary extension math into pure function (#127)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Extract CAN-boundary attachment-extension math into a pure function** (#127).
+  The 4-line "push `lastHeartbeatAt` / `expiresAt` out to `now + heartbeatMs` so
+  the new execution has room to land the next heartbeat" math was previously
+  inlined in `src/workflows/session.ts` immediately before `continueAsNew`,
+  making it effectively untestable without a full history-fill harness (rejected
+  in the PR-G architect review per #127 rationale — such a harness would test
+  Temporal's CAN-trigger heuristic rather than our extension logic, and is
+  brittle to SDK internals). The math now lives in
+  `src/workflows/attachment-math.ts` as the pure function
+  `extendAttachmentForCAN(attachment, heartbeatMs, now)`, backed by focused
+  unit tests in `test/workflows/can-boundary-extension.test.ts` (which was
+  previously an all-skipped stub awaiting this extraction). Behavior unchanged
+  — the session workflow call site is a one-line swap. Follow-up to #125
+  (PR-G) architect review.
+
 ## [0.26.0-beta.3] - 2026-04-18
 
 > **Beta release.** Completes the adapter resilience trilogy: reconnect across `continueAsNew`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ src/
 │   ├── session.ts     # claude-session workflow
 │   ├── scheduler.ts   # durable scheduler workflow (one per ensemble)
 │   ├── maestro.ts     # Maestro workflows — per-ensemble hub and global hub
+│   ├── attachment-math.ts # Pure CAN-boundary lease-extension helper (no Temporal imports)
 │   ├── maestro-signals.ts / scheduler-signals.ts / signals.ts   # Signal/query/update type defs
 │   └── index.ts       # Workflow re-exports for worker bundle
 ├── activities/

--- a/src/workflows/attachment-math.ts
+++ b/src/workflows/attachment-math.ts
@@ -1,0 +1,63 @@
+/**
+ * Pure attachment-math helpers for the session workflow.
+ *
+ * **Workflow-sandbox safe**: this file imports only types. No `@temporalio/*`
+ * runtime imports, no `Date.now()`, no random, no I/O — every caller passes
+ * `now` as a parameter so the same inputs always produce the same output.
+ * That makes it:
+ *   - Cheap to unit-test from Mocha without `TestWorkflowEnvironment`, and
+ *   - Safe to call from deterministic workflow code (caller is responsible
+ *     for sourcing `now` via the SDK-intercepted `new Date().getTime()`).
+ *
+ * Extracted in PR #127-fix as a follow-up to PR-G (#125) architect review:
+ * the alternative was a ~60 LOC history-fill harness that would have tested
+ * Temporal's CAN-trigger heuristic rather than our extension logic, and
+ * would have been brittle to Temporal-SDK internals. Pure-function + direct
+ * unit tests is the durable choice.
+ */
+import type { Attachment } from '../types';
+
+/**
+ * Produce a new {@link Attachment} whose lease window is extended so an
+ * adapter that was beating normally at the moment of `continueAsNew` has room
+ * to land its next heartbeat before the new execution's first main-loop tick
+ * reaps the lease.
+ *
+ * **Design rationale (session-lifecycle-rebuild-v2.md §2.3):** the CAN
+ * transition is not instantaneous. If we were to write the pre-CAN
+ * `expiresAt` verbatim into the new execution, a transition that takes
+ * ~100-500ms could leave the new run's first deadline race observing an
+ * already-expired lease and reaping a healthy attachment. Pushing
+ * `expiresAt` out to `now + heartbeatMs` guarantees the next normally-timed
+ * heartbeat has room to arrive.
+ *
+ * Why this is a total function (returns a new object unconditionally,
+ * rather than accepting `null` and returning `undefined`): null-handling is
+ * the caller's business — a workflow that has no current attachment simply
+ * skips the call. Keeping this function non-nullable keeps the unit tests
+ * focused on math rather than null-propagation.
+ *
+ * @param attachment - the pre-CAN attachment record. All non-timestamp
+ *   fields (`attachmentId`, `hostname`, `adapterId`, `adapterClass`,
+ *   `claimedAt`, `leaseMs`, `runId`) are carried forward verbatim.
+ * @param heartbeatMs - the adapter's heartbeat cadence in milliseconds. The
+ *   new `expiresAt` lands `heartbeatMs` past `now`. Callers typically pass
+ *   the workflow's `HEARTBEAT_INTERVAL_MS` constant, but any non-negative
+ *   integer is accepted — the function does not validate.
+ * @param now - current time in epoch milliseconds. In workflow context
+ *   callers pass `new Date().getTime()` (the Temporal SDK intercepts `new
+ *   Date()` to return replay-consistent time). In unit tests callers pass
+ *   an arbitrary fixed value.
+ * @returns a new `Attachment` object — the input is not mutated.
+ */
+export function extendAttachmentForCAN(
+  attachment: Attachment,
+  heartbeatMs: number,
+  now: number,
+): Attachment {
+  return {
+    ...attachment,
+    lastHeartbeatAt: new Date(now).toISOString(),
+    expiresAt: new Date(now + heartbeatMs).toISOString(),
+  };
+}

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -24,6 +24,7 @@ function workflowNow(): Date {
 
 import type { OutboxActivities } from '../activities/outbox';
 import type { HardTerminateResult } from '../activities/hard-terminate';
+import { extendAttachmentForCAN } from './attachment-math';
 
 import {
   SessionInput,
@@ -1513,12 +1514,9 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
       // new execution and the transition takes ~100–500ms, the new execution's first main
       // loop check could reap a healthy attachment as expired. Extend the lease by one
       // heartbeat interval so a normally-beating adapter has room to land its next heartbeat.
+      // Math lives in `./attachment-math.ts` for direct unit testability (#127).
       const extendedAttachment = currentAttachment
-        ? {
-            ...currentAttachment,
-            lastHeartbeatAt: workflowNow().toISOString(),
-            expiresAt: new Date(workflowNow().getTime() + HEARTBEAT_INTERVAL_MS).toISOString(),
-          }
+        ? extendAttachmentForCAN(currentAttachment, HEARTBEAT_INTERVAL_MS, workflowNow().getTime())
         : undefined;
 
       await continueAsNew<typeof claudeSessionWorkflow>({

--- a/test/workflows/can-boundary-extension.test.ts
+++ b/test/workflows/can-boundary-extension.test.ts
@@ -1,53 +1,167 @@
 /**
- * Workflow invariant: CAN-boundary lease extension (§2.3).
+ * Unit tests for the CAN-boundary lease-extension math (#127).
  *
- * Before firing `continueAsNew`, the session workflow extends the carried
- * `currentAttachment.expiresAt` by one `HEARTBEAT_INTERVAL_MS` so the new
- * execution's first main-loop tick doesn't reap a healthy attachment during the
- * CAN transition window.
- *
- * **PR-G scaffolding (step 7/7).** This file stubs the extension-before-CAN test
- * that architect-2 identified as complementary to PR-A's boot-side coverage.
- * Today's TestWorkflowEnvironment does not expose a stable way to force
- * `workflowInfo().continueAsNewSuggested === true` — the trigger is history-size
- * based and varies with SDK internals. Filling history deterministically from
- * a test would require either a patched workflow threshold or a ~50 LOC signal-
- * spam loop that's brittle across SDK versions.
- *
- * Un-skip and implement when the test harness gains an explicit CAN trigger
- * (e.g. `testEnv.advanceHistory()`), or when the extension helper is extracted
- * from `src/workflows/session.ts` as a pure function testable without a worker.
+ * The math — "push `expiresAt` out by one heartbeat interval so a healthy
+ * adapter has room to land its next heartbeat across the CAN transition" —
+ * was originally inlined in `src/workflows/session.ts` immediately before
+ * `continueAsNew`. PR-G (#125) considered adding a ~60 LOC history-fill
+ * harness to exercise the path but rejected it: that approach would have
+ * tested Temporal's CAN-trigger heuristic (`workflowInfo().continueAsNewSuggested`)
+ * rather than our extension logic, and would have been brittle to
+ * Temporal-SDK internals. PR #127 extracted the math into
+ * `src/workflows/attachment-math.ts#extendAttachmentForCAN` — a pure
+ * function — so this suite can test it directly without
+ * `TestWorkflowEnvironment` or workflow-bundle plumbing.
  *
  * Cross-reference:
- * - `test/session-lease.test.ts:61` covers the BOOT side — "pre-populated
+ * - `test/session-lease.test.ts` covers the BOOT side — "pre-populated
  *   `currentAttachment` is restored and phase=attached". Do NOT duplicate.
- * - `src/workflows/session.ts:1322-1333` is the production extension code
- *   (currentAttachment.expiresAt bumped to `workflow.now() + HEARTBEAT_INTERVAL_MS`
- *   just before `continueAsNew`).
+ * - `src/workflows/session.ts` line ~1516 is the sole production call site
+ *   (guarded by `currentAttachment` truthiness; the pure function is total).
  *
- * Design reference: docs/design/session-lifecycle-rebuild-v2.md §2.3, §9.5.
- * Sequencing memo: §3 PR-G "starter-3" (CAN-boundary extension-before-CAN path).
+ * Design reference: `docs/design/session-lifecycle-rebuild-v2.md` §2.3, §9.5.
  */
-import { setupTestEnv, teardownTestEnv } from '../helpers';
+import { expect } from 'chai';
+import { extendAttachmentForCAN } from '../../src/workflows/attachment-math';
+import type { Attachment } from '../../src/types';
 
-describe('workflow invariant: CAN-boundary lease extension (§2.3)', function () {
-  before(async function () {
-    this.timeout(60_000);
-    await setupTestEnv();
+/**
+ * Fixture builder. Callers override only the fields they care about — the
+ * defaults are a plausible "healthy mid-life attachment" so tests don't have
+ * to restate the full shape for every case.
+ */
+function makeAttachment(overrides: Partial<Attachment> = {}): Attachment {
+  return {
+    attachmentId: 'att-abc-123',
+    hostname: 'test-host',
+    adapterId: 'claude-code',
+    adapterClass: 'interactive',
+    claimedAt: '2026-04-01T12:00:00.000Z',
+    lastHeartbeatAt: '2026-04-01T12:30:00.000Z',
+    expiresAt: '2026-04-01T12:32:00.000Z',
+    leaseMs: 120_000,
+    runId: 'run-xyz-789',
+    ...overrides,
+  };
+}
+
+/** A known epoch ms so tests can assert the exact post-extension timestamps. */
+const NOW_MS = Date.UTC(2026, 3, 1, 12, 31, 15); // 2026-04-01T12:31:15.000Z
+const NOW_ISO = '2026-04-01T12:31:15.000Z';
+
+describe('extendAttachmentForCAN (#127 — design §2.3)', function () {
+  describe('happy path', () => {
+    it('sets lastHeartbeatAt to `now` and expiresAt to `now + heartbeatMs`', () => {
+      const input = makeAttachment();
+      const out = extendAttachmentForCAN(input, 30_000, NOW_MS);
+
+      expect(out.lastHeartbeatAt).to.equal(NOW_ISO);
+      expect(out.expiresAt).to.equal(new Date(NOW_MS + 30_000).toISOString());
+    });
+
+    it('preserves every non-timestamp field verbatim', () => {
+      const input = makeAttachment({
+        attachmentId: 'unique-id',
+        hostname: 'renamed-host',
+        adapterId: 'copilot',
+        adapterClass: 'sdk',
+        claimedAt: '2026-01-15T08:00:00.000Z',
+        leaseMs: 90_000,
+        runId: 'different-run',
+      });
+      const out = extendAttachmentForCAN(input, 60_000, NOW_MS);
+
+      expect(out.attachmentId).to.equal('unique-id');
+      expect(out.hostname).to.equal('renamed-host');
+      expect(out.adapterId).to.equal('copilot');
+      expect(out.adapterClass).to.equal('sdk');
+      expect(out.claimedAt).to.equal('2026-01-15T08:00:00.000Z');
+      expect(out.leaseMs).to.equal(90_000);
+      expect(out.runId).to.equal('different-run');
+    });
+
+    it('does not mutate the input attachment', () => {
+      const input = makeAttachment();
+      const snapshot = { ...input };
+      extendAttachmentForCAN(input, 30_000, NOW_MS);
+      expect(input).to.deep.equal(snapshot);
+    });
+
+    it('returns a fresh object (reference inequality with input)', () => {
+      const input = makeAttachment();
+      const out = extendAttachmentForCAN(input, 30_000, NOW_MS);
+      expect(out).to.not.equal(input);
+    });
   });
 
-  after(async function () {
-    await teardownTestEnv();
+  describe('edge cases', () => {
+    it('extends past an already-past expiresAt (the whole point of §2.3)', () => {
+      // This is the failure mode the extension exists to prevent: without the
+      // math, the new execution's first main-loop tick would see an expiresAt
+      // in the past and reap a healthy attachment. Confirming it here pins the
+      // behavior so a future well-meaning "optimization" (e.g. "only extend if
+      // current expiresAt is in the future") doesn't re-introduce the bug.
+      const input = makeAttachment({
+        expiresAt: '2026-04-01T12:00:00.000Z', // 31m15s BEFORE NOW_MS
+      });
+      const out = extendAttachmentForCAN(input, 30_000, NOW_MS);
+      expect(new Date(out.expiresAt).getTime()).to.equal(NOW_MS + 30_000);
+      expect(new Date(out.expiresAt).getTime()).to.be.greaterThan(
+        new Date(input.expiresAt).getTime(),
+      );
+    });
+
+    it('accepts heartbeatMs = 0 (degenerate but not forbidden)', () => {
+      const input = makeAttachment();
+      const out = extendAttachmentForCAN(input, 0, NOW_MS);
+      expect(out.lastHeartbeatAt).to.equal(NOW_ISO);
+      expect(out.expiresAt).to.equal(NOW_ISO);
+    });
+
+    it('accepts a very large heartbeatMs without overflow', () => {
+      // Temporal workflow heartbeatMs is bounded to 600_000 in practice, but
+      // the pure function does not validate. Ensure arithmetic stays sane up
+      // to at least ~year-2030 expiresAt.
+      const oneYearMs = 365 * 24 * 60 * 60 * 1000;
+      const input = makeAttachment();
+      const out = extendAttachmentForCAN(input, oneYearMs, NOW_MS);
+      expect(new Date(out.expiresAt).getTime()).to.equal(NOW_MS + oneYearMs);
+    });
+
+    it('is deterministic — same inputs produce equal outputs', () => {
+      const input = makeAttachment();
+      const a = extendAttachmentForCAN(input, 30_000, NOW_MS);
+      const b = extendAttachmentForCAN(input, 30_000, NOW_MS);
+      expect(a).to.deep.equal(b);
+    });
   });
 
-  it.skip('extends currentAttachment.expiresAt by HEARTBEAT_INTERVAL_MS before continueAsNew', async function () {
-    // TODO (PR-G follow-up or PR-C): see file docstring for the harness limitation.
-    // Expected shape once implementable:
-    //   1. Start a fresh session + claimAttachment (lease T0).
-    //   2. Trigger continueAsNew (currently no clean API; would require history spam).
-    //   3. Read post-CAN attachmentInfo — assert currentAttachment.expiresAt is
-    //      approximately `workflow.now() + HEARTBEAT_INTERVAL_MS` (30_000ms), not the
-    //      original T0 expiresAt (which could have been mid-lease).
-    //   4. Tolerance: ±1s for scheduler variance.
+  describe('production call-site contract', () => {
+    it('models the session.ts invocation with HEARTBEAT_INTERVAL_MS = 30_000', () => {
+      // This mirrors the call site exactly — documents the expected
+      // production behavior so anyone reading the test can see what
+      // `session.ts` is doing without opening the workflow file.
+      const currentAttachment = makeAttachment({
+        expiresAt: '2026-04-01T12:32:00.000Z', // 45s ahead of NOW_MS
+      });
+      const HEARTBEAT_INTERVAL_MS = 30_000;
+
+      const out = extendAttachmentForCAN(
+        currentAttachment,
+        HEARTBEAT_INTERVAL_MS,
+        NOW_MS,
+      );
+
+      // New expiresAt is now + 30s = 2026-04-01T12:31:45.000Z — pushed out
+      // from the pre-call 2026-04-01T12:32:00.000Z by a net -15s? No:
+      // 12:31:15 + 30s = 12:31:45, which is actually 15 SECONDS EARLIER than
+      // the pre-call expiresAt. Document this: the extension floors to
+      // `now + heartbeatMs`, it does NOT take `max(current expiresAt,
+      // now + heartbeatMs)`. For the §2.3 use case (adapter was beating
+      // normally, pre-CAN expiresAt is at most ~2x heartbeatMs past now)
+      // this is fine — the new expiresAt guarantees a next heartbeat window.
+      expect(new Date(out.expiresAt).getTime()).to.equal(NOW_MS + 30_000);
+      expect(out.lastHeartbeatAt).to.equal(NOW_ISO);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Extracts the 4-line CAN-boundary lease-extension math from `src/workflows/session.ts` into a pure function so it can be unit-tested directly — resolves the PR-G architect-review follow-up (#125 → #127).

**Before**: the math lived inline in `session.ts` immediately before `continueAsNew`. PR-G considered adding a ~60 LOC history-fill harness to cover it, but rejected: that approach would have tested Temporal's CAN-trigger heuristic rather than our extension logic, and would have been brittle to SDK internals.

**After**: `src/workflows/attachment-math.ts#extendAttachmentForCAN(attachment, heartbeatMs, now)`. Pure function — no `@temporalio/*` imports, no `Date.now()`, no I/O. Caller passes `now` as a parameter, so the function is workflow-sandbox-safe AND testable directly under Mocha. `session.ts` is a 4-line block → 1-line call; behavior unchanged.

`test/workflows/can-boundary-extension.test.ts` was previously an all-skipped stub whose docstring explicitly said "un-skip and implement when the extension helper is extracted from `src/workflows/session.ts` as a pure function testable without a worker" — exactly this PR. Rewritten with 9 focused unit tests.

## Scope confirmation

- **One CAN-math site post-#229, not two.** #226 touched only the CAN *condition* (adding `|| forceContinueAsNew`), not the math. Verified via `grep HEARTBEAT_INTERVAL_MS|extendedAttachment`.
- **No behavior change.** The extracted function is a byte-for-byte equivalent of the inline math (both timestamp derivations call `new Date(now).toISOString()` or `new Date(now + heartbeatMs).toISOString()`). Existing 768 Mocha tests pass unchanged; 9 new unit tests bring total to 777.
- **No bug fixes in-flight.** If I'd found a bug in the math I'd have flagged + filed separately per conductor's scope discipline note — none found. The "extends past already-past expiresAt" test pins the current behavior as a deliberate choice rather than accidentally re-introducing a well-meaning `max(current, now+heartbeat)` "optimization" that would re-introduce the §2.3 bug.

## File placement

Chose `src/workflows/attachment-math.ts` (conductor's weak preference). Alternatives considered: colocated in `session.ts` (rejected — no clean way to export for tests without polluting workflow namespace) or under `src/utils/` (rejected — the function is workflow-semantic, not a generic utility).

## Test coverage

Nine unit tests across three groups, all <5ms total runtime:

- **Happy path** (4): timestamps, field preservation, no mutation, fresh object.
- **Edge cases** (4): past-expiresAt extension (the §2.3 raison d'être), `heartbeatMs=0`, very-large-year-past `heartbeatMs`, determinism.
- **Production call-site contract** (1): mirrors the exact `session.ts` invocation with `HEARTBEAT_INTERVAL_MS=30_000` so a reader of the test can see what the workflow does without opening the workflow file.

## Test plan

- [x] `npm run build` — clean rebundle (workflow bundle size unchanged).
- [x] Unit tests pass: 9 passing, 5ms (no `TestWorkflowEnvironment` required).
- [x] Full Mocha suite: 777 passing, 22 pending, 0 failing (was 768 before — +9 new unit tests).
- [x] `git diff src/workflows/session.ts` — 4-line block → 1-line call. No other changes.

Fixes #127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)