### PR TITLE
fix(destroy): terminate process on detached destroy (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`destroy` now terminates orphaned processes on `phase=detached` sessions**
+  (#227). Before this, the destroy handler's hard-terminate branch was gated on
+  `if (currentAttachment)` — correct for `phase=attached` (the original #164
+  repro) but silently skipped when `phase=detached` (currentAttachment had been
+  nulled by the lease-reap path). Combined with the #226 CAN-cascade that
+  commonly left entire ensembles detached before teardown, every destroy
+  leaked its `claude.exe` + terminal tab; reliable repro during beta.2
+  teardown where 7/7 player workflows destroyed successfully but 7/7 processes
+  survived. The fix expands the guard to fire `hardTerminateAttachment`
+  whenever a host is known, pulling from the same provenance chain used
+  elsewhere (`currentAttachment.hostname` → `lastAdapterMeta.hostname` →
+  `preferredHost` → `input.metadata.hostname`). `hardTerminateAttachment`
+  itself is unchanged — its existing command-line match (`-n <playerName>`
+  AND `--remote-control-session-name-prefix <ensemble>`) plus image-name
+  PID-reuse guard already gives the equivalent of a stored-PID +
+  attach-time validation without any wire-protocol change. Best-effort, 5s
+  timeout, log-and-continue on failure. Regression-guarded by two new
+  integration tests in `test/destroy.test.ts` (one each for the attached
+  and detached paths) and an edge-case guard for the never-attached path.
+  Cross-reference: #159 (earlier same-family Windows orphan bug), #164
+  (initial attached-path hardTerminate wiring), #226 (adapter CAN-reconnect
+  bug that exposed this cascade in the wild).
+
 ### Changed
 
 - **Extract CAN-boundary attachment-extension math into a pure function** (#127).

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -561,26 +561,47 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
     // soon as destroyRequested=true, before the activity has a chance to dispatch).
     // Best-effort: 5s timeout, log-and-continue on failure. `destroyRequested` flips
     // AFTER the activity so the main loop stays alive to dispatch it.
-    if (currentAttachment) {
-      const killHost = currentAttachment.hostname || input.metadata.hostname;
-      if (killHost) {
-        try {
-          const killResult: HardTerminateResult = await getHardTerminateProxyForDestroy(killHost)({
-            ensemble: input.metadata.ensemble,
-            playerName: input.metadata.playerId,
-            agent: (input.metadata.agentType ?? 'claude') as AgentType,
-            workDir: input.metadata.workDir,
-          });
-          workflowLog.info(
-            `destroy hard-terminate on ${killHost}: strategy=${killResult.strategy}, ` +
-            `killedPids=[${killResult.killedPids.join(',')}]`,
-          );
-        } catch (err) {
-          workflowLog.warn(
-            `destroy hard-terminate failed on ${killHost} (continuing, best-effort): ` +
-            `${err instanceof Error ? err.message : String(err)}`,
-          );
-        }
+    //
+    // #227: the original (#164) guard was `if (currentAttachment)` — correct for the
+    // `phase=attached` case but silently skipped the kill when `phase=detached`, leaking
+    // `claude.exe` + terminal tab when a destroy ran on a session whose lease had been
+    // reaped. The ensemble cascade exposed by #226/#201 made this a reliable orphan
+    // generator: destroy → workflow COMPLETES, process survives. Fix: pick the best
+    // host we have from workflow state and fire the kill whenever *any* host is known.
+    //
+    // `hardTerminateAttachment` is already safe to run speculatively — it does image-
+    // name PID-reuse guards + command-line matching on `-n <playerName>` AND
+    // `--remote-control-session-name-prefix <ensemble>`, so a stale state that no
+    // longer corresponds to a live process returns `strategy: 'none'` with a clean
+    // log line. No new PID / attach-time wire-protocol fields needed.
+    //
+    // Host-pick priority (aligns with the reap path's provenance tracking):
+    //   1. `currentAttachment.hostname`  — `phase=attached` / `processing` / `awaiting`
+    //   2. `lastAdapterMeta.hostname`    — `phase=detached` (set by forceDetach / reap)
+    //   3. `preferredHost`               — post-CAN restore before any adapter landed
+    //   4. `input.metadata.hostname`     — recruit-time fallback (booting path)
+    const killHost =
+      currentAttachment?.hostname ??
+      lastAdapterMeta?.hostname ??
+      preferredHost ??
+      input.metadata.hostname;
+    if (killHost) {
+      try {
+        const killResult: HardTerminateResult = await getHardTerminateProxyForDestroy(killHost)({
+          ensemble: input.metadata.ensemble,
+          playerName: input.metadata.playerId,
+          agent: (input.metadata.agentType ?? 'claude') as AgentType,
+          workDir: input.metadata.workDir,
+        });
+        workflowLog.info(
+          `destroy hard-terminate on ${killHost} (phase=${phase}): strategy=${killResult.strategy}, ` +
+          `killedPids=[${killResult.killedPids.join(',')}]`,
+        );
+      } catch (err) {
+        workflowLog.warn(
+          `destroy hard-terminate failed on ${killHost} (continuing, best-effort): ` +
+          `${err instanceof Error ? err.message : String(err)}`,
+        );
       }
     }
     // Flip destroyRequested AFTER the kill so the main loop stays alive for activity

--- a/test/destroy.test.ts
+++ b/test/destroy.test.ts
@@ -1,5 +1,8 @@
 import { expect } from 'chai';
+import { Worker } from '@temporalio/worker';
 import { WorkflowIdConflictPolicy } from '@temporalio/client';
+import * as path from 'path';
+import * as fs from 'fs';
 import {
   setupTestEnv,
   teardownTestEnv,
@@ -11,6 +14,7 @@ import {
   attachmentInfoQuery,
   processingStartUpdate,
   getClient,
+  getNativeConnection,
   TASK_QUEUE,
 } from './helpers';
 
@@ -216,6 +220,229 @@ describe('destroy verb — fixes #164 (destroy with live attachment)', function 
       expect(anyFulfilled, 'at least one of forceDetach/destroy must succeed').to.equal(true);
 
       // Workflow must complete (destroy wins).
+      await handle.result();
+      expect(await handle.query(isDestroyedQuery)).to.equal(true);
+    });
+  });
+});
+
+// #227: destroy on a `phase=detached` session used to skip `hardTerminateAttachment`
+// (the `if (currentAttachment)` guard short-circuited because detached → null), leaking
+// `claude.exe` processes + terminal tabs. Exposed in the wild by the #226 CAN-cascade
+// repro during beta.2 teardown. This suite pins the fix: destroy now reads the best
+// host it has (currentAttachment.hostname → lastAdapterMeta.hostname → preferredHost →
+// input.metadata.hostname) and fires the activity whenever *any* host is known, passing
+// the same ensemble/player/agent payload as the attached path.
+//
+// We use a custom capturing `hardTerminateAttachment` stub (instead of the shared
+// `withWorker` stub) so we can assert the invocation happened, with the right args,
+// regardless of phase.
+describe('destroy verb — fixes #227 (orphan claude.exe on detached destroy)', function () {
+  before(async function () {
+    this.timeout(60_000);
+    await setupTestEnv();
+  });
+
+  after(async function () {
+    await teardownTestEnv();
+  });
+
+  /**
+   * Locate the pre-built workflow bundle. Resolves up from __dirname until we find
+   * `workflow-bundle.js` at the repo root. Mirrors `test/helpers.ts`'s private helper;
+   * inlined here to avoid widening the helpers export surface for one file.
+   */
+  function findWorkflowBundle(): string {
+    let dir = __dirname;
+    for (let i = 0; i < 5; i++) {
+      const candidate = path.join(dir, 'workflow-bundle.js');
+      if (fs.existsSync(candidate)) return candidate;
+      dir = path.dirname(dir);
+    }
+    throw new Error('workflow-bundle.js not found. Run `npm run build`.');
+  }
+
+  /**
+   * Spin up two workers (main task queue + per-host) with a hardTerminateAttachment
+   * stub that pushes every invocation into `captured`. Mirrors the structure of
+   * `withWorker` in helpers.ts but inlined so the capture is test-local.
+   */
+  async function withCapturingHardTerminate<T>(
+    captured: Array<{ host: string; ensemble: string; playerName: string; agent: string; workDir: string }>,
+    hostname: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const connection = getNativeConnection();
+    const bundle = { code: fs.readFileSync(findWorkflowBundle(), 'utf-8') };
+    const hostTaskQueue = `claude-tempo-${hostname}`;
+
+    const captureStub = async (input: {
+      ensemble: string;
+      playerName: string;
+      agent: string;
+      workDir: string;
+    }) => {
+      captured.push({ host: hostname, ...input });
+      return { killedPids: [], strategy: 'none' as const, notes: ['capture stub'] };
+    };
+
+    const mainWorker = await Worker.create({
+      connection,
+      taskQueue: TASK_QUEUE,
+      workflowBundle: bundle,
+    });
+    const hostWorker = await Worker.create({
+      connection,
+      taskQueue: hostTaskQueue,
+      activities: { hardTerminateAttachment: captureStub },
+    });
+
+    return mainWorker.runUntil(async () => {
+      const hostPromise = hostWorker.run();
+      try {
+        return await fn();
+      } finally {
+        hostWorker.shutdown();
+        await hostPromise.catch(() => { /* cleanup */ });
+      }
+    });
+  }
+
+  it('fires hardTerminateAttachment on destroy when phase=detached (core #227 repro)', async function () {
+    this.timeout(20_000);
+    const captured: Array<{ host: string; ensemble: string; playerName: string; agent: string; workDir: string }> = [];
+    const ensemble = `destroy-227-detached-${Date.now()}`;
+    const playerName = 'orphan-alpha';
+    const hostname = 'test-host';
+
+    await withCapturingHardTerminate(captured, hostname, async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({
+          playerId: playerName,
+          ensemble,
+          hostname,
+          workDir: '/tmp/orphan-alpha',
+          agentType: 'claude',
+        }),
+      });
+
+      // Bring the session through its full lifecycle to a true `phase=detached`
+      // state — this is exactly the repro path from the #227 issue body
+      // (adapter had attached and then its lease was reaped).
+      const token = await handle.executeUpdate(
+        (await import('../src/workflows/signals')).claimAttachmentUpdate,
+        { args: [{ host: hostname, adapterId: 'claude-code', adapterClass: 'interactive', leaseMs: 30_000 }] },
+      );
+      await handle.executeUpdate(
+        (await import('../src/workflows/signals')).forceDetachUpdate,
+        {
+          args: [{
+            reason: 'heartbeat-timeout' as const,
+            expectedAttachmentId: token.attachmentId,
+            gracePeriodMs: 0,
+          }],
+        },
+      );
+
+      // Confirm the workflow is in the bug-exposing state: phase=detached,
+      // currentAttachment=null, but lastAdapterMeta.hostname populated by the reap.
+      const preDestroy = await handle.query(attachmentInfoQuery);
+      expect(preDestroy.phase).to.equal('detached');
+      expect(preDestroy.currentAttachment).to.be.undefined;
+
+      // Pre-#227 this destroy would return success, the workflow would complete,
+      // but hardTerminateAttachment would never have been dispatched.
+      await handle.executeUpdate(destroyUpdate, { args: [{ reason: '#227 repro' }] });
+
+      // Post-#227: the kill activity was dispatched with the lastAdapterMeta host.
+      expect(captured.length, 'hardTerminate must be invoked on detached destroy').to.be.at.least(1);
+      const invocation = captured[0];
+      expect(invocation.host).to.equal(hostname);
+      expect(invocation.ensemble).to.equal(ensemble);
+      expect(invocation.playerName).to.equal(playerName);
+      expect(invocation.agent).to.equal('claude');
+      expect(invocation.workDir).to.equal('/tmp/orphan-alpha');
+
+      await handle.result();
+      expect(await handle.query(isDestroyedQuery)).to.equal(true);
+    });
+  });
+
+  it('still fires hardTerminateAttachment on destroy when phase=attached (regression guard on the #164 path)', async function () {
+    this.timeout(20_000);
+    const captured: Array<{ host: string; ensemble: string; playerName: string; agent: string; workDir: string }> = [];
+    const ensemble = `destroy-227-attached-${Date.now()}`;
+    const playerName = 'orphan-beta';
+    const hostname = 'test-host';
+
+    await withCapturingHardTerminate(captured, hostname, async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({
+          playerId: playerName,
+          ensemble,
+          hostname,
+          workDir: '/tmp/orphan-beta',
+          agentType: 'claude',
+        }),
+      });
+
+      await handle.executeUpdate(
+        (await import('../src/workflows/signals')).claimAttachmentUpdate,
+        { args: [{ host: hostname, adapterId: 'claude-code', adapterClass: 'interactive', leaseMs: 30_000 }] },
+      );
+
+      // phase=attached → #164 path; previously worked, must still work.
+      await handle.executeUpdate(destroyUpdate, { args: [{ reason: '#164 regression guard' }] });
+
+      expect(captured.length, 'hardTerminate must still fire on attached destroy').to.be.at.least(1);
+      expect(captured[0].host).to.equal(hostname);
+      expect(captured[0].ensemble).to.equal(ensemble);
+      expect(captured[0].playerName).to.equal(playerName);
+
+      await handle.result();
+    });
+  });
+
+  it('skips hardTerminate cleanly when there is no host to target (phase=booting)', async function () {
+    // Edge case: a session that was never attached AND has no preferred host.
+    // We force this by constructing metadata with an empty hostname. The destroy
+    // handler must NOT dispatch the activity (no host to target), but MUST still
+    // complete the workflow. No orphan can exist without a spawn, so this is
+    // correctness: the fix should skip, not crash.
+    this.timeout(15_000);
+    const captured: Array<{ host: string; ensemble: string; playerName: string; agent: string; workDir: string }> = [];
+    const ensemble = `destroy-227-nohost-${Date.now()}`;
+
+    // Note: we can't actually set hostname='' via playerMetadata() defaults —
+    // the helper always sets 'test-host'. We mirror withCapturingHardTerminate's
+    // structure but use a non-existent host so if the activity WERE dispatched
+    // it would hang for the whole retry window. The 10s test timeout catches
+    // such a regression. The expected behavior is captured.length === 0.
+    await withCapturingHardTerminate(captured, 'test-host', async () => {
+      const handle = await startSession({
+        metadata: playerMetadata({
+          playerId: 'never-attached',
+          ensemble,
+          hostname: 'test-host', // needed for recruit-time fallback
+          workDir: '/tmp/never-attached',
+          agentType: 'claude',
+        }),
+      });
+
+      // No claimAttachment, no forceDetach → phase=booting, no lastAdapterMeta,
+      // no preferredHost beyond metadata.hostname. With our fix, `killHost`
+      // falls through to input.metadata.hostname='test-host' and we DO dispatch
+      // (the activity itself returns strategy='none' for a non-existent process,
+      // which is the correct safe behavior — see issue #227 §Proposed fix).
+      await handle.executeUpdate(destroyUpdate, { args: [{ reason: 'no-attach destroy' }] });
+
+      // metadata.hostname fallback means the activity IS dispatched — but with
+      // strategy='none' the process search finds nothing. Either outcome here is
+      // acceptable as long as the workflow completes cleanly:
+      //   - 1+ invocation with strategy='none' (current fix behavior)
+      //   - 0 invocations (if we tightened the guard in a future PR)
+      // We assert just on workflow completion — the "always dispatch when a host
+      // exists" property is already pinned by the detached/attached tests above.
       await handle.result();
       expect(await handle.query(isDestroyedQuery)).to.equal(true);
     });

--- a/test/helpers.ts
+++ b/test/helpers.ts
@@ -223,6 +223,20 @@ export function getClient(): Client {
   return testEnv.client;
 }
 
+/**
+ * Get the shared `NativeConnection` for `Worker.create(...)`. Tests that need
+ * a custom Worker topology — for example, a per-host worker with a capturing
+ * `hardTerminateAttachment` stub (#227) — use this to build their own workers
+ * instead of going through `withWorker` / `withWorkerAndRecruitActivities`.
+ * Call `setupTestEnv()` first.
+ */
+export function getNativeConnection(): TestWorkflowEnvironment['nativeConnection'] {
+  if (!testEnv) {
+    throw new Error('getNativeConnection() called before setupTestEnv() — make sure your before() hook awaits setupTestEnv()');
+  }
+  return testEnv.nativeConnection;
+}
+
 /** Internal — resolves the current test env; for helpers only. */
 function requireTestEnv(): TestWorkflowEnvironment {
   if (!testEnv) {


### PR DESCRIPTION
## Summary

Destroy on a session with `phase === 'detached'` used to leak `claude.exe` + its terminal tab — the workflow terminated cleanly but `hardTerminateAttachment` was silently skipped because the guard `if (currentAttachment)` short-circuited (the reap path nulls `currentAttachment` before phase flips to detached). The #226 CAN-cascade exposed this reliably during beta.2 ensemble teardown: all 7 player workflows destroyed successfully, all 7 processes survived.

**Fix** (5-ish-line guard flip): pick the best host we know from workflow state and fire `hardTerminateAttachment` whenever any host is known.

```text
currentAttachment.hostname  // phase=attached / processing / awaiting
→ lastAdapterMeta.hostname  // phase=detached (set by forceDetach/reap)
→ preferredHost             // post-CAN restore before any adapter landed
→ input.metadata.hostname   // recruit-time fallback (booting path)
```

Fixes #227. Cross-references: #159 (earlier same-family Windows orphan), #164 (initial attached-path hardTerminate wiring), #226 (the adapter CAN-reconnect bug that exposed this cascade).

## Scope confirmation (from the brief)

- **No wire-protocol change.** No new signal payloads, no new workflow state fields, no changes to `claimAttachment`. The existing command-line match (`-n <playerName>` AND `--remote-control-session-name-prefix <ensemble>`) plus image-name PID-reuse guard in `hardTerminateAttachment` already provide equivalent safety to the "stored PID + attach-time" sketch in issue #227's Proposed fix direction — without touching any protocol.
- **`hardTerminateAttachment` internals untouched.** The fix is entirely in the workflow destroy handler; the activity is called the same way, just from one more code path.
- **Didn't bundle #138 (attachment-info CLI) or #151 (cross-host orphan handoff).** Both out of scope per brief.
- **No new fields added to workflow state.** Existing `lastAdapterMeta.hostname` is populated by the reap path; existing `preferredHost` is populated post-CAN; existing `input.metadata.hostname` is populated at recruit — all already wired.

## Test plan

- [x] Three new integration tests in `test/destroy.test.ts` under `fixes #227 (orphan claude.exe on detached destroy)`:
  1. **Core repro**: start session → claim → forceDetach (→ phase=detached, currentAttachment=null, lastAdapterMeta populated) → destroy → assert `hardTerminateAttachment` was invoked with `{ host: 'test-host', ensemble, playerName, agent: 'claude', workDir }`.
  2. **Attached-path regression guard**: same flow minus forceDetach (phase=attached at destroy time) — asserts the activity still fires as it did pre-#227 (this pins the #164 behavior).
  3. **Never-attached edge case**: destroy on a session that never claimed — asserts the workflow still completes cleanly. The fallback chain means `input.metadata.hostname` is still used, so the activity is dispatched and returns `strategy: 'none'` from the process search; acceptable behavior (no crash, no hang).
- [x] `npm run build` clean (workflow bundle rebuilt).
- [x] Full Mocha suite: **780 passing, 0 failing, 22 pending** (was 777; +3 new).
- [x] Added a small `getNativeConnection()` export to `test/helpers.ts` so the custom capturing-worker topology can be constructed inline — minimal surface widening, one line that mirrors the existing `getClient()` pattern. Flagged as a small helpers.ts touch explicitly (scope creep-adjacent but needed to write the test — happy to split to a prep PR if reviewer prefers strict scope).

## Intentional small deviations from the brief

1. **Never-attached case with metadata.hostname fallback still dispatches the activity.** Brief hinted at "skipped with log reason" for that path; I chose to let the activity fire because a non-existent process produces `strategy: 'none'` with a clean log line anyway, and keeping a single dispatch path is simpler than adding a "skip early" branch that's only logically different when no host exists at all (which the fallback chain prevents). The workflow still completes cleanly in all cases — the test pins that invariant.
2. **Log line now includes `phase=<phase>`** (e.g. `destroy hard-terminate on test-host (phase=detached): strategy=none, killedPids=[]`). Aids post-incident triage — tells you at a glance whether the destroy was on the attached, detached, or booting path. One-line addition in an already-present log statement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)