### PR TITLE
feat(cli): add attachment-info heartbeat age + formatter refactor (#138)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ claude-tempo up [ensemble]      # first-time setup
 claude-tempo conduct [ensemble] # start a conductor
 claude-tempo start [ensemble]   # start a player
 claude-tempo status [ensemble]  # list active sessions
+claude-tempo attachment-info <name> # inspect a session's phase, holder, lease, and heartbeat age
 claude-tempo release [ensemble] # release held players (unlock + deliver tasks)
 claude-tempo pause [ensemble]   # pause all sessions and the scheduler
 claude-tempo resume [ensemble]  # resume a paused ensemble (--release also releases held players)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -23,7 +23,7 @@ claude-tempo <command> [options]
 | `detach <name>` | Gracefully detach the adapter for a session — triggers draining and clean handoff. Use when migrating a session to another host. |
 | `destroy <name>` | Terminate a session's workflow — ordered shutdown via outbox drain. Use for permanent removal. |
 | `migrate <name>` | Move a session to a different host — sugar for `setPreferredHost` + `restart` on the target machine. Use `--to <hostname>`. |
-| `attachment-info <name>` | Inspect the attachment phase, current holder, lease expiry, and in-flight message count for a session. |
+| `attachment-info <name>` | Inspect a session's attachment phase, current holder, lease expiry, heartbeat age, and in-flight message count. |
 | `restore [name]` | **v0.25.** Restore orphaned (detached) sessions. Interactive picker by default; `--all` restores every orphan, `--from-host <hostname>` filters by preferred host, `--dry-run` lists without restoring. |
 | `release [ensemble]` | Release all held players — unlocks outboxes and delivers deferred task messages. Use `-n <name>` to release one player. |
 | `pause [ensemble]` | Pause the ensemble — locks all session outbox dispatch and pauses the scheduler. |

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -12,7 +12,7 @@ import { createTemporalConnection } from '../connection';
 import { playerReportSignal, updateMetadataSignal, releaseHeldSignal, outboxLockedQuery, setPausedSignal, destroyUpdate } from '../workflows/signals';
 import { addScheduleSignal, setSchedulerPausedSignal } from '../workflows/scheduler-signals';
 import { maestroSetPausedSignal } from '../workflows/maestro-signals';
-import { AgentType, ScheduleEntry, SessionInput, SessionMetadata } from '../types';
+import { AgentType, AttachmentInfo, ScheduleEntry, SessionInput, SessionMetadata } from '../types';
 import { runPreflight } from './preflight';
 import { isGlobalMcpRegistered, addGlobalMcp, removeGlobalMcp, isMcpConfigured } from './mcp';
 import { loadLineup, resolveLineupPath } from '../ensemble/loader';
@@ -2268,21 +2268,55 @@ export async function migrate(opts: MigrateCliOpts) {
   }
 }
 
+/**
+ * Render `claude-tempo attachment-info <name>` output as an array of plain
+ * strings. Pure — no Temporal, no stdout, no ANSI colors — so unit tests can
+ * assert exact lines without booting a client (#138).
+ *
+ * `now` is injected (defaults to `Date.now()`) so tests can freeze the clock
+ * and assert the heartbeat-age string deterministically. Heartbeat age uses
+ * the same `formatDurationMs` helper the scheduler output uses, suffixed with
+ * "ago" — e.g. `5s ago`, `2m ago`. Clock-skew (heartbeat timestamp in the
+ * future) renders as `just now`; a malformed timestamp renders as `unknown`.
+ */
+export function formatAttachmentInfoForCli(
+  name: string,
+  info: AttachmentInfo,
+  now: number = Date.now(),
+): string[] {
+  const lines: string[] = [
+    `${name} — phase: ${info.phase}`,
+    `  in-flight: ${info.inFlightCount}`,
+  ];
+  if (info.currentAttachment) {
+    const a = info.currentAttachment;
+    lines.push(`  attached on: ${a.hostname} (adapter: ${a.adapterId}/${a.adapterClass})`);
+    lines.push(`  attachmentId: ${a.attachmentId}`);
+    lines.push(`  lease expires: ${a.expiresAt}`);
+    lines.push(`  heartbeat: ${formatHeartbeatAge(a.lastHeartbeatAt, now)}`);
+  }
+  if (info.preferredHost) lines.push(`  preferred host: ${info.preferredHost}`);
+  if (info.processingSince) lines.push(`  processing since: ${info.processingSince}`);
+  return lines;
+}
+
+function formatHeartbeatAge(lastHeartbeatAt: string, now: number): string {
+  const then = Date.parse(lastHeartbeatAt);
+  if (!Number.isFinite(then)) return 'unknown';
+  const ageMs = now - then;
+  if (ageMs < 0) return 'just now'; // adapter clock ran ahead of ours — degrade gracefully
+  return `${formatDurationMs(ageMs)} ago`;
+}
+
 export async function attachmentInfo(opts: VerbOpts) {
   const { config, connection, client } = await verbClient(opts);
   const ensemble = opts.ensemble || config.ensemble;
   try {
     const tempo = createTempoClient(client);
     const info = await tempo.attachmentInfo(ensemble, opts.name);
-    out.log(`${out.bold(opts.name)} — phase: ${out.cyan(info.phase)}`);
-    out.log(`  in-flight: ${info.inFlightCount}`);
-    if (info.currentAttachment) {
-      out.log(`  attached on: ${info.currentAttachment.hostname} (adapter: ${info.currentAttachment.adapterId}/${info.currentAttachment.adapterClass})`);
-      out.log(`  attachmentId: ${info.currentAttachment.attachmentId}`);
-      out.log(`  lease expires: ${info.currentAttachment.expiresAt}`);
+    for (const line of formatAttachmentInfoForCli(opts.name, info)) {
+      out.log(line);
     }
-    if (info.preferredHost) out.log(`  preferred host: ${info.preferredHost}`);
-    if (info.processingSince) out.log(`  processing since: ${info.processingSince}`);
   } catch (err: any) {
     out.error(err?.message || String(err));
     process.exit(1);

--- a/test/cli-attachment-info.test.ts
+++ b/test/cli-attachment-info.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for the `claude-tempo attachment-info <name>` CLI command's
+ * pure formatter (#138). Tests the extracted `formatAttachmentInfoForCli`
+ * helper directly so no Temporal connection or TempoClient is required.
+ *
+ * Covers:
+ *   - Happy path: currentAttachment present → all fields including heartbeat
+ *     age render correctly.
+ *   - Detached: no currentAttachment → only phase + in-flight lines (no
+ *     attachment-specific fields).
+ *   - Optional fields populated: preferredHost + processingSince appear as
+ *     extra lines in the expected order.
+ *   - Heartbeat age edge cases:
+ *       · clock-skew (lastHeartbeatAt > now) → "just now"
+ *       · malformed timestamp → "unknown"
+ *
+ * "Not-found" (session doesn't exist) is handled by the CLI wrapper's
+ * try/catch → out.error → process.exit(1) path, mirroring sibling verbs
+ * restart/detach/destroy/migrate. No dedicated test for that path here —
+ * it would require mocking TempoClient, which no other CLI verb tests, and
+ * the formatter itself is what #138's AC is about.
+ */
+import { expect } from 'chai';
+import { formatAttachmentInfoForCli } from '../src/cli/commands';
+import type { AttachmentInfo } from '../src/types';
+
+// Frozen "now" so heartbeat-age strings are deterministic across CI runs.
+const NOW = Date.parse('2026-04-19T12:00:00.000Z');
+
+describe('formatAttachmentInfoForCli (#138)', function () {
+  it('happy path: attached session — renders all core fields + heartbeat age', function () {
+    const info: AttachmentInfo = {
+      phase: 'attached',
+      inFlightCount: 0,
+      currentAttachment: {
+        attachmentId: 'att-abc123',
+        hostname: 'main-laptop',
+        adapterId: 'claude-code',
+        adapterClass: 'interactive',
+        claimedAt: '2026-04-19T11:55:00.000Z',
+        lastHeartbeatAt: '2026-04-19T11:59:30.000Z', // 30s before NOW
+        expiresAt: '2026-04-19T12:02:30.000Z',
+        leaseMs: 180_000,
+        runId: 'run-xyz',
+      },
+    };
+    expect(formatAttachmentInfoForCli('tempo-eng', info, NOW)).to.deep.equal([
+      'tempo-eng — phase: attached',
+      '  in-flight: 0',
+      '  attached on: main-laptop (adapter: claude-code/interactive)',
+      '  attachmentId: att-abc123',
+      '  lease expires: 2026-04-19T12:02:30.000Z',
+      '  heartbeat: 30s ago',
+    ]);
+  });
+
+  it('detached session: no currentAttachment — only phase + in-flight lines render', function () {
+    const info: AttachmentInfo = {
+      phase: 'detached',
+      inFlightCount: 0,
+    };
+    expect(formatAttachmentInfoForCli('tempo-eng', info, NOW)).to.deep.equal([
+      'tempo-eng — phase: detached',
+      '  in-flight: 0',
+    ]);
+  });
+
+  it('attached with preferredHost + processingSince — extras appended in order', function () {
+    const info: AttachmentInfo = {
+      phase: 'processing',
+      inFlightCount: 2,
+      currentAttachment: {
+        attachmentId: 'att-def456',
+        hostname: 'remote-box',
+        adapterId: 'copilot',
+        adapterClass: 'sdk',
+        claimedAt: '2026-04-19T11:50:00.000Z',
+        lastHeartbeatAt: '2026-04-19T11:58:00.000Z', // 2m before NOW
+        expiresAt: '2026-04-19T12:04:00.000Z',
+        leaseMs: 360_000,
+        runId: 'run-abc',
+      },
+      preferredHost: 'remote-box',
+      processingSince: '2026-04-19T11:59:45.000Z',
+    };
+    expect(formatAttachmentInfoForCli('tempo-eng', info, NOW)).to.deep.equal([
+      'tempo-eng — phase: processing',
+      '  in-flight: 2',
+      '  attached on: remote-box (adapter: copilot/sdk)',
+      '  attachmentId: att-def456',
+      '  lease expires: 2026-04-19T12:04:00.000Z',
+      '  heartbeat: 2m ago',
+      '  preferred host: remote-box',
+      '  processing since: 2026-04-19T11:59:45.000Z',
+    ]);
+  });
+
+  it('heartbeat age: clock skew (adapter ran ahead of us) renders as "just now"', function () {
+    const info: AttachmentInfo = {
+      phase: 'attached',
+      inFlightCount: 0,
+      currentAttachment: {
+        attachmentId: 'att-1',
+        hostname: 'h',
+        adapterId: 'claude-code',
+        adapterClass: 'interactive',
+        claimedAt: NOW_ISO(-5_000),
+        lastHeartbeatAt: NOW_ISO(+500), // 500ms in the future
+        expiresAt: NOW_ISO(+180_000),
+        leaseMs: 180_000,
+        runId: 'run-1',
+      },
+    };
+    const lines = formatAttachmentInfoForCli('p', info, NOW);
+    expect(lines).to.include('  heartbeat: just now');
+  });
+
+  it('heartbeat age: malformed timestamp renders as "unknown" (defensive)', function () {
+    const info: AttachmentInfo = {
+      phase: 'attached',
+      inFlightCount: 0,
+      currentAttachment: {
+        attachmentId: 'att-1',
+        hostname: 'h',
+        adapterId: 'claude-code',
+        adapterClass: 'interactive',
+        claimedAt: '2026-04-19T11:00:00.000Z',
+        lastHeartbeatAt: 'not-a-valid-timestamp',
+        expiresAt: '2026-04-19T13:00:00.000Z',
+        leaseMs: 180_000,
+        runId: 'run-1',
+      },
+    };
+    const lines = formatAttachmentInfoForCli('p', info, NOW);
+    expect(lines).to.include('  heartbeat: unknown');
+  });
+});
+
+/** ISO timestamp at NOW + `offsetMs`, for building fixtures relative to the frozen clock. */
+function NOW_ISO(offsetMs: number): string {
+  return new Date(NOW + offsetMs).toISOString();
+}


### PR DESCRIPTION
## Summary

- Closes the `heartbeat age` gap on `claude-tempo attachment-info <name>` (#138 AC listed it; PR #136 shipped the command without it).
- Extracts a pure `formatAttachmentInfoForCli(name, info, now)` from the inline rendering so the output is unit-testable without booting Temporal.
- Adds `test/cli-attachment-info.test.ts` — first CLI-level test in the sibling group (restart/detach/destroy/migrate were all previously uncovered; this sets the testable pattern).
- Updates `docs/cli.md` + `README.md` `## CLI` block to mention the new field.

Closes #138.

## Scope discipline

Per the conductor brief: **no** behavior change on `TempoClient.getAttachmentInfo`, **no** MCP-tool edits, **no** new env vars. Pure extraction + one new output field + test + README line. TUI rendering is unchanged (noted as a latent inconsistency follow-up — out of scope here).

## Output example

```
tempo-eng — phase: attached
  in-flight: 0
  attached on: main-laptop (adapter: claude-code/interactive)
  attachmentId: att-abc123
  lease expires: 2026-04-19T12:02:30.000Z
  heartbeat: 30s ago
```

`heartbeat: just now` on clock-skew, `heartbeat: unknown` on malformed timestamp — both defensive.

## Test plan

- [x] `npm run build` clean (TypeScript + workflow bundle)
- [x] `npm run build:test` clean
- [x] `npx mocha --grep formatAttachmentInfoForCli` → 5 passing
- [x] Spot-revert RED→GREEN: removed the `heartbeat` line from the formatter → 4 tests failed with diff mismatches; restored → 5 passing
- [ ] CI 6-job matrix (shard-{1,2} × node-{20,22,24} + TUI + lint-commits + lint-test-ensemble) — waiting on CI