### PR TITLE
fix(worktree): repoint HEAD on reuse with different branch (#261)

### DIFF
--- a/src/tools/worktree.ts
+++ b/src/tools/worktree.ts
@@ -94,7 +94,26 @@ export function registerWorktreeTool(
               }],
             });
 
-            return ok(`Worktree created for **${player}**:\n- Path: \`${result.path}\`\n- Branch: \`${result.branch}\`\n- Created: ${result.created ? 'new' : 'reused existing'}\n\nPlayer has been notified.`);
+            // #261: when we reused an existing worktree directory, surface the
+            // actual state transition (same branch / switched / created-from-main)
+            // so the conductor sees ground truth instead of the prior silent
+            // "reused existing" that implied the worktree was already on the
+            // requested branch.
+            const createdLabel = result.created
+              ? 'new'
+              : (() => {
+                  switch (result.switched) {
+                    case 'same':
+                      return `reused existing (already on \`${result.branch}\`)`;
+                    case 'switched':
+                      return `reused existing (switched to \`${result.branch}\`)`;
+                    case 'created-from-main':
+                      return `reused existing (created \`${result.branch}\` from origin/main)`;
+                    default:
+                      return 'reused existing';
+                  }
+                })();
+            return ok(`Worktree created for **${player}**:\n- Path: \`${result.path}\`\n- Branch: \`${result.branch}\`\n- Created: ${createdLabel}\n\nPlayer has been notified.`);
           }
 
           case 'remove': {

--- a/src/utils/worktree.ts
+++ b/src/utils/worktree.ts
@@ -26,6 +26,19 @@ export interface CreateWorktreeOpts {
   branch?: string;
 }
 
+/**
+ * Tag returned by {@link switchWorktreeToBranch} and surfaced on
+ * {@link CreateWorktreeResult.switched} so the MCP tool's response text can
+ * report the actual state transition instead of silently reusing the request
+ * as ground truth (#261). Values:
+ *
+ * - `same` — the worktree was already on the requested branch. No-op.
+ * - `switched` — the requested branch existed locally; plain `git checkout`.
+ * - `created-from-main` — the requested branch did not exist locally;
+ *   created it off `origin/main` via `git checkout -b`.
+ */
+export type WorktreeSwitchResult = 'same' | 'switched' | 'created-from-main';
+
 export interface CreateWorktreeResult {
   /** Absolute path to the worktree directory. */
   path: string;
@@ -33,11 +46,114 @@ export interface CreateWorktreeResult {
   branch: string;
   /** Whether the worktree was newly created (false if it already existed). */
   created: boolean;
+  /**
+   * When `created === false` (reuse path), which git operation the helper ran
+   * to bring the worktree onto the requested branch. `undefined` on fresh
+   * creation — the #261 information is only meaningful for reuse.
+   */
+  switched?: WorktreeSwitchResult;
+}
+
+/**
+ * Ensure the worktree at `wtPath` is checked out on `targetBranch`.
+ *
+ * Fix for #261: the prior reuse path returned the *requested* branch name in
+ * its result without ever consulting the worktree's actual HEAD, silently
+ * papering over mismatches when a worktree from a prior task was recycled for
+ * a new branch. This helper does the repointing that was missing — and
+ * refuses (rather than silently discarding) if the target worktree has
+ * uncommitted work on a different branch.
+ *
+ * Decision tree (mirrors the conductor's guidance on #261):
+ *   1. current branch === targetBranch        → no-op, return `'same'`. The
+ *      hot path. Deliberately does NOT run `status --porcelain`: if we're
+ *      not flipping the branch, dirty work is fine.
+ *   2. `git status --porcelain` non-empty     → throw `"uncommitted changes"`
+ *      with path + current branch. Must precede any checkout so we never
+ *      silently discard work on a branch flip.
+ *   3. target branch exists locally           → `git checkout <target>`.
+ *      Preserves the branch's recorded state; no `-B`, no force-reset.
+ *   4. target branch does not exist locally   → `git checkout -b <target> origin/main`.
+ *      Matches the semantics of the fresh-worktree `git worktree add -B`
+ *      path — new branch rooted at the current main tip.
+ *
+ * Caller is expected to have already verified `wtPath` is an existing git
+ * worktree (this helper runs the git commands with `-C <wtPath>` and does no
+ * path-existence checks of its own).
+ */
+export function switchWorktreeToBranch(
+  wtPath: string,
+  targetBranch: string,
+): WorktreeSwitchResult {
+  const current = execFileSync('git', ['-C', wtPath, 'branch', '--show-current'], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+
+  if (current === targetBranch) {
+    log(`Worktree at "${wtPath}" already on "${targetBranch}" — no-op`);
+    return 'same';
+  }
+
+  // Branch mismatch → dirty-tree guard before any checkout. `--porcelain`
+  // emits one line per change with no color/decoration; empty output means
+  // the working tree + index are clean (ignored files don't count).
+  const dirty = execFileSync('git', ['-C', wtPath, 'status', '--porcelain'], {
+    encoding: 'utf8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+  if (dirty.trim().length > 0) {
+    throw new Error(
+      `Worktree at "${wtPath}" has uncommitted changes on branch "${current}"; ` +
+      `cannot repoint to "${targetBranch}". Commit or discard changes first.`,
+    );
+  }
+
+  // Does the target branch already exist locally? `rev-parse --verify` exits
+  // 0 on hit, non-zero on miss.
+  let branchExistsLocally = false;
+  try {
+    execFileSync('git', ['-C', wtPath, 'rev-parse', '--verify', `refs/heads/${targetBranch}`], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    branchExistsLocally = true;
+  } catch {
+    // refs/heads/<target> doesn't exist — fall through to create-from-main.
+  }
+
+  if (branchExistsLocally) {
+    log(`Worktree at "${wtPath}" switching "${current}" → "${targetBranch}" (existing local branch)`);
+    try {
+      execFileSync('git', ['-C', wtPath, 'checkout', targetBranch], {
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (err: any) {
+      const msg = err.stderr || err.stdout || err.message || String(err);
+      throw new Error(`Failed to switch "${wtPath}" to "${targetBranch}": ${msg.trim()}`);
+    }
+    return 'switched';
+  }
+
+  log(`Worktree at "${wtPath}" switching "${current}" → "${targetBranch}" (new local branch from origin/main)`);
+  try {
+    execFileSync('git', ['-C', wtPath, 'checkout', '-b', targetBranch, 'origin/main'], {
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch (err: any) {
+    const msg = err.stderr || err.stdout || err.message || String(err);
+    throw new Error(`Failed to create "${targetBranch}" from origin/main in "${wtPath}": ${msg.trim()}`);
+  }
+  return 'created-from-main';
 }
 
 /**
  * Create a git worktree for a player. If the worktree already exists
- * at the expected path, returns it without re-creating.
+ * at the expected path, returns it after repointing to the requested branch
+ * via {@link switchWorktreeToBranch} — the fix for #261, which previously
+ * reused the directory without ever consulting its actual HEAD.
  *
  * Branch defaults to `{ensemble}/{playerName}` if not specified.
  */
@@ -47,10 +163,14 @@ export function createWorktree(opts: CreateWorktreeOpts): CreateWorktreeResult {
   const basePath = worktreeBasePath(gitRoot, ensemble);
   const wtPath = path.join(basePath, playerName);
 
-  // If worktree already exists, reuse it
+  // If worktree already exists, reuse it — but verify its HEAD matches the
+  // requested branch (repoint if not). This is the #261 fix: the previous
+  // early-return trusted `branch` from the request as ground truth, so a
+  // worktree left on a prior task's branch would be silently misreported.
   if (existsSync(path.join(wtPath, '.git'))) {
-    log(`Worktree already exists at "${wtPath}" — reusing`);
-    return { path: wtPath, branch, created: false };
+    log(`Worktree already exists at "${wtPath}" — reusing, verifying branch`);
+    const switched = switchWorktreeToBranch(wtPath, branch);
+    return { path: wtPath, branch, created: false, switched };
   }
 
   // Ensure base directory exists

--- a/test/worktree.test.ts
+++ b/test/worktree.test.ts
@@ -1,7 +1,10 @@
 import { expect } from 'chai';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
 import * as path from 'path';
 import { WorktreeEntry } from '../src/types';
-import { worktreeBasePath } from '../src/utils/worktree';
+import { createWorktree, worktreeBasePath } from '../src/utils/worktree';
 import {
   setupTestEnv,
   teardownTestEnv,
@@ -15,6 +18,7 @@ import {
   setWorktreeSignal,
   removeWorktreeSignal,
   worktreesQuery,
+  getTestEnsemble,
 } from './helpers';
 
 describe('worktree helpers', function () {
@@ -261,5 +265,152 @@ describe('worktree workflow state', function () {
       await handle.executeUpdate(destroyUpdate, { args: [{}] });
       await handle.result();
     });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// #261 — createWorktree reuse must repoint HEAD on branch mismatch, must
+// refuse on a dirty tree, and must stay a no-op when the branch already
+// matches. These tests exercise the real git binary in a tmp repo; no
+// Temporal dependency.
+// ──────────────────────────────────────────────────────────────────────────
+
+describe('createWorktree reuse semantics (#261)', function () {
+  // Allow git + worktree calls on slow Windows CI runners.
+  this.timeout(30_000);
+
+  let tmpRoot: string;
+  let primaryRepo: string;
+  // Per shared-TestWorkflowEnvironment policy (#210): never hardcode
+  // `test-ensemble`; derive from `getTestEnsemble()` so the per-file random
+  // suffix keeps ensembles disjoint across test files.
+  const ensemble = getTestEnsemble();
+  const playerName = 'test-player';
+  let expectedWtPath: string;
+
+  // Run git with `cwd`, capturing output and re-throwing with useful context
+  // if it fails — shell default error messages from execFileSync are noisy.
+  const git = (cwd: string, args: string[]): string => {
+    try {
+      return execFileSync('git', args, {
+        cwd,
+        encoding: 'utf8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).toString();
+    } catch (err: any) {
+      const msg = err.stderr || err.stdout || err.message || String(err);
+      throw new Error(`git ${args.join(' ')} (in ${cwd}) failed: ${msg.trim()}`);
+    }
+  };
+
+  beforeEach(function () {
+    // Fresh tmpdir per test so leftovers from a prior failure don't bleed in.
+    tmpRoot = mkdtempSync(path.join(tmpdir(), 'ct-wt-261-'));
+
+    // `primaryRepo` is the git root that `createWorktree` will operate
+    // against. Worktrees get provisioned at `<tmpRoot>/.ct-worktrees/<ensemble>/<player>`
+    // — same convention as production (`worktreeBasePath`), achieved by
+    // placing the repo one level deep in tmpRoot so `path.dirname(gitRoot)`
+    // lands back at tmpRoot.
+    primaryRepo = path.join(tmpRoot, 'primary');
+    mkdirSync(primaryRepo);
+
+    // Initialise a real repo with a single commit on `main`, plus a local
+    // `legacy` branch pointing at the same commit. Add an `origin` remote
+    // aliased to the repo itself so `origin/main` resolves — the helper's
+    // `create-from-main` path needs that ref.
+    git(primaryRepo, ['init', '-b', 'main']);
+    git(primaryRepo, ['config', 'user.email', 'test@example.com']);
+    git(primaryRepo, ['config', 'user.name', 'Test']);
+    writeFileSync(path.join(primaryRepo, 'README.md'), '# test repo\n');
+    git(primaryRepo, ['add', 'README.md']);
+    git(primaryRepo, ['commit', '-m', 'init']);
+    git(primaryRepo, ['branch', 'legacy']);
+    // Alias origin → ourselves so origin/main is a valid rev.
+    git(primaryRepo, ['remote', 'add', 'origin', primaryRepo]);
+    git(primaryRepo, ['fetch', 'origin']);
+
+    expectedWtPath = path.join(
+      worktreeBasePath(primaryRepo, ensemble),
+      playerName,
+    );
+  });
+
+  afterEach(function () {
+    // `force: true` tolerates Windows file-handle holds left by git processes
+    // that have already exited but may still have directory watchers open.
+    try {
+      rmSync(tmpRoot, { recursive: true, force: true, maxRetries: 3 });
+    } catch {
+      // Best-effort cleanup; a leftover tmpdir is never worse than failing
+      // the suite on Windows for cleanup flake.
+    }
+  });
+
+  it('(a) reuse with different branch: repoints the inner HEAD (#261)', function () {
+    // ARRANGE: first creation lands the worktree on `legacy`.
+    createWorktree({ gitRoot: primaryRepo, ensemble, playerName, branch: 'legacy' });
+    expect(
+      git(expectedWtPath, ['branch', '--show-current']).trim(),
+    ).to.equal('legacy', 'precondition: first create should leave worktree on legacy');
+
+    // ACT: second creation reuses the directory but asks for a different branch.
+    const result = createWorktree({
+      gitRoot: primaryRepo,
+      ensemble,
+      playerName,
+      branch: 'requested',
+    });
+
+    // ASSERT: what the function claims vs. what's actually on disk. Pre-#261
+    // both looked fine on the returned object but the git state diverged.
+    expect(result.created).to.equal(false, 'second call must take the reuse path');
+    expect(result.branch).to.equal('requested');
+    expect(result.switched).to.equal(
+      'created-from-main',
+      '`requested` did not exist locally → helper should create from origin/main',
+    );
+    const actualBranch = git(expectedWtPath, ['branch', '--show-current']).trim();
+    expect(actualBranch).to.equal(
+      'requested',
+      'the bug: returned object says `requested` but the worktree HEAD still points at `legacy`',
+    );
+  });
+
+  it('(b) reuse with same branch: no-op, no branch flip', function () {
+    // ARRANGE: first creation on `legacy`.
+    createWorktree({ gitRoot: primaryRepo, ensemble, playerName, branch: 'legacy' });
+
+    // ACT: second creation with the SAME branch — hot path; should early-return.
+    const result = createWorktree({ gitRoot: primaryRepo, ensemble, playerName, branch: 'legacy' });
+
+    // ASSERT: the helper reports `same`, branch stays legacy, no git side effects.
+    expect(result.created).to.equal(false);
+    expect(result.branch).to.equal('legacy');
+    expect(result.switched).to.equal('same');
+    expect(
+      git(expectedWtPath, ['branch', '--show-current']).trim(),
+    ).to.equal('legacy');
+  });
+
+  it('(c) reuse with different branch + dirty tree: throws, preserves work', function () {
+    // ARRANGE: first creation on `legacy`, then dirty the tree.
+    createWorktree({ gitRoot: primaryRepo, ensemble, playerName, branch: 'legacy' });
+    const dirtyFile = path.join(expectedWtPath, 'in-flight.txt');
+    writeFileSync(dirtyFile, 'work the player has not committed yet\n');
+
+    // ACT + ASSERT: must throw rather than blow away uncommitted work.
+    expect(() =>
+      createWorktree({ gitRoot: primaryRepo, ensemble, playerName, branch: 'requested' }),
+    ).to.throw(/uncommitted changes/i);
+
+    // ASSERT: branch still on legacy, dirty file still present.
+    expect(
+      git(expectedWtPath, ['branch', '--show-current']).trim(),
+    ).to.equal('legacy', 'branch must not have flipped after the throw');
+    expect(existsSync(dirtyFile)).to.equal(
+      true,
+      'the operator\'s in-flight file must survive a refused repoint',
+    );
   });
 });


### PR DESCRIPTION
## Summary

The `worktree` MCP tool's `create` action was silently lying to the conductor when the target directory already existed: the returned result named the requested branch, but the inner worktree's `HEAD` was never repointed. It stayed on whatever branch was left by the prior task — producing the drift that tripped me during today's cleanup-batch dispatch.

Fix: a new `switchWorktreeToBranch(wtPath, targetBranch)` helper repoints the reuse path, with a dirty-tree guard that refuses rather than silently discarding operator work.

Closes #261.

## Decision tree (mirrors conductor's #261 guidance)

| Situation | Action | `switched` tag |
|---|---|---|
| `current === target` | no-op (skip `status` check; no flip means no work loss) | `'same'` |
| mismatch + `status --porcelain` non-empty | **throw** `"uncommitted changes"` | — |
| target exists locally | `git checkout <target>` (preserve branch state; no `-B`) | `'switched'` |
| target missing locally | `git checkout -b <target> origin/main` | `'created-from-main'` |

## Response-text change (MCP tool)

Before:
```
- Created: reused existing
```

After (three shapes, depending on state):
```
- Created: reused existing (already on `X`)
- Created: reused existing (switched to `X`)
- Created: reused existing (created `X` from origin/main)
```

## Scope discipline

- `CreateWorktreeResult.switched?: WorktreeSwitchResult` — optional; undefined on fresh creation (fresh worktrees don't need it).
- No fresh-path behavior change.
- `createWorktree` has **one** caller (`src/tools/worktree.ts:56`), already wrapped in a top-level `try/catch → fail(...)` — so the new dirty-tree throw surfaces as a clean tool-failure message.
- No other callers, no CLI path, no tests exercise `createWorktree` outside the new reuse-semantics block.

## Test plan

- [x] `npm run build` clean
- [x] `npm run build:test` clean
- [x] `npx mocha --grep "createWorktree reuse semantics"` → 3 passing
- [x] `npx mocha --grep "worktree"` → 17 passing (14 pre-existing + 3 new)
- [x] Spot-revert RED→GREEN: stripping the helper call from the reuse path fails all 3 new tests with distinct assertion messages; restoring → 3 passing
- [ ] CI matrix (6 jobs) — waiting on CI

## Regression tests (test/worktree.test.ts)

Real git binary in a tmp repo (one local commit + `legacy` branch + `origin` remote aliased to itself so `origin/main` resolves). Windows-safe cleanup via `rmSync({recursive, force, maxRetries: 3})`.

- **(a)** reuse with different branch: `result.switched === 'created-from-main'` and `git branch --show-current` returns the requested branch
- **(b)** reuse with same branch: `result.switched === 'same'`, no flip
- **(c)** reuse with different branch + dirty tree: throws `/uncommitted changes/i`, branch stays put, dirty file preserved