### PR TITLE
fix(tui/store): add identity guard to STATUS_SCROLL_UP and PICKER_UP

### DIFF
--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -581,8 +581,11 @@ export function tuiReducer(state: TuiState, action: TuiAction): TuiState {
       if (idx === state.overlay.selectedIndex) return state;
       return { ...state, overlay: { ...state.overlay, selectedIndex: idx } };
     }
-    case 'STATUS_SCROLL_UP':
-      return { ...state, statusScrollOffset: Math.max(0, state.statusScrollOffset - 1) };
+    case 'STATUS_SCROLL_UP': {
+      const next = Math.max(0, state.statusScrollOffset - 1);
+      if (next === state.statusScrollOffset) return state;
+      return { ...state, statusScrollOffset: next };
+    }
     case 'STATUS_SCROLL_DOWN':
       return { ...state, statusScrollOffset: state.statusScrollOffset + 1 };
 
@@ -592,8 +595,11 @@ export function tuiReducer(state: TuiState, action: TuiAction): TuiState {
     case 'HIDE_PICKER':
       return { ...state, pickerVisible: false, pickerType: null, pickerIntent: null, pickerIndex: 0, pickerStatusFilter: null };
 
-    case 'PICKER_UP':
-      return { ...state, pickerIndex: Math.max(0, state.pickerIndex - 1) };
+    case 'PICKER_UP': {
+      const next = Math.max(0, state.pickerIndex - 1);
+      if (next === state.pickerIndex) return state;
+      return { ...state, pickerIndex: next };
+    }
 
     case 'PICKER_DOWN': {
       const maxIdx = (state.pickerType === 'ensembles' ? (state.ensembles?.length ?? 0) : state.players.length - 1);

--- a/tests/tui/store.test.ts
+++ b/tests/tui/store.test.ts
@@ -103,6 +103,36 @@ describe('tuiReducer — no-op identity', () => {
     expect(out).not.toBe(s);
     expect(out.paletteIndex).toBe(3);
   });
+
+  // ── Identity-rule assertions (fixed in #244) ──
+  // STATUS_SCROLL_UP and PICKER_UP both used `Math.max(0, ...)` spread with no
+  // identity guard, returning `{ ...state, ... }` even when already at 0. The
+  // fix mirrors the OVERLAY_SELECT / PALETTE_UP pattern.
+  it('STATUS_SCROLL_UP at offset 0 returns the same reference (identity rule)', () => {
+    const s = { ...s0(), statusScrollOffset: 0 };
+    const out = tuiReducer(s, { type: 'STATUS_SCROLL_UP' });
+    expect(out).toBe(s);
+  });
+
+  it('STATUS_SCROLL_UP above offset 0 produces a new state with decremented offset', () => {
+    const s = { ...s0(), statusScrollOffset: 3 };
+    const out = tuiReducer(s, { type: 'STATUS_SCROLL_UP' });
+    expect(out).not.toBe(s);
+    expect(out.statusScrollOffset).toBe(2);
+  });
+
+  it('PICKER_UP at index 0 returns the same reference (identity rule)', () => {
+    const s = { ...s0(), pickerIndex: 0 };
+    const out = tuiReducer(s, { type: 'PICKER_UP' });
+    expect(out).toBe(s);
+  });
+
+  it('PICKER_UP above index 0 produces a new state with decremented index', () => {
+    const s = { ...s0(), pickerIndex: 4 };
+    const out = tuiReducer(s, { type: 'PICKER_UP' });
+    expect(out).not.toBe(s);
+    expect(out.pickerIndex).toBe(3);
+  });
 });
 
 describe('tuiReducer — state transitions', () => {


### PR DESCRIPTION
## Summary

Follow-up to PR #242 (fix for #108 `PALETTE_UP/DOWN` identity bug). `tempo-qa`'s review there surfaced two more reducer branches in `src/tui/store.ts` with the same pattern -- `STATUS_SCROLL_UP` (store.ts:574) and `PICKER_UP` (store.ts:585) both spread `{ ...state, ... }` even when the clamp target is already 0, which forces spurious React re-renders on repeated arrow-key presses at the top of the status pane and picker list. Closes #244.

## Why this matters

`PLAYER_SCROLL_UP/DOWN`, `PICKER_DOWN`, `OVERLAY_SELECT`, and (post-#242) `PALETTE_UP/DOWN` all use the `if (next === prev) return state;` pattern that preserves reference identity and lets React skip the subtree re-render. `STATUS_SCROLL_UP` and `PICKER_UP` don't, which is the inconsistency the issue flags. The user-visible symptom is perceptible TUI flicker/lag when holding arrow-up at the top of the status list or picker -- no state actually changes, but React re-commits anyway.

## Changes

**`src/tui/store.ts`** (2 reducer branches, mirroring the existing `PALETTE_UP` / `OVERLAY_SELECT` shape):

```ts
// STATUS_SCROLL_UP
case 'STATUS_SCROLL_UP': {
  const next = Math.max(0, state.statusScrollOffset - 1);
  if (next === state.statusScrollOffset) return state;
  return { ...state, statusScrollOffset: next };
}

// PICKER_UP
case 'PICKER_UP': {
  const next = Math.max(0, state.pickerIndex - 1);
  if (next === state.pickerIndex) return state;
  return { ...state, pickerIndex: next };
}
```

**`tests/tui/store.test.ts`** -- four new reference-equality assertions in the same `identity-rule` describe block that already covers `PALETTE_UP/DOWN` from PR #242:

```ts
it('STATUS_SCROLL_UP at offset 0 returns the same reference (identity rule)', ...)
it('STATUS_SCROLL_UP above offset 0 produces a new state with decremented offset', ...)
it('PICKER_UP at index 0 returns the same reference (identity rule)', ...)
it('PICKER_UP above index 0 produces a new state with decremented index', ...)
```

## Testing

```
$ npx vitest run tests/tui/store.test.ts
 ✓ tests/tui/store.test.ts (23 tests) 5ms

 Test Files  1 passed (1)
      Tests  23 passed (23)
```

All 19 pre-existing tests still pass, plus the 4 new identity-rule tests.

## Scope

As documented in #244: single file on the reducer side, single file on the tests side, 4 new test cases. No shape changes to `TuiState`, no action type additions.

Closes #244

---

This contribution was developed with AI assistance (Claude Code).
