### PR TITLE
chore: bump version to v0.26.0-beta.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.0-beta.5] - 2026-04-19
+
+### Added
+- CLI: `attachment-info` command now displays heartbeat age (#138)
+
+### Fixed
+- worktree tool `create` action: reusing an existing directory with a different branch now correctly repoints the inner HEAD and refuses to destroy uncommitted work (previously silently reported the requested branch without changing HEAD) (#261)
+
 ## [0.26.0-beta.4] - 2026-04-19
 
 > **Beta release.** Closes the message-delivery trilogy (#249): heartbeat/watcher orphan fix,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.4",
+  "version": "0.26.0-beta.5",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Version bump for v0.26.0-beta.5.

## Changes in this release

### Added
- CLI: `attachment-info` command now displays heartbeat age (#138)

### Fixed
- worktree tool `create` action: reusing an existing directory with a different branch now correctly repoints the inner HEAD and refuses to destroy uncommitted work (#261)

## Checklist
- [x] `package.json` bumped `0.26.0-beta.4` → `0.26.0-beta.5`
- [x] `CHANGELOG.md` entry added under `## [0.26.0-beta.5] - 2026-04-19`
- [ ] CI green — pending this PR