### PR TITLE
fix: message-delivery trilogy — heartbeat/watcher orphan + CAN lease math + poller CAN-blindness (closes #249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,52 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- **Message-delivery trilogy — heartbeat/watcher orphan + CAN lease math +
+  poller CAN-blindness** (#249). Four compounding bugs caused long-running
+  ensembles to silently stop delivering inbound cues: cues landed in workflow
+  inboxes as signal events, the workflow reported `phase=detached`, `recall`
+  still retrieved messages, but nothing ever pushed them into the Claude Code
+  session's context — and no adapter log fired. Reliable repro on
+  `v0.26.0-beta.3` after a multi-hour conductor session with at least one
+  `continueAsNew` boundary. Fixes:
+  1. **`tickHeartbeat` try/finally reschedule** (`src/adapters/base.ts`).
+     Pre-fix early-return paths (guard trips, handled terminal errors)
+     silently orphaned the heartbeat timer; the loop died with no teardown,
+     no log, no state change. Now wrapped in `try/finally` that reschedules
+     unless `stopped`, `reconnecting`, or `terminalFired` — the reconnect loop
+     and terminal machinery retain ownership of their cases, everything else
+     rearms.
+  2. **`tickPhaseWatcher` orphan parity** (`src/adapters/base.ts`). Same
+     orphan shape, same fix. When the heartbeat loop dies, the watcher is the
+     only remaining self-heal surface — losing it too meant no recovery short
+     of process restart.
+  3. **CAN-boundary lease math matches adapter cadence**
+     (`src/workflows/session.ts`, `src/workflows/attachment-math.ts`).
+     Pre-fix the `continueAsNew` extension was a hardcoded 30s, disconnected
+     from the adapter's actual `heartbeatMs` (60s for `claude-code`). A CAN
+     between heartbeats reaped healthy attachments before their next tick
+     could land. Post-fix uses `currentAttachment.leaseMs` (= 3× heartbeatMs,
+     negotiated at claim time), guarded by a `patched('v0.26-can-lease-from-attachment')`
+     so pre-#249 histories still replay deterministically. `extendAttachmentForCAN`
+     parameter renamed `heartbeatMs → extendMs` to match the semantic.
+  4. **Message-poller surfaces terminal `WorkflowNotFoundError`**
+     (`src/adapters/claude-code/adapter.ts`). Pre-fix the poller swallowed
+     every error — a CAN closed the pinned runId, `handle.query('pendingMessages')`
+     threw terminal-class, but the poller just backed off and spun forever
+     against a dead run while the successor ran unattended. Post-fix the
+     poller uses the newly-extracted `src/adapters/terminal-error.ts`
+     `isTerminalWorkflowError` classifier, logs the terminal event, and
+     exits cleanly; the base class's heartbeat/watcher rebind path restarts
+     a fresh poller on the successor via `onReconnected` (depends on bugs
+     1+2 being fixed — revert together).
+  5. **Diagnostic logging** for recurrence detection: `first heartbeat
+     scheduled in Xms` after claim, `heartbeat#1 delivered` on first tick,
+     `heartbeats-delivered=N` / `phase-ticks=N` summary every 10 ticks,
+     structured `guard tripped: {...}` on any tick early-return, and a
+     `WARNING: heartbeat staleness` line when the phase-watcher observes
+     `lastHeartbeatAt` falling more than 2× `heartbeatMs` behind `now`.
+     Operators can `grep '\[claude-tempo:adapter\]'` for breadcrumbs instead
+     of parsing Temporal history for hours.
 - **Suppress spurious `[copilot-bridge]` stderr on non-Copilot MCP startup** (#122).
   `src/adapters/copilot/adapter.ts` was printing "Error: @github/copilot-sdk is not
   installed" to stderr on every `claude-tempo up` / `src/server.ts` startup for users

--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -51,10 +51,12 @@ const log = (...args: unknown[]) => console.error('[claude-tempo:outbox]', ...ar
  * transient signatures if we see false-permanent rates in the wild.
  *
  * ## Why name/message sniffing, not `instanceof`
- * Matches the established pattern in `src/adapters/base.ts` `isTerminalErr`:
- * the Temporal Node SDK surfaces slightly different error shapes between
- * `@temporalio/client`, the gRPC layer, and `WorkflowUpdateFailedError`
- * wrappers. Sniffing on name + message is resilient across those shapes.
+ * Matches the established pattern in `src/adapters/terminal-error.ts`
+ * `isTerminalWorkflowError`: the Temporal Node SDK surfaces slightly different
+ * error shapes between `@temporalio/client`, the gRPC layer, and
+ * `WorkflowUpdateFailedError` wrappers. Sniffing on name + message is resilient
+ * across those shapes. Activity-side classification is kept separate here so
+ * `src/activities/` has no adapter-module dependency.
  */
 function isRetryableTemporalError(err: unknown): boolean {
   // ApplicationFailure instances have already been classified by the thrower

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -27,11 +27,21 @@ import type {
   AttachmentPhase,
   DetachReason,
 } from '../types';
+import { isTerminalWorkflowError } from './terminal-error';
 const log = (...args: unknown[]) => console.error('[claude-tempo:adapter]', ...args);
 
 /** Backoff tuning for the heartbeat + phase-watcher loops on transient errors. */
 const LOOP_BACKOFF_FACTOR = 1.5;
 const LOOP_BACKOFF_MAX_MS = 30_000;
+
+/**
+ * Emit a periodic `heartbeats-delivered=N` / `phase-ticks=N` summary every N
+ * successful ticks (#249). Chosen so a live claude-code adapter (60s cadence)
+ * logs roughly once every 10 minutes and an SDK adapter (30s cadence) once
+ * every 5 — rare enough to stay quiet, frequent enough that a 2-hour incident
+ * window always contains at least one breadcrumb.
+ */
+const LOOP_SUMMARY_EVERY = 10;
 
 /**
  * Reconnect tuning (#201). The loop retries `claimAttachment` with exponential backoff
@@ -100,6 +110,27 @@ export abstract class BaseAttachment {
   private stopped = false;
   private terminalFired = false;
   private knownPhase: AttachmentPhase | null = null;
+  /**
+   * `true` once a heartbeat has successfully landed on the current attachment (or rebind).
+   * Cleared on `startV2Lifecycle`, reconnect-loop success, and CAN rebind so each freshly
+   * live attachment emits its own `heartbeat#1 delivered` diagnostic. Added in #249 to
+   * distinguish "claim OK but heartbeat loop died" from "adapter just hasn't ticked yet."
+   */
+  private firstHeartbeatLogged = false;
+  /**
+   * Monotonic heartbeat counter for the current attachment cycle. Reset on
+   * claim/reconnect/CAN-rebind. Emitted periodically (every {@link HEARTBEAT_SUMMARY_EVERY}
+   * ticks) so a long-running session leaves breadcrumbs in the log proving the loop is
+   * alive — operators can `grep 'heartbeats-delivered='` to confirm health without
+   * parsing Temporal history. Added in #249.
+   */
+  private heartbeatsSent = 0;
+  /**
+   * Mirror of {@link heartbeatsSent} for the phase-watcher loop. Same emission cadence,
+   * same rationale — the watcher is the only self-heal surface when the heartbeat loop
+   * dies silently, so a summary log line proves it's still live too.
+   */
+  private phaseTicksDone = 0;
 
   private readonly phaseChangeListeners: Array<(phase: AttachmentPhase) => void> = [];
   private readonly leaseRevokedListeners: Array<(reason: DetachReason) => void> = [];
@@ -225,9 +256,16 @@ export abstract class BaseAttachment {
     });
 
     this.pinnedHandle = this.client.workflow.getHandle(workflowId, this.token.runId);
+    // #249: reset the per-attachment diagnostic counters so the next tick emits
+    // `heartbeat#1 delivered` on the freshly live lease. Without this reset a
+    // renewal path (e.g. restart → renewed claim) would never re-log first-heartbeat.
+    this.firstHeartbeatLogged = false;
+    this.heartbeatsSent = 0;
+    this.phaseTicksDone = 0;
     log(
       `${expectedAttachmentId ? 'renewed' : 'attached to'} ${workflowId} ` +
-      `(attachmentId=${this.token.attachmentId}, runId=${this.token.runId})`,
+      `(attachmentId=${this.token.attachmentId}, runId=${this.token.runId}); ` +
+      `first heartbeat scheduled in ${this.descriptor.heartbeatMs}ms`,
     );
 
     this.scheduleHeartbeat();
@@ -279,23 +317,88 @@ export abstract class BaseAttachment {
     this.heartbeatTimer = setTimeout(() => { void this.tickHeartbeat(); }, delay);
   }
 
+  /**
+   * Emit a loud diagnostic when a tick early-returns via one of its guard paths (#249).
+   * Pre-#249 these returns were silent — the only observable effect was "heartbeats stop
+   * arriving." Now operators can grep `adapter.*guard tripped` to confirm or rule out
+   * tick-orphan as a failure mode without needing workflow history.
+   *
+   * `terminalFired=true` / `stopped=true` guards are load-bearing on the terminal path
+   * (don't want to re-enter terminal) so they're expected during teardown; we still log
+   * them but at the same level — operators can correlate timestamps against the preceding
+   * `terminal (...) — stopping delivery poll permanently` line.
+   */
+  private logGuardTrip(loop: 'heartbeat' | 'phase-watcher'): void {
+    log(
+      `${loop} guard tripped:`,
+      JSON.stringify({
+        stopped: this.stopped,
+        reconnecting: this.reconnecting,
+        hasHandle: this.pinnedHandle !== null,
+        hasToken: this.token !== null,
+        terminalFired: this.terminalFired,
+      }),
+    );
+  }
+
+  /**
+   * Single tick of the heartbeat loop. Try/finally scaffolding (#249) guarantees
+   * reschedule in every path except genuinely terminal state (`stopped`,
+   * `terminalFired`) or when the reconnect loop has taken ownership of scheduling
+   * (`reconnecting`). Pre-#249 the three early-return paths at the top + the
+   * handled-terminal-error path silently orphaned the timer forever; a transient
+   * `reconnecting=true` window or a null-handle race was enough to kill the loop
+   * with no log and no teardown.
+   *
+   * Handled terminals (CAN rebind, destroy) still short-circuit via `return` —
+   * the `finally` block re-checks `reconnecting` / `terminalFired` before
+   * rescheduling, so the reconnect/terminal machinery keeps ownership of
+   * whatever comes next.
+   */
   private async tickHeartbeat(): Promise<void> {
-    if (this.stopped || this.reconnecting || !this.pinnedHandle || !this.token) return;
     try {
-      await this.pinnedHandle.signal(heartbeatSignal, {
-        attachmentId: this.token.attachmentId,
-        at: new Date().toISOString(),
-      });
-      this.heartbeatBackoff = 0;
-    } catch (err) {
-      if (await this.handleRunEndError(err)) return;
-      this.heartbeatBackoff = Math.min(
-        this.heartbeatBackoff ? this.heartbeatBackoff * LOOP_BACKOFF_FACTOR : this.descriptor.heartbeatMs,
-        LOOP_BACKOFF_MAX_MS,
-      );
-      log(`heartbeat transient error (retry in ${Math.round(this.heartbeatBackoff)}ms):`, (err as Error)?.message ?? err);
+      if (this.stopped || this.terminalFired) {
+        this.logGuardTrip('heartbeat');
+        return;
+      }
+      if (this.reconnecting) {
+        // Reconnect loop owns reschedule; this tick was queued before the guard
+        // flipped. Dropping it is correct — the reconnect path will rearm.
+        this.logGuardTrip('heartbeat');
+        return;
+      }
+      if (!this.pinnedHandle || !this.token) {
+        // Should be unreachable after `startV2Lifecycle` success — surface loudly
+        // if we ever hit it instead of silently orphaning (the pre-#249 behavior).
+        this.logGuardTrip('heartbeat');
+        return;
+      }
+      try {
+        await this.pinnedHandle.signal(heartbeatSignal, {
+          attachmentId: this.token.attachmentId,
+          at: new Date().toISOString(),
+        });
+        this.heartbeatBackoff = 0;
+        this.heartbeatsSent++;
+        if (!this.firstHeartbeatLogged) {
+          this.firstHeartbeatLogged = true;
+          log(`heartbeat#1 delivered (attachmentId=${this.token.attachmentId}, runId=${this.token.runId})`);
+        } else if (this.heartbeatsSent % LOOP_SUMMARY_EVERY === 0) {
+          log(`heartbeats-delivered=${this.heartbeatsSent} (attachmentId=${this.token.attachmentId})`);
+        }
+      } catch (err) {
+        if (await this.handleRunEndError(err)) return;
+        this.heartbeatBackoff = Math.min(
+          this.heartbeatBackoff ? this.heartbeatBackoff * LOOP_BACKOFF_FACTOR : this.descriptor.heartbeatMs,
+          LOOP_BACKOFF_MAX_MS,
+        );
+        log(`heartbeat transient error (retry in ${Math.round(this.heartbeatBackoff)}ms):`, (err as Error)?.message ?? err);
+      }
+    } finally {
+      if (!this.stopped && !this.reconnecting && !this.terminalFired) {
+        this.scheduleHeartbeat();
+      }
     }
-    if (!this.stopped && !this.reconnecting) this.scheduleHeartbeat();
   }
 
   private schedulePhaseWatcher(): void {
@@ -305,92 +408,108 @@ export abstract class BaseAttachment {
     this.phaseWatcherTimer = setTimeout(() => { void this.tickPhaseWatcher(); }, delay);
   }
 
-  private async tickPhaseWatcher(): Promise<void> {
-    if (this.stopped || this.reconnecting || !this.pinnedHandle || !this.token) return;
-    try {
-      const info: AttachmentInfo = await this.pinnedHandle.query(attachmentInfoQuery);
-      this.phaseBackoff = 0;
-
-      if (this.knownPhase !== info.phase) {
-        this.knownPhase = info.phase;
-        for (const l of this.phaseChangeListeners) {
-          try { l(info.phase); } catch (err) { log('phase listener threw:', err); }
-        }
-      }
-
-      // Lease revocation (§9.3) — another claimant took over.
-      if (
-        info.currentAttachment &&
-        info.currentAttachment.attachmentId !== this.token.attachmentId
-      ) {
-        log(`lease revoked: attachmentId ${info.currentAttachment.attachmentId} does not match ours ${this.token.attachmentId}`);
-        for (const l of this.leaseRevokedListeners) {
-          try { l('superseded'); } catch (err) { log('leaseRevoked listener threw:', err); }
-        }
-        this.fireTerminalOrReconnect('superseded');
-        return;
-      }
-
-      // #201: the workflow side reaped our lease (main-loop §9.5.a) without anyone
-      // else claiming. This is the laptop-sleep failure mode — `phase=detached` with
-      // `currentAttachment=undefined`. Before #201 this branch was silent and the
-      // poller kept querying a workflow that had already evicted us, so no cues were
-      // delivered until manual `restart`. Now we surface it as a recoverable terminal
-      // that the subclass can choose to reconnect through.
-      if (info.phase === 'detached' && !info.currentAttachment) {
-        log(`lease reaped workflow-side (phase=detached, no current attachment)`);
-        for (const l of this.leaseRevokedListeners) {
-          try { l('heartbeat-timeout'); } catch (err) { log('leaseRevoked listener threw:', err); }
-        }
-        this.fireTerminalOrReconnect('heartbeat-timeout');
-        return;
-      }
-
-      // Phase `gone` is terminal — workflow destroyed. Never recoverable.
-      if (info.phase === 'gone') {
-        this.fireTerminal('destroy');
-        return;
-      }
-    } catch (err) {
-      if (await this.handleRunEndError(err)) return;
-      this.phaseBackoff = Math.min(
-        this.phaseBackoff ? this.phaseBackoff * LOOP_BACKOFF_FACTOR : this.descriptor.heartbeatMs,
-        LOOP_BACKOFF_MAX_MS,
-      );
-      log(`phase watcher transient error (retry in ${Math.round(this.phaseBackoff)}ms):`, (err as Error)?.message ?? err);
-    }
-    if (!this.stopped && !this.reconnecting) this.schedulePhaseWatcher();
-  }
-
   /**
-   * Classify a Temporal error as terminal-class vs transient.
-   *
-   * **Gotcha the caller must know:** the Temporal Node SDK conflates the two
-   * terminal sub-kinds on pinned-runId signal/query failures. Both
-   *   (a) the closed run's specific runId no longer accepting traffic (CAN or
-   *       true COMPLETE / TERMINATED), and
-   *   (b) the workflow id having been fully GC'd
-   * surface as `WorkflowNotFoundError` with message "workflow execution already
-   * completed". We therefore can't tell them apart by error shape alone — the
-   * authoritative differentiator is `fetchHistory` ({@link findCanSuccessorRunId}).
-   * This method only says "yes, this is a terminal-class error; caller must
-   * decide sub-kind" vs "transient, keep retrying."
-   *
-   * Uses name/message-sniffing rather than `instanceof` to tolerate the slightly
-   * different shapes that errors take between `@temporalio/client` and the raw
-   * gRPC layer.
+   * Single tick of the phase-watcher loop. Same orphan-resistance scaffolding as
+   * {@link tickHeartbeat} (#249): try/finally reschedule, unconditional unless
+   * `stopped` / `terminalFired` / `reconnecting`. When the heartbeat loop dies
+   * silently, the watcher is the only remaining self-heal surface — losing it
+   * too meant the adapter had no path back to a healthy state short of process
+   * restart.
    */
-  private isTerminalErr(err: unknown): boolean {
-    const e = err as { name?: string; message?: string } | undefined;
-    const name = e?.name ?? '';
-    const msg = e?.message ?? '';
-    return (
-      name.includes('WorkflowNotFound') ||
-      name.includes('WorkflowExecutionAlreadyCompleted') ||
-      msg.includes('WorkflowGone') ||
-      msg.includes('NOT_FOUND') ||
-      msg.includes('workflow execution already completed')
-    );
+  private async tickPhaseWatcher(): Promise<void> {
+    try {
+      if (this.stopped || this.terminalFired) {
+        this.logGuardTrip('phase-watcher');
+        return;
+      }
+      if (this.reconnecting) {
+        this.logGuardTrip('phase-watcher');
+        return;
+      }
+      if (!this.pinnedHandle || !this.token) {
+        this.logGuardTrip('phase-watcher');
+        return;
+      }
+      try {
+        const info: AttachmentInfo = await this.pinnedHandle.query(attachmentInfoQuery);
+        this.phaseBackoff = 0;
+        this.phaseTicksDone++;
+        if (this.phaseTicksDone % LOOP_SUMMARY_EVERY === 0) {
+          log(`phase-ticks=${this.phaseTicksDone} (phase=${info.phase}, attachmentId=${this.token.attachmentId})`);
+        }
+
+        // #249: if the workflow-side attachment record shows our last heartbeat landed
+        // more than 2 * heartbeatMs ago, the heartbeat loop is drifting (or has
+        // silently died) even though the lease hasn't yet expired. Loud warning so
+        // operators can catch degradation before the reaper fires. Baseline is
+        // `claimedAt` on cycles before the first post-claim heartbeat lands.
+        if (info.currentAttachment && info.currentAttachment.attachmentId === this.token.attachmentId) {
+          const lastBeatMs = new Date(
+            info.currentAttachment.lastHeartbeatAt || info.currentAttachment.claimedAt,
+          ).getTime();
+          const ageMs = Date.now() - lastBeatMs;
+          if (ageMs > 2 * this.descriptor.heartbeatMs) {
+            log(
+              `WARNING: heartbeat staleness — lastHeartbeatAt=${info.currentAttachment.lastHeartbeatAt} ` +
+              `age=${ageMs}ms exceeds 2× heartbeatMs (${2 * this.descriptor.heartbeatMs}ms); ` +
+              `lease may be about to reap (expiresAt=${info.currentAttachment.expiresAt})`,
+            );
+          }
+        }
+
+        if (this.knownPhase !== info.phase) {
+          this.knownPhase = info.phase;
+          for (const l of this.phaseChangeListeners) {
+            try { l(info.phase); } catch (err) { log('phase listener threw:', err); }
+          }
+        }
+
+        // Lease revocation (§9.3) — another claimant took over.
+        if (
+          info.currentAttachment &&
+          info.currentAttachment.attachmentId !== this.token.attachmentId
+        ) {
+          log(`lease revoked: attachmentId ${info.currentAttachment.attachmentId} does not match ours ${this.token.attachmentId}`);
+          for (const l of this.leaseRevokedListeners) {
+            try { l('superseded'); } catch (err) { log('leaseRevoked listener threw:', err); }
+          }
+          this.fireTerminalOrReconnect('superseded');
+          return;
+        }
+
+        // #201: the workflow side reaped our lease (main-loop §9.5.a) without anyone
+        // else claiming. This is the laptop-sleep failure mode — `phase=detached` with
+        // `currentAttachment=undefined`. Before #201 this branch was silent and the
+        // poller kept querying a workflow that had already evicted us, so no cues were
+        // delivered until manual `restart`. Now we surface it as a recoverable terminal
+        // that the subclass can choose to reconnect through.
+        if (info.phase === 'detached' && !info.currentAttachment) {
+          log(`lease reaped workflow-side (phase=detached, no current attachment)`);
+          for (const l of this.leaseRevokedListeners) {
+            try { l('heartbeat-timeout'); } catch (err) { log('leaseRevoked listener threw:', err); }
+          }
+          this.fireTerminalOrReconnect('heartbeat-timeout');
+          return;
+        }
+
+        // Phase `gone` is terminal — workflow destroyed. Never recoverable.
+        if (info.phase === 'gone') {
+          this.fireTerminal('destroy');
+          return;
+        }
+      } catch (err) {
+        if (await this.handleRunEndError(err)) return;
+        this.phaseBackoff = Math.min(
+          this.phaseBackoff ? this.phaseBackoff * LOOP_BACKOFF_FACTOR : this.descriptor.heartbeatMs,
+          LOOP_BACKOFF_MAX_MS,
+        );
+        log(`phase watcher transient error (retry in ${Math.round(this.phaseBackoff)}ms):`, (err as Error)?.message ?? err);
+      }
+    } finally {
+      if (!this.stopped && !this.reconnecting && !this.terminalFired) {
+        this.schedulePhaseWatcher();
+      }
+    }
   }
 
   /**
@@ -402,13 +521,13 @@ export abstract class BaseAttachment {
    *
    * Always consults `fetchHistory` on any terminal-class error, because the
    * Temporal SDK can't distinguish CAN-close from true-complete at the error
-   * level — see {@link isTerminalErr}. The history lookup is cheap (only runs
-   * on terminal, so at most once per adapter lifetime per terminal) and safer
-   * than re-querying by workflow id (which could race a fresh session reusing
-   * the id).
+   * level — see {@link isTerminalWorkflowError}. The history lookup is cheap
+   * (only runs on terminal, so at most once per adapter lifetime per terminal)
+   * and safer than re-querying by workflow id (which could race a fresh session
+   * reusing the id).
    */
   private async handleRunEndError(err: unknown): Promise<boolean> {
-    if (!this.isTerminalErr(err)) return false;
+    if (!isTerminalWorkflowError(err)) return false;
     // Always try to find a CAN successor — the Temporal SDK's error shape is
     // ambiguous between CAN and true-destroy, so history is the only reliable
     // disambiguator (option 1 from the #226 design brief).
@@ -621,6 +740,13 @@ export abstract class BaseAttachment {
       this.knownPhase = null; // force next phase-watcher tick to re-emit phaseChange
       this.heartbeatBackoff = 0;
       this.phaseBackoff = 0;
+      // #249: reset per-attachment diagnostic counters so the first post-rebind
+      // heartbeat re-logs `heartbeat#1 delivered`. Without this a rebind could
+      // mask a dead loop on the successor run — we'd never see the confirmation
+      // that heartbeats resumed.
+      this.firstHeartbeatLogged = false;
+      this.heartbeatsSent = 0;
+      this.phaseTicksDone = 0;
       log(
         `rebound ${workflowId} to CAN successor ` +
         `(attachmentId=${this.token.attachmentId}, oldRunId=${oldRunId}, newRunId=${newRunId})`,
@@ -712,7 +838,7 @@ export abstract class BaseAttachment {
         try {
           info = await unpinned.query(attachmentInfoQuery);
         } catch (err) {
-          if (this.isTerminalErr(err)) {
+          if (isTerminalWorkflowError(err)) {
             // #226: either terminal kind inside the reconnect loop's pre-check
             // ends the loop. We don't recurse into another CAN rebind here —
             // that path is only for the pinned-handle tick ticks where we can
@@ -763,6 +889,11 @@ export abstract class BaseAttachment {
           this.knownPhase = null; // force the next phase-watcher tick to re-emit phaseChange
           this.heartbeatBackoff = 0;
           this.phaseBackoff = 0;
+          // #249: reset per-attachment diagnostic counters so the first post-reconnect
+          // heartbeat re-logs `heartbeat#1 delivered`. Parity with CAN rebind path.
+          this.firstHeartbeatLogged = false;
+          this.heartbeatsSent = 0;
+          this.phaseTicksDone = 0;
           log(
             `reconnected to ${workflowId} after ${attempt} attempt(s) ` +
             `(new attachmentId=${newToken.attachmentId}, runId=${newToken.runId})`,
@@ -786,7 +917,7 @@ export abstract class BaseAttachment {
           }
           return;
         } catch (err) {
-          if (this.isTerminalErr(err)) {
+          if (isTerminalWorkflowError(err)) {
             log('reconnect: workflow gone during claim');
             this.fireTerminal('destroy');
             return;

--- a/src/adapters/claude-code/adapter.ts
+++ b/src/adapters/claude-code/adapter.ts
@@ -19,6 +19,7 @@
  */
 import type { Client, WorkflowHandle } from '@temporalio/client';
 import { BaseAttachment, type BaseAttachmentOptions } from '../base';
+import { isTerminalWorkflowError } from '../terminal-error';
 import type { AdapterDescriptor, DetachReason } from '../../types';
 import { Message } from '../../types';
 import { ENV } from '../../config';
@@ -49,9 +50,23 @@ const POLL_MAX_MS = 30000;
 /**
  * Poll a session workflow for pending messages and deliver them via `onMessages`.
  *
- * Verbatim lift from the old `src/channel.ts`. Module-private; callers go through
- * {@link InteractiveAttachment.start}. Used by both the V2 path (on a runId-pinned
- * handle) and the legacy compat path (on the unpinned handle from server.ts).
+ * Module-private; callers go through {@link InteractiveAttachment.start}. Runs
+ * on the V2 runId-pinned handle so `markDelivered` signals reach the correct
+ * execution.
+ *
+ * **Terminal-error handling (#249 Bug 4):** pre-#249 this loop's catch-all
+ * swallowed every error including `WorkflowNotFoundError` from a CAN-closed
+ * pinned runId, so the poller spun forever against a dead run while the
+ * successor accepted messages no one was draining. Post-fix: classify via
+ * the shared {@link isTerminalWorkflowError}, stop cleanly when seen, and
+ * rely on the base class's heartbeat/watcher `handleRunEndError` path to
+ * run the CAN rebind — which then calls `onReconnected` on
+ * {@link InteractiveAttachment} to start a fresh poller on the successor.
+ *
+ * This fix depends on Bugs 1+2 (tick orphan resistance) — if the heartbeat
+ * loop is dead, `onReconnected` never fires and the poller stays stopped
+ * without a replacement. See the Bug 4 commit message for the revert-together
+ * dependency.
  */
 function startMessagePoller(
   handle: WorkflowHandle,
@@ -61,6 +76,13 @@ function startMessagePoller(
   let timeout: ReturnType<typeof setTimeout> | null = null;
   let currentInterval = POLL_BASE_MS;
   let consecutiveErrors = 0;
+
+  const cleanupTimer = () => {
+    if (timeout) {
+      clearTimeout(timeout);
+      timeout = null;
+    }
+  };
 
   const poll = async () => {
     if (stopped) return;
@@ -77,6 +99,22 @@ function startMessagePoller(
       currentInterval = POLL_BASE_MS;
       consecutiveErrors = 0;
     } catch (err) {
+      // #249 Bug 4: surface terminal-class errors instead of swallowing. The
+      // pinned-runId handle throws `WorkflowNotFoundError` /
+      // `WorkflowExecutionAlreadyCompleted` when its run has CAN'd or been
+      // destroyed. Keep polling against the closed run is pointless and masks
+      // the lifecycle event from logs. Stop the poller here; the base class's
+      // heartbeat/watcher tick will trigger CAN rebind or terminal, and
+      // `onReconnected` restarts a fresh poller on the live run.
+      if (isTerminalWorkflowError(err)) {
+        log(
+          `poll hit terminal workflow error — stopping (onReconnected will restart on successor if recoverable):`,
+          (err as Error)?.message ?? err,
+        );
+        stopped = true;
+        cleanupTimer();
+        return;
+      }
       consecutiveErrors++;
       // Apply exponential backoff on errors
       currentInterval = Math.min(currentInterval * POLL_BACKOFF_FACTOR, POLL_MAX_MS);
@@ -93,10 +131,7 @@ function startMessagePoller(
 
   return () => {
     stopped = true;
-    if (timeout) {
-      clearTimeout(timeout);
-      timeout = null;
-    }
+    cleanupTimer();
   };
 }
 

--- a/src/adapters/terminal-error.ts
+++ b/src/adapters/terminal-error.ts
@@ -1,0 +1,38 @@
+/**
+ * Shared terminal-class error classifier for adapter code (#249 Bug 4).
+ *
+ * The Temporal TS SDK conflates two terminal sub-kinds on pinned-runId
+ * signal/query failures:
+ *   (a) the closed run's specific runId no longer accepting traffic (CAN,
+ *       true COMPLETE, TERMINATED, FAILED), and
+ *   (b) the workflow id having been fully GC'd.
+ * Both surface as `WorkflowNotFoundError` with message
+ * "workflow execution already completed". This classifier says "yes, this is a
+ * terminal-class error" vs "transient, keep retrying" — it does NOT distinguish
+ * the sub-kinds. Callers that need sub-kind resolution consult
+ * `fetchHistory` (see {@link BaseAttachment.handleRunEndError}).
+ *
+ * **Extracted from `BaseAttachment.isTerminalErr` to break a code-duplication
+ * risk** — both the heartbeat/watcher ticks (in `base.ts`) and the delivery
+ * poller (in `claude-code/adapter.ts`) need to classify the same errors, and
+ * divergence between the two would re-create the #249 Bug 4 regression surface.
+ * One implementation, one import point.
+ *
+ * Uses name/message-sniffing rather than `instanceof` to tolerate the slightly
+ * different shapes errors take between `@temporalio/client` and the raw gRPC
+ * layer. The tradeoff is a narrow window where gRPC could add a new phrasing
+ * for the same error class — but that's caught by the existing adapter
+ * reconnect integration tests.
+ */
+export function isTerminalWorkflowError(err: unknown): boolean {
+  const e = err as { name?: string; message?: string } | undefined;
+  const name = e?.name ?? '';
+  const msg = e?.message ?? '';
+  return (
+    name.includes('WorkflowNotFound') ||
+    name.includes('WorkflowExecutionAlreadyCompleted') ||
+    msg.includes('WorkflowGone') ||
+    msg.includes('NOT_FOUND') ||
+    msg.includes('workflow execution already completed')
+  );
+}

--- a/src/workflows/attachment-math.ts
+++ b/src/workflows/attachment-math.ts
@@ -28,8 +28,8 @@ import type { Attachment } from '../types';
  * `expiresAt` verbatim into the new execution, a transition that takes
  * ~100-500ms could leave the new run's first deadline race observing an
  * already-expired lease and reaping a healthy attachment. Pushing
- * `expiresAt` out to `now + heartbeatMs` guarantees the next normally-timed
- * heartbeat has room to arrive.
+ * `expiresAt` out to `now + extendMs` guarantees the adapter has room to land
+ * its next heartbeat.
  *
  * Why this is a total function (returns a new object unconditionally,
  * rather than accepting `null` and returning `undefined`): null-handling is
@@ -40,10 +40,14 @@ import type { Attachment } from '../types';
  * @param attachment - the pre-CAN attachment record. All non-timestamp
  *   fields (`attachmentId`, `hostname`, `adapterId`, `adapterClass`,
  *   `claimedAt`, `leaseMs`, `runId`) are carried forward verbatim.
- * @param heartbeatMs - the adapter's heartbeat cadence in milliseconds. The
- *   new `expiresAt` lands `heartbeatMs` past `now`. Callers typically pass
- *   the workflow's `HEARTBEAT_INTERVAL_MS` constant, but any non-negative
- *   integer is accepted — the function does not validate.
+ * @param extendMs - how far past `now` to push `expiresAt`, in milliseconds.
+ *   Post-#249 callers pass `attachment.leaseMs` (= 3 × heartbeatMs — covers one
+ *   full lease window and therefore at least one full heartbeat interval for
+ *   every adapter class). Pre-#249 callers passed a hardcoded 30_000 constant
+ *   which under-covered the claude-code adapter's 60s cadence — the rename
+ *   from `heartbeatMs` disambiguates that the parameter is a raw extension
+ *   duration, not a cadence. The function does not validate — any non-negative
+ *   integer is accepted.
  * @param now - current time in epoch milliseconds. In workflow context
  *   callers pass `new Date().getTime()` (the Temporal SDK intercepts `new
  *   Date()` to return replay-consistent time). In unit tests callers pass
@@ -52,12 +56,12 @@ import type { Attachment } from '../types';
  */
 export function extendAttachmentForCAN(
   attachment: Attachment,
-  heartbeatMs: number,
+  extendMs: number,
   now: number,
 ): Attachment {
   return {
     ...attachment,
     lastHeartbeatAt: new Date(now).toISOString(),
-    expiresAt: new Date(now + heartbeatMs).toISOString(),
+    expiresAt: new Date(now + extendMs).toISOString(),
   };
 }

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -147,7 +147,14 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
   // PR-C commit 6 (#119a): each attachment carries its own `leaseMs` (negotiated at
   // claim time). No workflow-side default constant — heartbeats extend `expiresAt`
   // by `currentAttachment.leaseMs`.
-  /** Default heartbeat cadence (interactive). SDK adapters use 30s; descriptor-driven in PR-C. */
+  /**
+   * Legacy CAN-extension constant. Retained solely so sessions that ran on a
+   * pre-#249 workflow bundle replay deterministically: the `patched()` branch at
+   * the CAN-boundary extension site selects this constant on the non-patched
+   * side, matching the exact arg sequence those histories recorded. New runs
+   * (and all post-#249 CAN transitions) use `currentAttachment.leaseMs` instead
+   * — see the call site below.
+   */
   const HEARTBEAT_INTERVAL_MS = 30_000;
   /**
    * Default grace period for `draining → detached` transition after requestDetach. Used when a
@@ -1533,11 +1540,28 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
       // ── CAN-boundary lease extension (design §2.3) ──
       // The CAN transition is not instantaneous. If we write the old expiresAt into the
       // new execution and the transition takes ~100–500ms, the new execution's first main
-      // loop check could reap a healthy attachment as expired. Extend the lease by one
-      // heartbeat interval so a normally-beating adapter has room to land its next heartbeat.
+      // loop check could reap a healthy attachment as expired. Extend the lease so a
+      // normally-beating adapter has room to land its next heartbeat.
+      //
+      // #249 Bug 3: pre-fix this used a hardcoded 30s constant, but the claude-code
+      // adapter's `heartbeatMs` is 60s → CAN would grant 30s of runway when the adapter
+      // needed 60s minimum, so the first post-CAN main-loop tick reaped the healthy
+      // attachment before its next heartbeat could land. Post-fix we use
+      // `currentAttachment.leaseMs` (= 3 × heartbeatMs, negotiated at claim time) which
+      // matches what the adapter signed up for and covers at least one full heartbeat
+      // interval for every adapter class.
+      //
+      // The `patched()` gate keeps replay of pre-#249 workflow runs deterministic:
+      // histories that CAN'd on the old bundle recorded `extendAttachmentForCAN(…, 30_000, …)`,
+      // so replaying those runs must pick the legacy constant. New runs (and in-flight
+      // runs that CAN *after* the deploy) take the patched branch.
+      //
       // Math lives in `./attachment-math.ts` for direct unit testability (#127).
+      const extendMs = patched('v0.26-can-lease-from-attachment')
+        ? currentAttachment?.leaseMs ?? HEARTBEAT_INTERVAL_MS
+        : HEARTBEAT_INTERVAL_MS;
       const extendedAttachment = currentAttachment
-        ? extendAttachmentForCAN(currentAttachment, HEARTBEAT_INTERVAL_MS, workflowNow().getTime())
+        ? extendAttachmentForCAN(currentAttachment, extendMs, workflowNow().getTime())
         : undefined;
 
       await continueAsNew<typeof claudeSessionWorkflow>({

--- a/test/heartbeat-trilogy.test.ts
+++ b/test/heartbeat-trilogy.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Integration tests for the #249 message-delivery trilogy.
+ *
+ * Covers the four compounding bugs holistically (unit coverage for each lives
+ * in its own suite):
+ *   1. tickHeartbeat orphan pattern — diagnostic log assertions confirming the
+ *      loop reschedules across guard trips and that `heartbeat#1 delivered`
+ *      lands after claim.
+ *   2. tickPhaseWatcher orphan parity — parity assertions for the watcher loop.
+ *   3. CAN lease-extension math — **fails on pre-#249 main**. The pre-fix
+ *      workflow extends by a hardcoded 30s; with `leaseMs=90_000` the post-fix
+ *      extension exceeds that, so the assertion `expiresAt - now >= 60_000`
+ *      rejects the legacy behavior.
+ *   4. Poller CAN-blindness — verified indirectly by the adapter-reconnect CAN
+ *      rebind test (`adapter-reconnect.test.ts`): post-CAN delivery requires a
+ *      poller to run on the successor runId, which only happens if the old
+ *      poller stopped cleanly (Bug 4 fix) and the rebind path restarted it.
+ *
+ * Cross-file note: `adapter-reconnect.test.ts` already covers the end-to-end
+ * reconnect + CAN rebind delivery flows. This file pins the SURGICAL assertions
+ * around the trilogy fixes — guard-trip logs, CAN extension magnitude, and the
+ * diagnostic log lines operators will grep for on recurrence.
+ */
+import { expect } from 'chai';
+import type { WorkflowHandle } from '@temporalio/client';
+import {
+  setupTestEnv,
+  teardownTestEnv,
+  withWorker,
+  startSession,
+  playerMetadata,
+  getClient,
+  claimAttachmentUpdate,
+  attachmentInfoQuery,
+  destroyUpdate,
+} from './helpers';
+import { testForceContinueAsNewSignal } from '../src/workflows/signals';
+import type { AttachmentInfo, DetachReason } from '../src/types';
+import { InteractiveAttachment } from '../src/adapters/claude-code/adapter';
+import type { BaseAttachmentOptions } from '../src/adapters/base';
+
+/**
+ * Capture `console.error` output for the duration of `fn` and return what
+ * was logged. The adapter module uses `console.error` as its log sink
+ * (`log = (...args) => console.error('[claude-tempo:adapter]', ...args)`)
+ * so this is the seam for asserting on diagnostic output without mocking
+ * the module itself.
+ */
+async function captureAdapterLog<T>(
+  fn: () => Promise<T>,
+): Promise<{ result: T; lines: string[] }> {
+  const lines: string[] = [];
+  const original = console.error;
+  console.error = (...args: unknown[]) => {
+    lines.push(args.map((a) => (typeof a === 'string' ? a : JSON.stringify(a))).join(' '));
+  };
+  try {
+    const result = await fn();
+    return { result, lines };
+  } finally {
+    console.error = original;
+  }
+}
+
+/**
+ * Fast heartbeat subclass — 400ms cadence, matching `adapter-reconnect.test.ts`.
+ * The exposed test hooks are the minimum needed to drive the guard paths
+ * directly; we intentionally don't replace the class's tick logic.
+ */
+class FastInteractiveAttachment extends InteractiveAttachment {
+  readonly descriptor = {
+    adapterId: 'claude-code',
+    adapterClass: 'interactive' as const,
+    blocksOnLLMTurn: false,
+    heartbeatMs: 400,
+  };
+
+  public async publicStopV2(reason: DetachReason = 'user-stop'): Promise<void> {
+    return this.stopV2Lifecycle(reason, false);
+  }
+}
+
+/** Poll `handle.query(attachmentInfoQuery)` until `pred` passes or timeout. */
+async function waitForAttachmentInfo(
+  handle: WorkflowHandle,
+  pred: (info: AttachmentInfo) => boolean,
+  timeoutMs = 5000,
+  label = '<predicate>',
+): Promise<AttachmentInfo> {
+  const deadline = Date.now() + timeoutMs;
+  let last: AttachmentInfo | undefined;
+  while (Date.now() < deadline) {
+    last = await handle.query(attachmentInfoQuery);
+    if (pred(last)) return last;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  throw new Error(
+    `Timed out waiting for ${label}; last info=${JSON.stringify(last)}`,
+  );
+}
+
+describe('heartbeat trilogy (#249)', function () {
+  before(async function () {
+    this.timeout(60_000);
+    await setupTestEnv();
+  });
+
+  after(async function () {
+    await teardownTestEnv();
+  });
+
+  describe('diagnostic logging (Bugs 1+2 defensive coverage)', () => {
+    it('logs `heartbeat#1 delivered` on the first successful heartbeat', async function () {
+      // Pre-#249 this log line did not exist. Post-fix it is the canonical
+      // signal that a claimed attachment actually began renewing its lease —
+      // absence is the smoking gun for a dead heartbeat loop.
+      this.timeout(15_000);
+
+      await withWorker(async () => {
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: `heartbeat-log-${Date.now()}` }),
+        });
+
+        const options: BaseAttachmentOptions = {
+          client: getClient(),
+          host: 'test-host',
+          reconnectTiming: { baseMs: 100, maxMs: 500, budgetMs: 10_000, backoffFactor: 1.5 },
+        };
+        const adapter = new FastInteractiveAttachment(options);
+
+        const { lines } = await captureAdapterLog(async () => {
+          const stop = adapter.start(handle, async () => { /* no-op */ });
+          try {
+            // 400ms heartbeat + some jitter → 2s is plenty for the first few.
+            await waitForAttachmentInfo(
+              handle,
+              (i) => i.phase === 'attached' && !!i.currentAttachment,
+              5000,
+              'initial attached',
+            );
+            // Give the very first heartbeat a chance to land.
+            await new Promise((r) => setTimeout(r, 1200));
+          } finally {
+            stop();
+            await adapter.publicStopV2();
+            await handle.executeUpdate(destroyUpdate, { args: [{}] });
+            await handle.result().catch(() => { /* expected */ });
+          }
+        });
+
+        // The pinned "first heartbeat scheduled in Xms" line lands on claim
+        // success; the "heartbeat#1 delivered" line lands on the first tick
+        // that actually signals. Both must appear for the diagnostic to be
+        // useful on a real incident.
+        const scheduleLine = lines.find((l) => l.includes('first heartbeat scheduled'));
+        const firstHbLine = lines.find((l) => l.includes('heartbeat#1 delivered'));
+        expect(scheduleLine, `expected "first heartbeat scheduled" in logs:\n${lines.join('\n')}`).to.exist;
+        expect(firstHbLine, `expected "heartbeat#1 delivered" in logs:\n${lines.join('\n')}`).to.exist;
+      });
+    });
+
+    it('emits a guard-trip log when a tick fires during teardown', async function () {
+      // Force a guard-trip by stopping the adapter mid-session and waiting long
+      // enough for any queued tick to fire under `stopped=true`. The post-fix
+      // guard-trip log is structured JSON with every flag, so a regression
+      // that removes the log (or replaces it with the pre-#249 silent return)
+      // fails this assertion.
+      this.timeout(15_000);
+
+      await withWorker(async () => {
+        const handle = await startSession({
+          metadata: playerMetadata({ playerId: `guard-trip-${Date.now()}` }),
+        });
+
+        const options: BaseAttachmentOptions = {
+          client: getClient(),
+          host: 'test-host',
+        };
+        const adapter = new FastInteractiveAttachment(options);
+
+        const { lines } = await captureAdapterLog(async () => {
+          const stop = adapter.start(handle, async () => { /* no-op */ });
+          try {
+            await waitForAttachmentInfo(
+              handle,
+              (i) => i.phase === 'attached' && !!i.currentAttachment,
+              5000,
+              'initial attached',
+            );
+            // Stop the adapter; any queued tick that fires after this sees
+            // `stopped=true` and should log a guard-trip.
+            stop();
+            await adapter.publicStopV2();
+            // Wait past one tick interval so a queued tick has a chance to fire.
+            await new Promise((r) => setTimeout(r, 600));
+          } finally {
+            await handle.executeUpdate(destroyUpdate, { args: [{}] });
+            await handle.result().catch(() => { /* expected */ });
+          }
+        });
+
+        // A guard-trip log from either loop suffices — both follow the same
+        // shape post-fix. We only assert shape (stopped=true present), not
+        // which loop emitted, because the race between heartbeat and watcher
+        // tick cadence can pick either.
+        const guardLines = lines.filter((l) => l.includes('guard tripped'));
+        // Guard-trip may not fire if the tick happened to complete cleanly
+        // before stop(); this is a best-effort diagnostic check. Any
+        // guard-trip emission confirms the log exists and has the expected
+        // shape. When it does fire, it must carry the full guard object.
+        if (guardLines.length > 0) {
+          expect(guardLines.some((l) => l.includes('"stopped":true'))).to.equal(
+            true,
+            `expected stopped:true in guard-trip log; got: ${guardLines.join(' | ')}`,
+          );
+        }
+      });
+    });
+  });
+
+  describe('Bug 3 — CAN lease-extension math', () => {
+    it(
+      'post-CAN extended expiresAt covers the full negotiated lease (fails on pre-#249 main)',
+      async function () {
+        // This is the test that distinguishes pre-fix from post-fix:
+        //   - pre-#249 workflow: CAN extends `expiresAt` by a hardcoded 30_000ms
+        //   - post-#249 workflow: CAN extends by `currentAttachment.leaseMs`
+        //
+        // With `leaseMs=90_000` (well above 30_000) the post-fix extension gives
+        // the adapter ≥60s of runway past `now`, while pre-fix would only give
+        // ~30s. The assertion `remainingMs >= 60_000` rejects the legacy value.
+        //
+        // Stronger assertions per tempo-researcher flag 5: we also assert strict
+        // `>` on expiresAt progression from the pre-CAN value, guarding against
+        // an identity-function regression that happens to leave timestamps
+        // intact but doesn't actually extend them.
+        this.timeout(30_000);
+
+        await withWorker(async () => {
+          const handle = await startSession({
+            metadata: playerMetadata({ playerId: `can-lease-math-${Date.now()}` }),
+          });
+
+          try {
+            // Claim with a lease well above the pre-fix 30s hardcoded constant.
+            // Renewal on heartbeat refreshes `expiresAt` by `leaseMs`, so a healthy
+            // pre-CAN adapter ends up with expiresAt ≈ (heartbeat time + 90s).
+            const LEASE_MS = 90_000;
+            const token = await handle.executeUpdate(claimAttachmentUpdate, {
+              args: [{
+                host: 'test-host',
+                adapterId: 'claude-code',
+                adapterClass: 'interactive' as const,
+                leaseMs: LEASE_MS,
+              }],
+            });
+            expect(token.leaseMs).to.equal(LEASE_MS);
+
+            const preCan = await handle.query(attachmentInfoQuery);
+            expect(preCan.currentAttachment?.leaseMs).to.equal(LEASE_MS);
+            const preCanExpires = new Date(preCan.currentAttachment!.expiresAt).getTime();
+
+            // Force CAN via test-only signal. The workflow's CAN path calls
+            // `extendAttachmentForCAN(currentAttachment, currentAttachment.leaseMs, now)`
+            // on the post-fix branch, carrying the extended attachment into the
+            // new execution.
+            await handle.signal(testForceContinueAsNewSignal);
+
+            // Wait for the successor run (signaled implicitly: a fresh
+            // attachmentInfo query lands on the new run after CAN).
+            const postCan = await waitForAttachmentInfo(
+              handle,
+              (i) => !!i.currentAttachment && i.currentAttachment.attachmentId === token.attachmentId,
+              10_000,
+              'post-CAN attachment carried forward',
+            );
+
+            // AC #3: extension covers one full adapter heartbeat interval. With
+            // leaseMs=90s and post-fix math, remainingMs is ~90s (minus CAN
+            // transition latency). Pre-fix would give ~30s only — the `>= 60_000`
+            // assertion FAILS on pre-fix, PASSES on post-fix.
+            const postCanExpires = new Date(postCan.currentAttachment!.expiresAt).getTime();
+            const nowMs = Date.now();
+            const remainingMs = postCanExpires - nowMs;
+
+            expect(
+              remainingMs,
+              `post-CAN expiresAt should cover at least 60s past now; got ${remainingMs}ms ` +
+              `(pre-fix hardcoded 30_000 would yield ~30_000ms — this assertion rejects it)`,
+            ).to.be.at.least(60_000);
+
+            // Strict progression: the extension MUST push expiresAt past the
+            // pre-CAN value. Pre-fix with 30s extension + pre-CAN expiresAt at
+            // `heartbeat-time + 90s` would actually REDUCE expiresAt, which is
+            // another way this assertion rejects the legacy behavior.
+            expect(
+              postCanExpires,
+              `post-CAN expiresAt (${new Date(postCanExpires).toISOString()}) should be >= ` +
+              `pre-CAN expiresAt (${new Date(preCanExpires).toISOString()})`,
+            ).to.be.at.least(preCanExpires - 2_000); // 2s slack for wall-clock drift across CAN
+          } finally {
+            await handle.executeUpdate(destroyUpdate, { args: [{}] });
+            await handle.result().catch(() => { /* expected */ });
+          }
+        });
+      },
+    );
+  });
+});

--- a/test/workflows/can-boundary-extension.test.ts
+++ b/test/workflows/can-boundary-extension.test.ts
@@ -51,7 +51,7 @@ const NOW_ISO = '2026-04-01T12:31:15.000Z';
 
 describe('extendAttachmentForCAN (#127 — design §2.3)', function () {
   describe('happy path', () => {
-    it('sets lastHeartbeatAt to `now` and expiresAt to `now + heartbeatMs`', () => {
+    it('sets lastHeartbeatAt to `now` and expiresAt to `now + extendMs`', () => {
       const input = makeAttachment();
       const out = extendAttachmentForCAN(input, 30_000, NOW_MS);
 
@@ -111,14 +111,14 @@ describe('extendAttachmentForCAN (#127 — design §2.3)', function () {
       );
     });
 
-    it('accepts heartbeatMs = 0 (degenerate but not forbidden)', () => {
+    it('accepts extendMs = 0 (degenerate but not forbidden)', () => {
       const input = makeAttachment();
       const out = extendAttachmentForCAN(input, 0, NOW_MS);
       expect(out.lastHeartbeatAt).to.equal(NOW_ISO);
       expect(out.expiresAt).to.equal(NOW_ISO);
     });
 
-    it('accepts a very large heartbeatMs without overflow', () => {
+    it('accepts a very large extendMs without overflow', () => {
       // Temporal workflow heartbeatMs is bounded to 600_000 in practice, but
       // the pure function does not validate. Ensure arithmetic stays sane up
       // to at least ~year-2030 expiresAt.
@@ -137,10 +137,11 @@ describe('extendAttachmentForCAN (#127 — design §2.3)', function () {
   });
 
   describe('production call-site contract', () => {
-    it('models the session.ts invocation with HEARTBEAT_INTERVAL_MS = 30_000', () => {
-      // This mirrors the call site exactly — documents the expected
-      // production behavior so anyone reading the test can see what
-      // `session.ts` is doing without opening the workflow file.
+    it('legacy pre-#249 invocation: hardcoded HEARTBEAT_INTERVAL_MS = 30_000', () => {
+      // Documents the pre-#249 call shape — still reachable via the non-patched
+      // replay branch at `session.ts:1540` for histories that CAN'd before the
+      // #249 fix deployed. Preserved so a future refactor of the `patched()`
+      // gate doesn't silently break replay.
       const currentAttachment = makeAttachment({
         expiresAt: '2026-04-01T12:32:00.000Z', // 45s ahead of NOW_MS
       });
@@ -152,15 +153,49 @@ describe('extendAttachmentForCAN (#127 — design §2.3)', function () {
         NOW_MS,
       );
 
-      // New expiresAt is now + 30s = 2026-04-01T12:31:45.000Z — pushed out
-      // from the pre-call 2026-04-01T12:32:00.000Z by a net -15s? No:
-      // 12:31:15 + 30s = 12:31:45, which is actually 15 SECONDS EARLIER than
-      // the pre-call expiresAt. Document this: the extension floors to
-      // `now + heartbeatMs`, it does NOT take `max(current expiresAt,
-      // now + heartbeatMs)`. For the §2.3 use case (adapter was beating
-      // normally, pre-CAN expiresAt is at most ~2x heartbeatMs past now)
-      // this is fine — the new expiresAt guarantees a next heartbeat window.
+      // new expiresAt = now + 30s (NOT max(current, now+30s)) — documents the
+      // floor-to-extendMs semantic. For §2.3 this is fine because the adapter
+      // was beating normally pre-CAN (expiresAt ≤ ~2x heartbeatMs past now).
       expect(new Date(out.expiresAt).getTime()).to.equal(NOW_MS + 30_000);
+      expect(out.lastHeartbeatAt).to.equal(NOW_ISO);
+    });
+
+    it('post-#249 invocation: uses currentAttachment.leaseMs (claude-code = 180_000)', () => {
+      // #249 Bug 3: post-fix the session workflow passes `currentAttachment.leaseMs`
+      // (= 3 × heartbeatMs = 180_000 for claude-code) instead of the hardcoded 30_000
+      // constant. This test models the POST-fix call shape exactly so a regression
+      // that silently goes back to the legacy constant fails here.
+      //
+      // Assertions strengthened per tempo-researcher flag 5: equality on the exact
+      // extension value, and strict `>` on the expiresAt progression (guards against
+      // an identity-function regression that happens to leave lastHeartbeatAt fresh
+      // but leaves expiresAt unchanged).
+      const CLAUDE_CODE_HEARTBEAT_MS = 60_000;
+      const CLAUDE_CODE_LEASE_MS = 3 * CLAUDE_CODE_HEARTBEAT_MS; // 180_000
+      const preCanExpiresAt = '2026-04-01T12:32:00.000Z'; // 45s ahead of NOW_MS
+      const currentAttachment = makeAttachment({
+        leaseMs: CLAUDE_CODE_LEASE_MS,
+        expiresAt: preCanExpiresAt,
+      });
+
+      const out = extendAttachmentForCAN(
+        currentAttachment,
+        currentAttachment.leaseMs,
+        NOW_MS,
+      );
+
+      // Equality: new expiresAt = now + leaseMs exactly (not ≥ — stronger bound).
+      expect(new Date(out.expiresAt).getTime()).to.equal(NOW_MS + CLAUDE_CODE_LEASE_MS);
+      // Strict progression: the extension MUST push expiresAt forward from the
+      // pre-CAN value. 30_000 would have yielded 12:31:45 (earlier than 12:32:00);
+      // 180_000 yields 12:34:15. Pins the actual fix rather than just its floor.
+      expect(new Date(out.expiresAt).getTime()).to.be.greaterThan(
+        new Date(preCanExpiresAt).getTime(),
+      );
+      // Covers at least one full adapter heartbeat interval (AC #3 in #249).
+      expect(new Date(out.expiresAt).getTime() - NOW_MS).to.be.at.least(
+        CLAUDE_CODE_HEARTBEAT_MS,
+      );
       expect(out.lastHeartbeatAt).to.equal(NOW_ISO);
     });
   });


### PR DESCRIPTION
## Summary

Closes #249. Fixes four compounding bugs that cause silent adapter message-delivery failure, and adds diagnostic monitoring so recurrence is loud (not silent).

## The four bugs

1. **Heartbeat orphan** (`src/adapters/base.ts`) — `tickHeartbeat` early-return guards exited without rescheduling the next tick. Wrapped in try/finally; reschedule gate includes `!stopped && !reconnecting && !terminalFired`.
2. **Phase-watcher orphan parity** (`src/adapters/base.ts`) — same pattern applied to `tickPhaseWatcher` (independent loop, independent fix).
3. **CAN lease-extension math** (`src/workflows/session.ts`) — CAN-boundary extension now uses `currentAttachment.leaseMs` instead of hardcoded `HEARTBEAT_INTERVAL_MS = 30_000`. Gated behind `patched('v0.26-can-lease-from-attachment')` for deterministic replay of pre-#249 histories. Legacy constant retained for the pre-patch branch.
4. **Poller CAN-blindness** (`src/adapters/claude-code/adapter.ts`) — poller now classifies terminal workflow errors via the new shared `src/adapters/terminal-error.ts` module, logs `poll hit terminal workflow error — stopping`, exits cleanly, and relies on heartbeat tick's CAN-rebind path (`onReconnected`) to restart.

**Commit discipline**: Bug 4's option-b fix presumes Bugs 1+2 are fixed — if heartbeat orphan persists, rebind is a dead code path. **Revert together** if bisecting.

## Diagnostic monitoring (user-requested recurrence insurance)

- `first heartbeat scheduled in ${ms}ms` at end of `startV2Lifecycle`
- `heartbeat#1 delivered` one-shot after first successful tick (resets on CAN rebind + reconnect success, so a rebound loop re-fires it)
- `heartbeat guard tripped` with full state object `{stopped, reconnecting, hasHandle, hasToken, terminalFired}` on **every** early-return path (previously silent — this was the detection blindness)
- Periodic summary every 10 ticks (~10min for claude-code, ~5min for SDK)
- Phase-watcher staleness warning if `now - lastHeartbeatAt > 2 * heartbeatMs` (uses existing `attachmentInfoQuery.currentAttachment.lastHeartbeatAt`, no new wire-protocol)

## Files changed

- `src/adapters/base.ts` — try/finally + monitoring + counter reset on rebind
- `src/adapters/terminal-error.ts` — NEW, shared classifier
- `src/adapters/claude-code/adapter.ts` — poller uses shared classifier, explicit terminal log
- `src/workflows/session.ts` — patched CAN extension
- `src/workflows/attachment-math.ts` — parameter rename `heartbeatMs → extendMs` + JSDoc update
- `src/activities/outbox.ts` — comment reference update
- `test/heartbeat-trilogy.test.ts` — NEW integration test (orphan detection + CAN math)
- `test/workflows/can-boundary-extension.test.ts` — post-#249 unit test with equality + strict `>` assertions
- `CHANGELOG.md` — `### Fixed` entry

## Verification

- `npm run build` green
- `npm run build:test` green
- Vitest (tests/): **90/90 passing**
- Mocha non-Temporal suites: **25/25 passing** (includes new post-#249 CAN-math unit test)
- Mocha TestWorkflowEnvironment suites: blocked locally on Windows `os error 5` (ephemeral Temporal dev-server access-denied). Reproduces on plain `main` — **not caused by this PR**. CI (Linux) is the authority.
- `/simplify` triple-review: zero must-fix, zero should-fix

## Wire-protocol

**No changes.** Confirmed no edits to `src/workflows/signals.ts` or `scheduler-signals.ts`. Staleness warning reuses existing `attachmentInfoQuery.currentAttachment.lastHeartbeatAt`.

## Known non-testable acceptance criterion

AC #7 ("conductor idle 10+ min maintains `attached`/`awaiting`") cannot be validated by unit tests because the adapter's real-clock `setTimeout` does not respond to `TestWorkflowEnvironment` time-skip. **Will be validated by post-merge burn-in on `tempo-impl` or a dedicated staging ensemble.** QA: flag at review time.

## Live repro reference

Workflow `claude-session-tempo-impl-conductor`, run `0d17dc0f-90fb-487a-a068-0c1f1111ebc3` — 131 events, 0 heartbeats over ~65min. Post-merge, we'll re-parse this against the new monitoring lens to confirm retroactive explanation or flag a fifth-latent-bug hypothesis raised by architect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)