### PR TITLE
chore(tui): document STATUS_SCROLL_DOWN render-layer clamping intent (closes #250)

### DIFF
--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -587,6 +587,12 @@ export function tuiReducer(state: TuiState, action: TuiAction): TuiState {
       return { ...state, statusScrollOffset: next };
     }
     case 'STATUS_SCROLL_DOWN':
+      // #250: intentional — no upper-bound clamp lives in the reducer. The max
+      // offset depends on `players.length` and `contentHeight`, neither of which
+      // the reducer can see. `StatusOverlay` performs the final clamp via
+      // `Math.min(scrollOffset, max)` at render (components/StatusOverlay.tsx).
+      // Leaving the reducer unbounded + render-time clamping is cheaper than
+      // threading the render-time max back through every dispatch.
       return { ...state, statusScrollOffset: state.statusScrollOffset + 1 };
 
     case 'SHOW_PICKER':

--- a/tests/tui/store.test.ts
+++ b/tests/tui/store.test.ts
@@ -121,6 +121,19 @@ describe('tuiReducer — no-op identity', () => {
     expect(out.statusScrollOffset).toBe(2);
   });
 
+  // #250 design-contract pin: STATUS_SCROLL_DOWN intentionally does NOT
+  // upper-bound the offset in the reducer — the max depends on
+  // `players.length` + `contentHeight`, both invisible to the reducer.
+  // `StatusOverlay` clamps at render time via `Math.min(scrollOffset, max)`.
+  // This test fails if someone adds an upper-bound clamp here without also
+  // updating the render layer and the action shape.
+  it('STATUS_SCROLL_DOWN always increments (render layer owns the upper-bound clamp)', () => {
+    const s = { ...s0(), statusScrollOffset: 9_999 };
+    const out = tuiReducer(s, { type: 'STATUS_SCROLL_DOWN' });
+    expect(out).not.toBe(s);
+    expect(out.statusScrollOffset).toBe(10_000);
+  });
+
   it('PICKER_UP at index 0 returns the same reference (identity rule)', () => {
     const s = { ...s0(), pickerIndex: 0 };
     const out = tuiReducer(s, { type: 'PICKER_UP' });


### PR DESCRIPTION
## Summary

Closes #250 by landing acceptance criterion #4 — the only remaining item in the issue.

## Context — the issue body was stale

The bulk of #250 (PALETTE_UP/DOWN identity guards, three `it.todo` replacements) was already merged via:
- PR #242 (commit `292be13b`) — PALETTE_UP/DOWN identity guards + real tests
- PR #248 (commit `515d313`) — STATUS_SCROLL_UP + PICKER_UP identity guards

`grep -c it.todo tests/tui/store.test.ts` returns 0 on current main. Only AC #4 (`STATUS_SCROLL_DOWN` intent docs) was live.

## What this PR changes

- `src/tui/store.ts`: 6-line comment on the `STATUS_SCROLL_DOWN` case explaining why the reducer intentionally does not clamp the upper bound — clamping happens in the render layer (`StatusOverlay.tsx:44`'s `Math.min(scrollOffset, max)`). Rationale: threading `max` through every dispatcher adds surface area for a clarifying-only change.
- `tests/tui/store.test.ts`: contract-pin test asserting `STATUS_SCROLL_DOWN` from `statusScrollOffset: 9_999` → `10_000` with `not.toBe(s)`. Fails if a future change adds reducer-layer clamping without also updating the render layer and action shape.

## Verification

- `npm run build` green
- `npm test` green: 831 mocha passing / 22 pending (unchanged), vitest 91 passing across 6 files (`store.test.ts` 23 → 24)
- `/simplify` triple-review passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)