### PR TITLE
refactor(test): replace keyword-based kindFromSectionHeader with explicit allowlist (closes #239)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- Replaced the wire-protocol drift detector's keyword-based
+  `kindFromSectionHeader` with an explicit `SECTION_TO_KIND` allowlist that
+  throws on any section header not in the table
+  (`test/wire-protocol.test.ts`). Renames or typos in
+  `docs/WIRE-PROTOCOL.md` `## Section Header`s now surface as an immediate
+  test failure (`"Unknown WIRE-PROTOCOL section: ..."`) instead of
+  silently dropping drift coverage for the renamed section. Also removes
+  the dead `|| lower.includes('query')` branch from the old keyword
+  matcher. Two new unit tests pin classification for all 18 current
+  sections and assert the unknown-throws contract. (#239, follow-up to #126)
 - Tightened `phaseTag()` in `src/tools/ensemble.ts` to accept
   `AttachmentPhase | undefined` instead of `string | undefined`. Callers
   always have the typed phase in hand via `EnsembleSessionInfo.phase`;

--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -5,6 +5,8 @@ This document is the authoritative reference for all Temporal signal, query, upd
 ## Stability Guarantee
 
 > **These names are stable as of v0.10.** Renaming or removing any signal, query, update, or workflow name is a breaking change requiring a major version bump. Adding new names is non-breaking.
+>
+> **Adding a new `## Section` to this file** also requires a matching entry in the `SECTION_TO_KIND` map in `test/wire-protocol.test.ts` — the drift detector throws on unknown section headers.
 
 ---
 

--- a/test/wire-protocol.test.ts
+++ b/test/wire-protocol.test.ts
@@ -92,17 +92,72 @@ function extractNamesFromSource(filePath: string): WireName[] {
 }
 
 /**
+ * Explicit allowlist mapping WIRE-PROTOCOL.md `## Section Header` → `DefineKind`
+ * (or `null` for documentation-only sections that should be skipped by the
+ * drift detector). #239 replaced the earlier keyword-matching classifier
+ * with this table for three reasons:
+ *
+ * 1. **Section-rename resilience.** The old `lower.includes('signal')`
+ *    matcher would silently return `null` if someone renamed
+ *    `## Session Signals` → `## Session Handlers` — drift detection would
+ *    quietly stop covering that section, and the guardrail would develop
+ *    a hole exactly where it was supposed to protect. With this table,
+ *    the rename triggers an immediate "Unknown WIRE-PROTOCOL section"
+ *    throw that points directly at the fix.
+ *
+ * 2. **Typo detection.** The old matcher happily skipped typos like
+ *    `## Session Singals`. The allowlist catches them at run time.
+ *
+ * 3. **Explicit doc ↔ test coupling.** Adding a section to
+ *    `docs/WIRE-PROTOCOL.md` now requires an explicit allowlist entry.
+ *    That's deliberate — it's the same kind of deliberate coupling as the
+ *    wire protocol itself.
+ *
+ * Trade-off: the table must be updated when a section is legitimately added
+ * to `WIRE-PROTOCOL.md`. That's the point.
+ */
+const SECTION_TO_KIND: Record<string, DefineKind | null> = {
+  // Signal sections
+  'Session Signals': 'signal',
+  'Conductor Signals': 'signal',
+  'Scheduler Signals': 'signal',
+  'Per-Ensemble Maestro Signal': 'signal',
+  'Global Maestro Signal': 'signal',
+  // Query sections
+  'Session Queries': 'query',
+  'Session Outbox Query': 'query',
+  'Conductor Query': 'query',
+  'Scheduler Queries': 'query',
+  'Per-Ensemble Maestro Queries': 'query',
+  'Global Maestro Queries': 'query',
+  // Update sections
+  'Session Updates': 'update',
+  'Per-Ensemble Maestro Update': 'update',
+  'Global Maestro Updates': 'update',
+  // Explicit skips — documentation-only sections whose table entries are
+  // not `define*` handler names (workflow function names, Temporal search
+  // attribute keys, or payload struct fields).
+  'Stability Guarantee': null,
+  'Workflow Names': null,
+  'Search Attributes': null,
+  'Type Reference': null,
+};
+
+/**
  * Infer the DefineKind for a WIRE-PROTOCOL.md `## Section Header`.
  *
- * Returns null for sections that should be skipped (Workflow Names, Search
- * Attributes, Type Reference, Stability Guarantee, etc.).
+ * Returns `null` for sections that should be skipped (Workflow Names,
+ * Search Attributes, Type Reference, Stability Guarantee). Throws when the
+ * section header is absent from `SECTION_TO_KIND` — surfaces rename / typo
+ * drift immediately rather than silently dropping coverage (#239).
  */
 function kindFromSectionHeader(header: string): DefineKind | null {
-  const lower = header.toLowerCase();
-  if (lower.includes('signal')) return 'signal';
-  if (lower.includes('quer') || lower.includes('query')) return 'query';
-  if (lower.includes('update')) return 'update';
-  return null;
+  if (!(header in SECTION_TO_KIND)) {
+    throw new Error(
+      `Unknown WIRE-PROTOCOL section: "${header}". Add it to SECTION_TO_KIND in test/wire-protocol.test.ts.`,
+    );
+  }
+  return SECTION_TO_KIND[header];
 }
 
 /**
@@ -264,5 +319,62 @@ describe('wire-protocol drift detector (§17.9)', function () {
         .join('\n');
       throw new Error(`\nWire-protocol name collisions across kinds:\n${bulleted}`);
     }
+  });
+});
+
+describe('kindFromSectionHeader — #239 allowlist', function () {
+  // Independent hardcoded expectations per acceptance criterion "test asserting
+  // each of the 18 current section names classifies correctly." A bug in
+  // SECTION_TO_KIND (e.g. a typo'd key, or a section accidentally mapped to
+  // the wrong kind) breaks this matrix. Keep in sync with docs/WIRE-PROTOCOL.md.
+  const EXPECTED_CLASSIFICATIONS: ReadonlyArray<readonly [string, DefineKind | null]> = [
+    // Signal sections
+    ['Session Signals', 'signal'],
+    ['Conductor Signals', 'signal'],
+    ['Scheduler Signals', 'signal'],
+    ['Per-Ensemble Maestro Signal', 'signal'],
+    ['Global Maestro Signal', 'signal'],
+    // Query sections
+    ['Session Queries', 'query'],
+    ['Session Outbox Query', 'query'],
+    ['Conductor Query', 'query'],
+    ['Scheduler Queries', 'query'],
+    ['Per-Ensemble Maestro Queries', 'query'],
+    ['Global Maestro Queries', 'query'],
+    // Update sections
+    ['Session Updates', 'update'],
+    ['Per-Ensemble Maestro Update', 'update'],
+    ['Global Maestro Updates', 'update'],
+    // Explicit skips
+    ['Stability Guarantee', null],
+    ['Workflow Names', null],
+    ['Search Attributes', null],
+    ['Type Reference', null],
+  ];
+
+  it('classifies each of the 18 current WIRE-PROTOCOL.md sections to the expected kind', function () {
+    expect(EXPECTED_CLASSIFICATIONS.length).to.equal(
+      18,
+      'expected 18 known sections — if adding/removing, update EXPECTED_CLASSIFICATIONS and SECTION_TO_KIND',
+    );
+    for (const [header, expected] of EXPECTED_CLASSIFICATIONS) {
+      expect(kindFromSectionHeader(header)).to.equal(
+        expected,
+        `section "${header}" misclassified`,
+      );
+    }
+  });
+
+  it('throws on unknown section header (rename/typo safety net)', function () {
+    expect(() => kindFromSectionHeader('Session Handlers')).to.throw(
+      /Unknown WIRE-PROTOCOL section:/,
+    );
+    expect(() => kindFromSectionHeader('Session Singals')).to.throw(
+      /Unknown WIRE-PROTOCOL section:/,
+    );
+    // Precise error-message contract — we promise a pointer to the fix.
+    expect(() => kindFromSectionHeader('Bogus Section')).to.throw(
+      /Add it to SECTION_TO_KIND/,
+    );
   });
 });


### PR DESCRIPTION
## Summary

Hardens the wire-protocol drift detector from PR #237 (#126) against section-rename / typo drift. Closes [#239](https://github.com/vinceblank/claude-tempo/issues/239).

## Problem

The `kindFromSectionHeader` introduced by PR #237 classified WIRE-PROTOCOL.md section headers via substring matches:
```ts
const lower = header.toLowerCase();
if (lower.includes('signal')) return 'signal';
if (lower.includes('quer') || lower.includes('query')) return 'query';  // dead branch
if (lower.includes('update')) return 'update';
return null;
```

QA on PR #237 flagged two latent failure modes:

1. **Silent rename drift.** `## Session Signals` → `## Session Handlers` would keyword-miss (no 'signal' substring), return `null`, and the drift detector would silently skip that section. Guardrail holes where the guardrail was supposed to protect.
2. **Typo blindness.** `## Session Singals` would also silently skip.
3. **Dead code.** `|| lower.includes('query')` was unreachable — `'quer'` already matches any string containing `'query'` or `'queries'`.

## Fix

Explicit `SECTION_TO_KIND` allowlist, throw on unknown:

```ts
const SECTION_TO_KIND: Record<string, DefineKind | null> = {
  'Session Signals': 'signal',
  'Conductor Signals': 'signal',
  // … 16 more entries …
  'Type Reference': null,
};

function kindFromSectionHeader(header: string): DefineKind | null {
  if (!(header in SECTION_TO_KIND)) {
    throw new Error(
      `Unknown WIRE-PROTOCOL section: "${header}". Add it to SECTION_TO_KIND in test/wire-protocol.test.ts.`,
    );
  }
  return SECTION_TO_KIND[header];
}
```

**Coverage**: all 18 current `## Section Header`s in `docs/WIRE-PROTOCOL.md`:
- 5 signal sections (Session, Conductor, Scheduler, Per-Ensemble Maestro, Global Maestro)
- 6 query sections (Session, Session Outbox, Conductor, Scheduler, Per-Ensemble Maestro, Global Maestro)
- 3 update sections (Session, Per-Ensemble Maestro, Global Maestro)
- 4 explicit-skip sections (Stability Guarantee, Workflow Names, Search Attributes, Type Reference)

**Trade-off**: legitimately adding a new section to WIRE-PROTOCOL.md now requires an explicit allowlist entry. That's the point — deliberate doc ↔ test coupling, same pattern as the wire protocol itself.

## Tests

Two new cases in a new `kindFromSectionHeader — #239 allowlist` describe block:

1. **Exhaustive classification** — independent hardcoded `EXPECTED_CLASSIFICATIONS` matrix of 18 `[header, expected]` pairs. A typo in `SECTION_TO_KIND` breaks this test (not a tautology — the expected kinds are asserted independent of the lookup table).
2. **Unknown-throws** — calls `kindFromSectionHeader` with `'Session Handlers'`, `'Session Singals'`, and `'Bogus Section'`; asserts each throws with the documented error-message contract (`/Unknown WIRE-PROTOCOL section:/` + `/Add it to SECTION_TO_KIND/`).

The existing 5 drift-detection tests stay green (same 18 sections classify to identical kinds under the new implementation).

## Verification

- [x] `npm run build` — clean
- [x] `npm run build:test && mocha dist-test/test/wire-protocol.test.js` — 7/7 pass (5 existing + 2 new)
- [x] `npm test` — Mocha + Vitest both green
- [x] Rebased cleanly on current main (post-#242 + #243)

## Scope

- **Files touched**: `test/wire-protocol.test.ts` + `CHANGELOG.md`
- **Wire protocol surface**: unchanged
- **Effort**: +129 / -7

🤖 Generated with [Claude Code](https://claude.com/claude-code)