### PR TITLE
chore: bump version to v0.26.0-beta.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.0-beta.4] - 2026-04-19
+
+> **Beta release.** Closes the message-delivery trilogy (#249): heartbeat/watcher orphan fix,
+> CAN-boundary lease math correction, poller CAN-blindness fix, and full diagnostic observability.
+> Also includes TUI identity-guard fixes, outbox retry hardening, and wire-protocol cleanup.
+>
+> **Install:** `npm i -g claude-tempo@0.26.0-beta.4`
+> **Rollback:** `npm i -g claude-tempo@0.26.0-beta.3`
+
 ### Fixed
 
 - **Message-delivery trilogy — heartbeat/watcher orphan + CAN lease math +
@@ -186,6 +195,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
   as a Signal but declared as `defineQuery` in source will be caught as drift.
 - **`this.skip()` calls in test files now require a `// SKIP-REASON:` annotation** (#223). `scripts/lint-skip-reasons.js` scans `test/` and `tests/` and fails CI (as part of the `lint-test-ensemble` job) if any unannotated skip is found. Existing skips in `hard-terminate.test.ts` and `cli-crash-proof-isolation.test.ts` have been annotated.
 - **Scripts compiled from TypeScript to `dist/scripts/`** (#224). `scripts/run-shard.ts` and `scripts/verify-daemon-isolation-guard.ts` are now TypeScript sources; `npm run build:scripts` (included in `npm run build`) compiles them to `dist/scripts/`. Removes the fragile `!scripts/*.js` gitignore negation that would accidentally commit any future generated `.js` file. Invocation for the verification script: `npm run build:scripts && node dist/scripts/verify-daemon-isolation-guard.js`.
+- **`updateMetadata` signal no longer accepts `status?` field** (PR-H / #132, docs cleaned up in #252). The `status: 'terminated'` shim was retired in PR-H; `docs/WIRE-PROTOCOL.md` now reflects this. Use the `destroy` update for ordered session teardown.
 
 ## [0.26.0-beta.3] - 2026-04-18
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.3",
+  "version": "0.26.0-beta.4",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Release PR for v0.26.0-beta.4. See CHANGELOG.md for the consolidated entry.

**CHANGELOG [0.26.0-beta.4] contains:**
- Message-delivery trilogy fix (#249) — heartbeat/watcher orphan, CAN lease math, poller CAN-blindness + full diagnostic observability
- TUI identity guards for STATUS_SCROLL_UP + PICKER_UP (#244/#248)
- All post-beta.3 Changed entries: classifyAndRethrow extension (#236), kindFromSectionHeader allowlist (#239), phaseTag tightening + search-attribute helper (#203), CAN-boundary math extraction (#127), outbox retry (#140), restart constants (#139), wire-protocol drift detector (#126), this.skip annotations + TS scripts (#223/#224)
- updateMetadata status? field retirement note (PR-H/#132, docs cleanup #252)

**Tag after merge**: tag v0.26.0-beta.4 on the merge commit SHA, push → GitHub Actions publishes to npm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)