### PR TITLE
chore: post-beta.4 cleanup batch (#259, #251, #255 + adapter/ops/JSDoc doc fixes)

### DIFF
--- a/docs/ops/heartbeat-burnin.md
+++ b/docs/ops/heartbeat-burnin.md
@@ -35,26 +35,37 @@ claude-tempo up --lineup tempo-dev-team
 
 # 5. Check the conductor's attachment phase via the who_am_i tool
 #    (run inside the conductor's Claude Code session)
-#    Expect: Phase: attached
+#    Expect: Phase: attached OR Phase: awaiting
+#    (a healthy idle session that has not been cued recently sits in `awaiting`;
+#     `attached` and `awaiting` both satisfy AC #7 — the fail state is `detached`)
 
 # 6. Open Temporal UI → Workflows → filter by claudeSessionWorkflow
 #    Select the conductor's workflow. In Event History:
 #    - heartbeat signal events should appear roughly every 60s
 #    - no adapterExited or forceDetach events
 
-# 7. Grep the daemon log for heartbeat breadcrumbs
-grep "heartbeats-delivered=" ~/.claude-tempo/daemon.log | tail -5
-# Expect at least one line with N >= 10 after 10+ minutes of idle
+# 7. From a second Claude Code session in the same ensemble, inspect the
+#    conductor's attachment with the `attachment_info` MCP tool:
+#    attachment_info({ playerId: "<conductor-name>" })
+#    Expect:
+#      - phase: `attached` or `awaiting`
+#      - `lease expires` timestamp in the future (should advance by ~60s each
+#        time the adapter heartbeats — run twice 60s apart to confirm progression)
+#      - `in-flight messages: 0`
+#    The adapter breadcrumbs (`heartbeats-delivered=N`) land on the per-session
+#    Claude Code stderr stream, NOT `~/.claude-tempo/daemon.log` (the daemon
+#    logs only carry daemon-side worker logs). Lease progression is the
+#    authoritative durable signal that the adapter loop is live.
 ```
 
 ---
 
 ## Pass criteria
 
-- `who_am_i` reports **`Phase: attached`** (not `detached`, `draining`, or `disconnected`)
+- `who_am_i` reports **`Phase: attached`** or **`Phase: awaiting`** (not `detached`, `draining`, or `disconnected` — both `attached` and `awaiting` satisfy AC #7 from #249)
 - Temporal UI shows `heartbeat` signal events at the expected cadence (~1/60s for `claude-code`)
 - No `adapterExited` or `forceDetach` events in the conductor's workflow history
-- Daemon log contains at least one `heartbeats-delivered=N` line with **N ≥ 10** after 10+ minutes
+- `attachment_info` shows `lease expires` advancing between samples taken ~60s apart — the durable proof that the adapter heartbeat loop is extending the lease on each tick
 
 ---
 
@@ -62,11 +73,11 @@ grep "heartbeats-delivered=" ~/.claude-tempo/daemon.log | tail -5
 
 | Symptom | What it means |
 |---------|---------------|
-| `Phase: detached` + **no** `heartbeat guard tripped` in daemon log | A tick-orphan path the #249 fix didn't cover — or a new latent bug. Escalate to research. |
-| `Phase: detached` + `heartbeat guard tripped` in daemon log | A guard path triggered that the fix should have handled; the rescheduling logic missed a case. Reopen #249. |
-| `Phase: attached` but heartbeat signal count not incrementing in Temporal UI | Heartbeat signal is not reaching the workflow (push-path bug); separate from #249's tick-orphan fix. |
-| `adapterExited` event in workflow history | The adapter process died — check `~/.claude-tempo/daemon.log` for a crash or OS kill near the timestamp. |
-| `WARNING: heartbeat staleness` in daemon log | Phase-watcher fired before lease reap — heartbeat loop is alive but running late. Investigate scheduler pressure or system sleep. |
+| `Phase: detached` + **no** `heartbeat guard tripped` in per-session Claude Code stderr | A tick-orphan path the #249 fix didn't cover — or a new latent bug. Escalate to research. |
+| `Phase: detached` + `heartbeat guard tripped` in per-session Claude Code stderr | A guard path triggered that the fix should have handled; the rescheduling logic missed a case. Reopen #249. |
+| `Phase: attached` or `awaiting` but `attachment_info` lease expiry not advancing between samples | Heartbeat signal is not reaching the workflow (push-path bug); separate from #249's tick-orphan fix. |
+| `adapterExited` event in workflow history | The adapter process died — check the per-session Claude Code terminal for a crash or OS kill near the timestamp. |
+| `WARNING: heartbeat staleness` in per-session Claude Code stderr | Phase-watcher fired before lease reap — heartbeat loop is alive but running late. Investigate scheduler pressure or system sleep. |
 
 ---
 

--- a/src/adapters/base.ts
+++ b/src/adapters/base.ts
@@ -119,7 +119,7 @@ export abstract class BaseAttachment {
   private firstHeartbeatLogged = false;
   /**
    * Monotonic heartbeat counter for the current attachment cycle. Reset on
-   * claim/reconnect/CAN-rebind. Emitted periodically (every {@link HEARTBEAT_SUMMARY_EVERY}
+   * claim/reconnect/CAN-rebind. Emitted periodically (every {@link LOOP_SUMMARY_EVERY}
    * ticks) so a long-running session leaves breadcrumbs in the log proving the loop is
    * alive — operators can `grep 'heartbeats-delivered='` to confirm health without
    * parsing Temporal history. Added in #249.

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -22,7 +22,7 @@ import { shouldIncludeInBroadcast, validateEnsembleName } from '../utils/validat
 import { getAttachmentPhase, getEnsembleName } from '../utils/search-attributes';
 import { isDaemonRunning, startDaemon, stopDaemon, getDaemonStatus, DAEMON_LOG_PATH } from './daemon';
 import { createTempoClient } from '../client';
-import { ensembleReadyBanner, ensembleReadyDirective } from '../constants';
+import { ENSEMBLE_SENTINEL_FLAG, ensembleReadyBanner, ensembleReadyDirective } from '../constants';
 import * as out from './output';
 
 /** Package root is two levels up from dist/cli/ */
@@ -278,6 +278,10 @@ async function applyLineupPlayersAndSchedules(args: {
         const claudeArgs = [
           '--dangerously-skip-permissions',
           '--dangerously-load-development-channels', 'server:claude-tempo',
+          // ENSEMBLE_SENTINEL_FLAG carries the ensemble name into the spawned
+          // claude.exe's CommandLine so hard-terminate can scope `destroy --all`
+          // kills by ensemble (#180, #259). Mirrors src/activities/outbox.ts.
+          ENSEMBLE_SENTINEL_FLAG, ensemble,
           '-n', player.name,
           ...(resolvedPlayerType?.nativeResolvable ? ['--agent', resolvedPlayerType.name] :
               resolvedPlayerType ? ['--system-prompt', resolvedPlayerType.path] : []),
@@ -524,6 +528,10 @@ export async function start(opts: StartOpts) {
     const claudeArgs = [
       '--dangerously-skip-permissions',
       '--dangerously-load-development-channels', 'server:claude-tempo',
+      // ENSEMBLE_SENTINEL_FLAG carries the ensemble name into the spawned
+      // claude.exe's CommandLine so hard-terminate can scope `destroy --all`
+      // kills by ensemble (#180, #259). Mirrors src/activities/outbox.ts.
+      ENSEMBLE_SENTINEL_FLAG, opts.ensemble,
     ];
     if (opts.resume && sessionName) {
       // Resume the previous Claude Code conversation by name
@@ -1249,6 +1257,10 @@ export async function up(opts: UpOpts) {
     const claudeArgs = [
       '--dangerously-skip-permissions',
       '--dangerously-load-development-channels', 'server:claude-tempo',
+      // ENSEMBLE_SENTINEL_FLAG carries the ensemble name into the spawned
+      // claude.exe's CommandLine so hard-terminate can scope `destroy --all`
+      // kills by ensemble (#180, #259). Mirrors src/activities/outbox.ts.
+      ENSEMBLE_SENTINEL_FLAG, opts.ensemble,
       '-n', sessionName,
       ...(resolvedConductorType?.nativeResolvable ? ['--agent', resolvedConductorType.name] :
           resolvedConductorType ? ['--system-prompt', resolvedConductorType.path] :

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -1557,11 +1557,23 @@ export async function claudeSessionWorkflow(input: SessionInput): Promise<void> 
       // runs that CAN *after* the deploy) take the patched branch.
       //
       // Math lives in `./attachment-math.ts` for direct unit testability (#127).
-      const extendMs = patched('v0.26-can-lease-from-attachment')
-        ? currentAttachment?.leaseMs ?? HEARTBEAT_INTERVAL_MS
-        : HEARTBEAT_INTERVAL_MS;
+      //
+      // #255 cleanup: the `patched()` call stays at the eager/unconditional
+      // position it was introduced in — relocating it inside the
+      // `currentAttachment ?` branch would skip marker recording on histories
+      // that hit the CAN site with a null attachment, risking replay
+      // non-determinism against those recordings. The dead-code cleanup is
+      // strictly the removal of the `?? HEARTBEAT_INTERVAL_MS` fallback that
+      // used to sit inside the ternary: on the patched branch it never fires
+      // (Attachment.leaseMs is required), and on the pre-patched branch the
+      // fallback is replaced by the bare constant — same value either way.
+      const usePatchedLease = patched('v0.26-can-lease-from-attachment');
       const extendedAttachment = currentAttachment
-        ? extendAttachmentForCAN(currentAttachment, extendMs, workflowNow().getTime())
+        ? extendAttachmentForCAN(
+            currentAttachment,
+            usePatchedLease ? currentAttachment.leaseMs : HEARTBEAT_INTERVAL_MS,
+            workflowNow().getTime(),
+          )
         : undefined;
 
       await continueAsNew<typeof claudeSessionWorkflow>({

--- a/src/workflows/signals.ts
+++ b/src/workflows/signals.ts
@@ -60,7 +60,12 @@ export type {
 
 // ── Player Signals ──
 
-export const receiveMessageSignal = defineSignal<[{ from: string; text: string; isMaestro?: boolean; responseRequested?: boolean }]>('receiveMessage');
+// `isScheduled` + `scheduleName` are set by `src/activities/schedule-fire.ts`
+// when the message originated from the scheduler workflow — allows dashboards
+// and consumers to distinguish scheduled fires from direct cues. Documented in
+// docs/WIRE-PROTOCOL.md; runtime senders have populated both fields since the
+// scheduler shipped, but the TS type drifted (#251). Optional everywhere.
+export const receiveMessageSignal = defineSignal<[{ from: string; text: string; isMaestro?: boolean; isScheduled?: boolean; scheduleName?: string; responseRequested?: boolean }]>('receiveMessage');
 export const recordSentMessageSignal = defineSignal<[{ to: string; text: string }]>('recordSentMessage');
 export const setPartSignal = defineSignal<[string]>('setPart');
 export const markDeliveredSignal = defineSignal<[string[]]>('markDelivered');

--- a/test/cli-spawn-sentinel.test.ts
+++ b/test/cli-spawn-sentinel.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Regression test for #259 — every CLI spawn path that launches `claude.exe`
+ * must include `ENSEMBLE_SENTINEL_FLAG <ensemble>` in its argv, so that the
+ * hard-terminate path (src/activities/hard-terminate.ts) can scope
+ * `destroy --all` kills by ensemble (#180).
+ *
+ * The bug caught by #259 was that `src/cli/commands.ts` had three
+ * `claudeArgs` builders (one per spawn site: `up` player, standalone
+ * conduct, `up` conductor) that drifted from the correct pattern in
+ * `src/activities/outbox.ts` and omitted the sentinel entirely — making
+ * `destroy` a silent no-op for every `up`-spawned process.
+ *
+ * This test is intentionally structural (it reads the source file and
+ * inspects each builder) rather than runtime — exercising the CLI spawn
+ * paths at runtime would require booting Temporal and actually spawning
+ * processes. The invariant being guarded is a drift-prevention one:
+ * "every claudeArgs builder in commands.ts contains ENSEMBLE_SENTINEL_FLAG",
+ * which is exactly what a source-level test asserts.
+ */
+import { expect } from 'chai';
+import { readFileSync } from 'fs';
+import * as path from 'path';
+import { ENSEMBLE_SENTINEL_FLAG } from '../src/constants';
+
+// `__dirname` at runtime is `<repo>/dist-test/test` (Mocha runs the compiled
+// JS), so `../..` reaches the repo root where `src/` actually lives. Same
+// trick `test/wire-protocol.test.ts` uses for its docs-drift assertions.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+
+describe('CLI spawn sentinel (#259)', function () {
+  it('ENSEMBLE_SENTINEL_FLAG has the value hard-terminate greps for', function () {
+    expect(ENSEMBLE_SENTINEL_FLAG).to.equal('--remote-control-session-name-prefix');
+  });
+
+  it('every claudeArgs builder in src/cli/commands.ts carries ENSEMBLE_SENTINEL_FLAG', function () {
+    const src = readFileSync(path.join(REPO_ROOT, 'src', 'cli', 'commands.ts'), 'utf8');
+    const builders = [...src.matchAll(/const claudeArgs = \[([\s\S]*?)\];/g)];
+    expect(builders.length).to.be.at.least(
+      3,
+      `expected ≥3 claudeArgs builders in src/cli/commands.ts (up player + conduct + up conductor); found ${builders.length}`,
+    );
+    for (let i = 0; i < builders.length; i++) {
+      const body = builders[i][1];
+      expect(body).to.include(
+        'ENSEMBLE_SENTINEL_FLAG',
+        `claudeArgs builder #${i + 1} in src/cli/commands.ts is missing ENSEMBLE_SENTINEL_FLAG — hard-terminate would be a no-op for processes spawned from this path. See #259.`,
+      );
+    }
+  });
+
+  it('the recruit-path spawn (src/activities/outbox.ts) also carries the sentinel (regression guard for drift the other way)', function () {
+    const src = readFileSync(path.join(REPO_ROOT, 'src', 'activities', 'outbox.ts'), 'utf8');
+    expect(src).to.include(
+      'ENSEMBLE_SENTINEL_FLAG',
+      'recruit path lost ENSEMBLE_SENTINEL_FLAG — this was the pattern the CLI paths were supposed to mirror (#180).',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Post-v0.26.0-beta.4 cleanup batch. Five logical commits bundled into one PR because every item is small, mechanical, and independent.

### Fixes
- **#259** — `fix(cli)`: add `ENSEMBLE_SENTINEL_FLAG` to all three `up`-spawn `claudeArgs` builders in `src/cli/commands.ts`. Without the flag, `destroy`'s hard-terminate is a silent no-op against `up`-spawned sessions (spawn path diverged from `conduct` and recruit-outbox, which set the sentinel). New regression test in `test/cli-spawn-sentinel.test.ts` asserts every spawn path carries the sentinel; spot-revert confirmed the test goes red on pre-fix code.
- **#251** — `fix(signals)`: align `receiveMessageSignal` TypeScript type with its documented payload (`isScheduled?: boolean` + `scheduleName?: string`). Purely additive — no wire-protocol rename or removal. `docs/WIRE-PROTOCOL.md` already documented both fields.
- **#255** — `chore(session)`: remove the now-dead `?? HEARTBEAT_INTERVAL_MS` fallback on the patched CAN-lease branch in `src/workflows/session.ts`. After #254 (closes #249), `currentAttachment.leaseMs` is the authoritative lease source on that branch. The `patched('v0.26-can-lease-from-attachment')` call remains at its unconditional position to preserve replay safety; `HEARTBEAT_INTERVAL_MS` constant is retained for the pre-patched history replay path.

### Doc / JSDoc
- `docs(adapter)`: `src/adapters/base.ts:122` JSDoc `{@link}` corrected — `HEARTBEAT_SUMMARY_EVERY` → `LOOP_SUMMARY_EVERY`.
- `docs(ops)`: `docs/ops/heartbeat-burnin.md` — step 5 pass criterion now accepts `attached` OR `awaiting` per AC #7 from #249 (a 10-min-idle session sits in `awaiting`). Step 7 replaces the incorrect `grep ~/.claude-tempo/daemon.log` instruction with an `attachment_info` lease-progression check, since adapter breadcrumbs emit from per-session Claude Code stderr rather than the shared daemon log. Fail-symptoms table updated to match.

### No-op note
- The original batch brief included doc-drift items for `CLAUDE.md` and `README.md` from a stale pre-#256 audit. Those items were verified as already-correct on HEAD (`66d2a5f`) — `connection.ts`/`constants.ts`/`spawn.ts`/`worker.ts` are present in the project-structure block at lines 42–45; `listen.ts` is present in the tools listing at line 65; the README section is already titled `## CLI` with no `Command Discovery` string anywhere in the repo. No commits for those items.

## Test plan

- [x] `npm run build` — clean
- [x] Mocha 838 pass / 22 pending / 0 fail (full local suite)
- [x] Vitest 91 pass / 0 fail
- [x] Targeted replay tests (`can-boundary | heartbeat-trilogy | attachment-math`) — 17 passing
- [x] #259 spot-revert check — new regression test goes red on pre-fix code, green on post-fix code
- [x] #255 `patched()` position verified unchanged (eager, unconditional, pre-`currentAttachment ?` branch)
- [x] Stray-debug scan — zero matches
- [ ] CI matrix (shard × Node) — pending this PR

Closes #259
Closes #251
Closes #255