### PR TITLE
refactor(outbox): harden deliver activity error handling (closes #139, #140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   previously an all-skipped stub awaiting this extraction). Behavior unchanged
   — the session workflow call site is a one-line swap. Follow-up to #125
   (PR-G) architect review.
+- **Outbox delivery activities now retry transient Temporal RPC errors** instead
+  of flattening every mid-algorithm failure to `ApplicationFailure.nonRetryable`.
+  `deliverDetach`, `deliverDestroy`, and `deliverRestart` route uncaught errors
+  through a new `isRetryableTemporalError` classifier: `TransportError`,
+  `TimeoutError`, `DEADLINE_EXCEEDED`, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`,
+  `CANCELLED`, and common `ECONN*` / `ETIMEDOUT` signatures are re-thrown as
+  plain `Error` so the activity retry policy backs off and retries. Permanent
+  classes (`WorkflowNotFoundError`, `WorkflowUpdateFailedError`, "workflow
+  execution already completed") and unknown errors stay non-retryable. Typed
+  `ApplicationFailure.nonRetryable` throws inside the activity (e.g. "no
+  session found", "phase=gone") pass through unchanged. (#140)
+- Extracted `DEFAULT_RESTART_DETACH_DEADLINE_MS` (5s) and
+  `DEFAULT_RESTART_LEASE_MS` (90s) constants from `deliverRestart` into
+  `src/utils/validation.ts` for consistency with the other restart / detach
+  knobs already documented there. No behavioral change. (#139)
 
 ## [0.26.0-beta.3] - 2026-04-18
 

--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -5,7 +5,11 @@ import * as path from 'path';
 import * as crypto from 'crypto';
 import { Config, conductorWorkflowId, sessionWorkflowId } from '../config';
 import { AgentType, SessionInput, AdapterClass, AttachmentInfo, SessionMetadata, Message, DetachReason } from '../types';
-import { PREVIEW_MAX_LENGTH } from '../utils/validation';
+import {
+  PREVIEW_MAX_LENGTH,
+  DEFAULT_RESTART_DETACH_DEADLINE_MS,
+  DEFAULT_RESTART_LEASE_MS,
+} from '../utils/validation';
 import { ENSEMBLE_SENTINEL_FLAG } from '../constants';
 import { getGitInfo } from '../git-info';
 import { spawnInTerminal, spawnCopilotBridge } from '../spawn';
@@ -29,6 +33,89 @@ import {
 } from '../workflows/signals';
 
 const log = (...args: unknown[]) => console.error('[claude-tempo:outbox]', ...args);
+
+/**
+ * Classify a Temporal client error raised by `handle.query` / `handle.signal`
+ * / `handle.executeUpdate` as retryable (transient) vs permanent (#140).
+ *
+ * ## Contract
+ * - Returns `true` → caller should **re-throw the underlying Error** so the
+ *   activity's retry policy can back off and retry (per-worker config).
+ * - Returns `false` → caller should wrap in `ApplicationFailure.nonRetryable`
+ *   so the outbox surfaces a permanent failure and stops retrying.
+ *
+ * ## Safety posture
+ * **Conservative default: unknown → non-retryable.** Over-classifying as
+ * retryable causes infinite retry loops on genuinely permanent errors. The
+ * activity will fail fast on unknown cases; a follow-up PR can whitelist more
+ * transient signatures if we see false-permanent rates in the wild.
+ *
+ * ## Why name/message sniffing, not `instanceof`
+ * Matches the established pattern in `src/adapters/base.ts` `isTerminalErr`:
+ * the Temporal Node SDK surfaces slightly different error shapes between
+ * `@temporalio/client`, the gRPC layer, and `WorkflowUpdateFailedError`
+ * wrappers. Sniffing on name + message is resilient across those shapes.
+ */
+function isRetryableTemporalError(err: unknown): boolean {
+  // ApplicationFailure instances have already been classified by the thrower
+  // (nonRetryable=true/false). The calling code paths in this module only ask
+  // about non-ApplicationFailure errors, but this guard makes the helper safe
+  // to call unconditionally.
+  if (err instanceof ApplicationFailure) return false;
+  const e = err as { name?: string; message?: string } | undefined;
+  const name = e?.name ?? '';
+  const msg = e?.message ?? '';
+  // ── Permanent: workflow is genuinely gone or validator rejected the op. ──
+  if (
+    name.includes('WorkflowNotFound') ||
+    name.includes('WorkflowExecutionAlreadyCompleted') ||
+    // Update rejected by the workflow-side validator (e.g. `WorkflowGone`
+    // thrown from `claimAttachment`'s validator on a destroyed session).
+    // A retry won't make the validator change its mind.
+    name.includes('WorkflowUpdateFailed') ||
+    msg.includes('WorkflowGone') ||
+    msg.includes('workflow execution already completed')
+  ) return false;
+  // ── Transient: RPC / network / temporary SDK unavailability. ──
+  if (
+    name.includes('TransportError') ||
+    name.includes('TimeoutError') ||
+    msg.includes('DEADLINE_EXCEEDED') ||
+    msg.includes('UNAVAILABLE') ||
+    msg.includes('RESOURCE_EXHAUSTED') ||
+    msg.includes('CANCELLED') ||
+    /\bECONNRESET\b/.test(msg) ||
+    /\bECONNREFUSED\b/.test(msg) ||
+    /\bETIMEDOUT\b/.test(msg) ||
+    /\bENOTFOUND\b/.test(msg) ||
+    /\bEAI_AGAIN\b/.test(msg)
+  ) return true;
+  // Unknown shape — stay permanent (see "Safety posture" above).
+  return false;
+}
+
+/**
+ * Standard shape for the 3 §8.2 deliver activities' catch-all tail.
+ * Centralises the branch so each activity body stays concise.
+ *
+ * - If `err` is already an `ApplicationFailure` (typed permanent — e.g. the
+ *   explicit "not found" / "destroyed" throws), re-throw as-is.
+ * - If `err` is retryable per {@link isRetryableTemporalError}, re-throw the
+ *   original `Error` so the activity retry policy handles it.
+ * - Otherwise wrap in `ApplicationFailure.nonRetryable` with a caller-supplied
+ *   context prefix (e.g. `Detach failed for "alice"`).
+ */
+function classifyAndRethrow(err: unknown, contextPrefix: string): never {
+  if (err instanceof ApplicationFailure) throw err;
+  if (isRetryableTemporalError(err)) {
+    // Re-throw the original so the activity retry policy backs off and retries.
+    // Normalise non-Error throwables (extremely rare) into Error form.
+    throw err instanceof Error ? err : new Error(String(err));
+  }
+  throw ApplicationFailure.nonRetryable(
+    `${contextPrefix}: ${err instanceof Error ? err.message : String(err)}`,
+  );
+}
 
 // ── Activity input types ──
 
@@ -448,10 +535,10 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
         log(`Detach signaled for "${targetPlayerId}" (deadline=${deadlineMs}ms)`);
         return { success: true };
       } catch (err) {
-        if (err instanceof ApplicationFailure) throw err;
-        throw ApplicationFailure.nonRetryable(
-          `Detach failed for "${targetPlayerId}": ${err instanceof Error ? err.message : String(err)}`,
-        );
+        // #140: re-throw transient RPC/network errors so the activity retry
+        // policy handles them; permanent cases (validator rejection, workflow
+        // gone, unknown) become `ApplicationFailure.nonRetryable`.
+        classifyAndRethrow(err, `Detach failed for "${targetPlayerId}"`);
       }
     },
 
@@ -490,10 +577,10 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
         }
         return { success: true };
       } catch (err) {
-        if (err instanceof ApplicationFailure) throw err;
-        throw ApplicationFailure.nonRetryable(
-          `Destroy failed for "${targetPlayerId}": ${err instanceof Error ? err.message : String(err)}`,
-        );
+        // #140: transient errors (network, RPC timeout) become retryable;
+        // permanent cases (WorkflowNotFound, validator rejection) stay
+        // non-retryable. Unknown errors default to non-retryable.
+        classifyAndRethrow(err, `Destroy failed for "${targetPlayerId}"`);
       }
     },
 
@@ -530,7 +617,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             try {
               await handle.signal(requestDetachSignal, {
                 reason: 'restart',
-                deadlineMs: 5_000,
+                deadlineMs: DEFAULT_RESTART_DETACH_DEADLINE_MS,
               });
             } catch {
               // Best-effort; force path handles it below.
@@ -573,7 +660,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             host: targetHost,
             adapterId,
             adapterClass,
-            leaseMs: 90_000,
+            leaseMs: DEFAULT_RESTART_LEASE_MS,
           }],
         });
 
@@ -647,10 +734,11 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
         log(`Restart prepared for "${targetPlayerId}" — attachmentId=${token.attachmentId}, spawnEntryId=${spawnEntryId}, host=${targetHost}${fresh ? ` (fresh sessionId=${spawnSessionId})` : ''}`);
         return { success: true };
       } catch (err) {
-        if (err instanceof ApplicationFailure) throw err;
-        throw ApplicationFailure.nonRetryable(
-          `Restart failed for "${targetPlayerId}": ${err instanceof Error ? err.message : String(err)}`,
-        );
+        // #140: the §8.2 restart algorithm fires many RPCs; any of them may
+        // hit a transient network/RPC error. Those get retried. Validator
+        // rejections (e.g. claim race), workflow-gone, and unknown errors
+        // stay permanent to avoid wedging the outbox on a dead target.
+        classifyAndRethrow(err, `Restart failed for "${targetPlayerId}"`);
       }
     },
 

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -65,6 +65,22 @@ export const RESTART_CONTEXT_MESSAGES_MAX = 50;
 export const MAX_DETACH_DEADLINE_MS = 120_000;
 
 /**
+ * Default graceful-detach deadline used by `deliverRestart`'s Step 2
+ * (`requestDetach` before a forced attachment handover). Internal, not
+ * user-controllable — well below `MAX_DETACH_DEADLINE_MS`. Extracted from
+ * a raw `5_000` literal in PR #136 F5 follow-up (#139).
+ */
+export const DEFAULT_RESTART_DETACH_DEADLINE_MS = 5_000;
+
+/**
+ * Default attachment lease (ms) used by `deliverRestart`'s Step 4
+ * (`claimAttachment`). Ninety seconds gives the freshly-spawned adapter
+ * enough runway to boot, renew, and begin heartbeating. Extracted from a
+ * raw `90_000` literal in PR #136 F5 follow-up (#139).
+ */
+export const DEFAULT_RESTART_LEASE_MS = 90_000;
+
+/**
  * Whether a session should be included in a broadcast based on its attachment phase.
  *
  * Option-B mapping (see #176 PR description):

--- a/test/activities.test.ts
+++ b/test/activities.test.ts
@@ -438,6 +438,274 @@ describe('terminateSession', function () {
 //  in test/tools.test.ts cover the §8.2 algorithm directly. `restart` operates
 //  on any non-`gone` phase; encore's `stale`-only variant was retired.)
 
+// ── #140: error classification in deliverDetach / deliverDestroy / deliverRestart ──
+//
+// The three activities added in PR-D originally wrapped every mid-algorithm
+// error as `ApplicationFailure.nonRetryable`, defeating activity-level retry
+// for transient RPC failures. These tests pin the post-#140 behavior:
+//   • Transient (DEADLINE_EXCEEDED, UNAVAILABLE, ECONNRESET, …) → re-thrown
+//     as plain Error so the activity retry policy takes over.
+//   • Permanent (WorkflowNotFound, WorkflowUpdateFailed, unknown) → wrapped
+//     as `ApplicationFailure.nonRetryable` so the outbox stops retrying.
+//
+// Unknown errors default to non-retryable to avoid infinite retry loops on
+// genuinely-permanent failures we haven't catalogued yet.
+
+/** Build an Error-like object with a specific `name` so the classifier sees it. */
+function namedError(name: string, message: string): Error {
+  const e = new Error(message);
+  e.name = name;
+  return e;
+}
+
+describe('deliverDetach — error classification (#140)', function () {
+  /** Baseline metadata so `resolveSession`'s `getMetadata` query matches e1/alice. */
+  const aliceMeta: SessionMetadata = {
+    playerId: 'alice',
+    ensemble: 'e1',
+    hostname: 'h',
+    workDir: '/w',
+    isConductor: false,
+    agentType: 'claude',
+  };
+
+  /**
+   * Build a mock handle that returns valid metadata on `getMetadata` (so
+   * `resolveSession` picks it up) but throws `throwOnAttachmentInfo` on the
+   * `attachmentInfo` query that `deliverDetach` does next. This isolates
+   * the catch-block classifier from the unrelated resolver path.
+   */
+  function handleWithAttachmentInfoThrow(throwOnAttachmentInfo: () => never) {
+    return mockHandle({
+      metadata: aliceMeta,
+      queryFn(name) {
+        if (name === 'attachmentInfo') throwOnAttachmentInfo();
+        if (name === 'getMetadata') return aliceMeta;
+        return undefined;
+      },
+    });
+  }
+
+  it('re-throws plain Error when handle.query hits a transient RPC failure', async function () {
+    const handle = handleWithAttachmentInfoThrow(() => {
+      throw namedError('TransportError', 'UNAVAILABLE: temporal dev server blip');
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverDetach({ ensemble: 'e1', targetPlayerId: 'alice' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    // Retryable path: plain Error, NOT an ApplicationFailure. The activity
+    // retry policy will see a regular failure and back off.
+    expect(caught).to.be.instanceOf(Error);
+    expect(caught).to.not.be.instanceOf(ApplicationFailure);
+    expect((caught as Error).message).to.include('UNAVAILABLE');
+  });
+
+  it('wraps nonRetryable when handle.query hits WorkflowNotFoundError', async function () {
+    const handle = handleWithAttachmentInfoThrow(() => {
+      throw namedError('WorkflowNotFoundError', 'workflow execution already completed');
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverDetach({ ensemble: 'e1', targetPlayerId: 'alice' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(ApplicationFailure);
+    expect((caught as ApplicationFailure).nonRetryable).to.equal(true);
+    expect((caught as Error).message).to.include('Detach failed');
+  });
+
+  it('wraps nonRetryable for unknown errors (conservative default)', async function () {
+    const handle = handleWithAttachmentInfoThrow(() => {
+      throw namedError('ExoticCustomError', 'something weird happened downstream');
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverDetach({ ensemble: 'e1', targetPlayerId: 'alice' });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(ApplicationFailure);
+    expect((caught as ApplicationFailure).nonRetryable).to.equal(true);
+  });
+});
+
+describe('deliverDestroy — error classification (#140)', function () {
+  it('re-throws plain Error when executeUpdate hits a transient RPC failure', async function () {
+    const handle = mockHandle({
+      metadata: { playerId: 'bob', ensemble: 'e1' },
+      updateFn(name) {
+        if (name === 'destroy') {
+          throw namedError('TransportError', 'DEADLINE_EXCEEDED');
+        }
+        return undefined;
+      },
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverDestroy({
+        ensemble: 'e1',
+        targetPlayerId: 'bob',
+        terminatedBy: 'alice',
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(Error);
+    expect(caught).to.not.be.instanceOf(ApplicationFailure);
+    expect((caught as Error).message).to.include('DEADLINE_EXCEEDED');
+  });
+
+  it('wraps nonRetryable when executeUpdate hits WorkflowUpdateFailedError', async function () {
+    // The destroy update's validator rejected — retry won't change its mind.
+    const handle = mockHandle({
+      metadata: { playerId: 'bob', ensemble: 'e1' },
+      updateFn(name) {
+        if (name === 'destroy') {
+          throw namedError('WorkflowUpdateFailedError', 'validator rejected: WorkflowGone');
+        }
+        return undefined;
+      },
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverDestroy({
+        ensemble: 'e1',
+        targetPlayerId: 'bob',
+        terminatedBy: 'alice',
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(ApplicationFailure);
+    expect((caught as ApplicationFailure).nonRetryable).to.equal(true);
+    expect((caught as Error).message).to.include('Destroy failed');
+  });
+});
+
+describe('deliverRestart — error classification (#140)', function () {
+  const attachedPhase = {
+    phase: 'attached' as const,
+    inFlightCount: 0,
+    currentAttachment: { attachmentId: 'a1', hostname: 'host', adapterId: 'claude-code' },
+  };
+
+  it('re-throws plain Error when mid-algorithm claimAttachment hits ECONNRESET', async function () {
+    // Phase is 'detached' so we skip the reap branch and go straight to
+    // claimAttachment — isolates the throw site cleanly.
+    const handle = mockHandle({
+      metadata: { playerId: 'carol', ensemble: 'e1', agentType: 'claude' },
+      attachmentInfo: { phase: 'detached', inFlightCount: 0 },
+      updateFn(name) {
+        if (name === 'claimAttachment') {
+          throw namedError('TransportError', 'ECONNRESET: temporal server flap');
+        }
+        return undefined;
+      },
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverRestart({
+        ensemble: 'e1',
+        targetPlayerId: 'carol',
+        invokerPlayerId: 'alice',
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(Error);
+    expect(caught).to.not.be.instanceOf(ApplicationFailure);
+    expect((caught as Error).message).to.include('ECONNRESET');
+  });
+
+  it('wraps nonRetryable when forceDetach hits WorkflowUpdateFailedError', async function () {
+    // Phase attached + force=true → restart tries forceDetach. Validator
+    // rejection (e.g. attachmentId mismatch after a race) is permanent.
+    const handle = mockHandle({
+      metadata: { playerId: 'dave', ensemble: 'e1', agentType: 'claude' },
+      attachmentInfo: attachedPhase,
+      updateFn(name) {
+        if (name === 'forceDetach') {
+          throw namedError('WorkflowUpdateFailedError', 'attachmentId mismatch');
+        }
+        return undefined;
+      },
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverRestart({
+        ensemble: 'e1',
+        targetPlayerId: 'dave',
+        invokerPlayerId: 'alice',
+        force: true,
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(ApplicationFailure);
+    expect((caught as ApplicationFailure).nonRetryable).to.equal(true);
+    expect((caught as Error).message).to.include('Restart failed');
+  });
+
+  it('preserves existing nonRetryable for phase=gone (regression guard)', async function () {
+    // The explicit "was destroyed" throw inside the try block is an
+    // ApplicationFailure.nonRetryable and must pass through the new catch
+    // untouched — not re-wrapped, not re-classified.
+    const handle = mockHandle({
+      metadata: { playerId: 'ed', ensemble: 'e1' },
+      attachmentInfo: { phase: 'gone', inFlightCount: 0 },
+    });
+    const client = mockClient([handle]);
+    const activities = createOutboxActivities(client as any, mockConfig());
+
+    let caught: unknown;
+    try {
+      await activities.deliverRestart({
+        ensemble: 'e1',
+        targetPlayerId: 'ed',
+        invokerPlayerId: 'alice',
+      });
+      expect.fail('should have thrown');
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).to.be.instanceOf(ApplicationFailure);
+    expect((caught as ApplicationFailure).nonRetryable).to.equal(true);
+    expect((caught as Error).message).to.include('was destroyed');
+  });
+});
+
 // ── computeNextCronFire ──
 
 describe('computeNextCronFire', function () {


### PR DESCRIPTION
## Summary

Bundled hardening pass for the three outbox delivery activities introduced in PR-D. Closes [#139](https://github.com/vinceblank/claude-tempo/issues/139) and [#140](https://github.com/vinceblank/claude-tempo/issues/140).

### #139 — constants extraction (mechanical)

Two timeout literals in `deliverRestart` were left inline by the B3 PR-D move:
- `deadlineMs: 5_000` (Step 2 `requestDetach`)
- `leaseMs: 90_000` (Step 4 `claimAttachment`)

Extracted to `src/utils/validation.ts` as `DEFAULT_RESTART_DETACH_DEADLINE_MS` and `DEFAULT_RESTART_LEASE_MS`. No behavioral change. No `MAX_DETACH_DEADLINE_MS` validator call added — these constants are internal and fixed at compile time, well under the 120s cap, so a runtime check would be defense-in-depth with no payoff. JSDoc cross-references the two constants.

### #140 — error classification

The three PR-D activities (`deliverDetach`, `deliverDestroy`, `deliverRestart`) previously converted **every** mid-algorithm exception to `ApplicationFailure.nonRetryable`, which defeats the activity retry policy for transient RPC failures and fights the whole durability argument for routing restart through the outbox.

**New helpers** (module-local in `src/activities/outbox.ts`):
- `isRetryableTemporalError(err)` — name/message sniffing (mirrors the `isTerminalErr` pattern in `src/adapters/base.ts` because the Temporal Node SDK surfaces slightly different error shapes across `@temporalio/client` / gRPC / `WorkflowUpdateFailedError` wrappers).
- `classifyAndRethrow(err, contextPrefix)` — the three activities' catch-all tail, centralising the ApplicationFailure-passthrough / retryable-rethrow / non-retryable-wrap branch.

**Classification:**

| Class | Signatures | Behavior |
|---|---|---|
| **Permanent** (first check) | `WorkflowNotFound*`, `WorkflowExecutionAlreadyCompleted`, `WorkflowUpdateFailed*`, `WorkflowGone`, "workflow execution already completed" | `ApplicationFailure.nonRetryable` |
| **Transient** | `TransportError`, `TimeoutError`, `DEADLINE_EXCEEDED`, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`, `CANCELLED`, `ECONNRESET`, `ECONNREFUSED`, `ETIMEDOUT`, `ENOTFOUND`, `EAI_AGAIN` | Re-throw original `Error` → activity retry policy retries |
| **Unknown** (default) | Anything else | `ApplicationFailure.nonRetryable` (conservative — avoids infinite retry loops) |

Typed `ApplicationFailure.nonRetryable` throws *inside* each activity body (e.g. "no session found", "phase=gone", "use force=true") pass through the catch unchanged.

### Audit notes & deliberate scope

- **`WorkflowUpdateFailedError` → permanent.** A validator rejection (e.g. `WorkflowGone` thrown from the `claimAttachment` validator on a destroyed session) won't change its mind on retry.
- **`AttachmentConflict` during force=true → permanent.** TOCTOU loss on a concurrent claim. The restart tool caller can re-attempt from the tool layer if desired.
- **Unknown errors → permanent.** Over-classifying as retryable is the dangerous direction — infinite loops on permanent failures. Whitelist approach per the issue body's guidance.
- **Pre-existing activities not touched** per conductor scope-gate. `deliverCue`, `deliverReport`, `terminateSession`, `startRecruitedSession`, `releasePlayer`, `spawnProcess` all use the same catch-all-nonRetryable pattern. **Recommend a follow-up PR** applying the same classifier across them, or simply re-using `classifyAndRethrow` at their tail. Not in this PR's scope.

### Tests (`test/activities.test.ts`)

8 new Mocha cases using the existing `mockHandle` / `mockClient` unit-test pattern:
- `deliverDetach`: transient → plain Error; WorkflowNotFound → nonRetryable; unknown → nonRetryable (conservative default).
- `deliverDestroy`: transient → plain Error; WorkflowUpdateFailed → nonRetryable.
- `deliverRestart`: mid-algorithm ECONNRESET → plain Error; forceDetach WorkflowUpdateFailed → nonRetryable; phase=gone regression guard (typed ApplicationFailure passes through).

## Test plan

- [x] `npm run build` — clean
- [x] `npm run build:test && mocha dist-test/test/activities.test.js` — 40/40 pass (includes 8 new)
- [x] Full `mocha` suite — 776 passing (pre-change baseline preserved)
- [ ] QA: sanity-check classifier signatures against real-world failure modes from adapter reconnect logs (#201 / #226 era)
- [ ] QA: confirm `WorkflowUpdateFailedError` instance name matches what Temporal 1.15 actually emits (tested against mocked name; real SDK shape should be verified in a live failure scenario)

## Follow-ups (out of scope for this PR)

- Apply `classifyAndRethrow` to pre-existing outbox activities (`deliverCue`, `deliverReport`, `terminateSession`, `startRecruitedSession`, `releasePlayer`, `spawnProcess`).
- Consider reusing the classifier in `src/adapters/base.ts` `isTerminalErr` — they have overlapping concerns but different call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)