### PR TITLE
feat(tui): render heartbeat age on /attachment-info (#264)

### DIFF
--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -12,7 +12,9 @@ import { createTemporalConnection } from '../connection';
 import { playerReportSignal, updateMetadataSignal, releaseHeldSignal, outboxLockedQuery, setPausedSignal, destroyUpdate } from '../workflows/signals';
 import { addScheduleSignal, setSchedulerPausedSignal } from '../workflows/scheduler-signals';
 import { maestroSetPausedSignal } from '../workflows/maestro-signals';
-import { AgentType, AttachmentInfo, ScheduleEntry, SessionInput, SessionMetadata } from '../types';
+import { AgentType, ScheduleEntry, SessionInput, SessionMetadata } from '../types';
+import { formatDurationMs } from '../utils/duration';
+import { formatAttachmentInfoForDisplay } from '../utils/attachment-format';
 import { runPreflight } from './preflight';
 import { isGlobalMcpRegistered, addGlobalMcp, removeGlobalMcp, isMcpConfigured } from './mcp';
 import { loadLineup, resolveLineupPath } from '../ensemble/loader';
@@ -27,13 +29,6 @@ import * as out from './output';
 
 /** Package root is two levels up from dist/cli/ */
 const PACKAGE_ROOT = resolve(__dirname, '..', '..');
-
-function formatDurationMs(ms: number): string {
-  if (ms >= 86_400_000) return `${ms / 86_400_000}d`;
-  if (ms >= 3_600_000) return `${ms / 3_600_000}h`;
-  if (ms >= 60_000) return `${ms / 60_000}m`;
-  return `${ms / 1000}s`;
-}
 
 /**
  * Ensure the Maestro workflow is running for the given ensemble.
@@ -2268,53 +2263,17 @@ export async function migrate(opts: MigrateCliOpts) {
   }
 }
 
-/**
- * Render `claude-tempo attachment-info <name>` output as an array of plain
- * strings. Pure — no Temporal, no stdout, no ANSI colors — so unit tests can
- * assert exact lines without booting a client (#138).
- *
- * `now` is injected (defaults to `Date.now()`) so tests can freeze the clock
- * and assert the heartbeat-age string deterministically. Heartbeat age uses
- * the same `formatDurationMs` helper the scheduler output uses, suffixed with
- * "ago" — e.g. `5s ago`, `2m ago`. Clock-skew (heartbeat timestamp in the
- * future) renders as `just now`; a malformed timestamp renders as `unknown`.
- */
-export function formatAttachmentInfoForCli(
-  name: string,
-  info: AttachmentInfo,
-  now: number = Date.now(),
-): string[] {
-  const lines: string[] = [
-    `${name} — phase: ${info.phase}`,
-    `  in-flight: ${info.inFlightCount}`,
-  ];
-  if (info.currentAttachment) {
-    const a = info.currentAttachment;
-    lines.push(`  attached on: ${a.hostname} (adapter: ${a.adapterId}/${a.adapterClass})`);
-    lines.push(`  attachmentId: ${a.attachmentId}`);
-    lines.push(`  lease expires: ${a.expiresAt}`);
-    lines.push(`  heartbeat: ${formatHeartbeatAge(a.lastHeartbeatAt, now)}`);
-  }
-  if (info.preferredHost) lines.push(`  preferred host: ${info.preferredHost}`);
-  if (info.processingSince) lines.push(`  processing since: ${info.processingSince}`);
-  return lines;
-}
-
-function formatHeartbeatAge(lastHeartbeatAt: string, now: number): string {
-  const then = Date.parse(lastHeartbeatAt);
-  if (!Number.isFinite(then)) return 'unknown';
-  const ageMs = now - then;
-  if (ageMs < 0) return 'just now'; // adapter clock ran ahead of ours — degrade gracefully
-  return `${formatDurationMs(ageMs)} ago`;
-}
-
 export async function attachmentInfo(opts: VerbOpts) {
   const { config, connection, client } = await verbClient(opts);
   const ensemble = opts.ensemble || config.ensemble;
   try {
     const tempo = createTempoClient(client);
     const info = await tempo.attachmentInfo(ensemble, opts.name);
-    for (const line of formatAttachmentInfoForCli(opts.name, info)) {
+    // #264 carved the per-surface formatter out to src/utils/attachment-format.ts
+    // so the TUI's /attachment-info renders identical output including heartbeat
+    // age. The CLI is now a pure consumer; if you need to add a field, add it
+    // to the shared formatter so every surface picks it up at once.
+    for (const line of formatAttachmentInfoForDisplay(opts.name, info)) {
       out.log(line);
     }
   } catch (err: any) {

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -10,6 +10,7 @@ import type { Message, SentMessage } from '../types';
 import { statusIcons, supportsUnicode } from './utils/platform';
 import { phaseToLabel } from './utils/format';
 import { listAllLineups } from '../ensemble/saver';
+import { formatAttachmentInfoForDisplay } from '../utils/attachment-format';
 
 // ── Types ──
 
@@ -472,17 +473,11 @@ async function handleAttachmentInfo(
 
   try {
     const info = await api.attachmentInfo(ensemble, target);
-    const lines: string[] = [
-      `${target} — phase: ${info.phase}`,
-      `  in-flight: ${info.inFlightCount}`,
-    ];
-    if (info.currentAttachment) {
-      lines.push(`  attached on: ${info.currentAttachment.hostname} (${info.currentAttachment.adapterId}/${info.currentAttachment.adapterClass})`);
-      lines.push(`  attachmentId: ${info.currentAttachment.attachmentId}`);
-      lines.push(`  lease expires: ${info.currentAttachment.expiresAt}`);
-    }
-    if (info.preferredHost) lines.push(`  preferred host: ${info.preferredHost}`);
-    if (info.processingSince) lines.push(`  processing since: ${info.processingSince}`);
+    // #264: share the display formatter with the CLI (`src/utils/attachment-format.ts`)
+    // so both surfaces render heartbeat age + match each other's field order /
+    // edge-case handling. Pre-#264 this block inlined a near-identical render
+    // but omitted heartbeat age, creating a latent parity gap.
+    const lines = formatAttachmentInfoForDisplay(target, info);
     dispatch({ type: 'SHOW_COMMAND_OVERLAY', title: `Attachment \u00B7 ${target}`, content: lines.join('\n') });
   } catch (err) {
     commitStatic(dispatch, 'error', `attachment_info failed for ${target}: ${err instanceof Error ? err.message : String(err)}`);

--- a/src/utils/attachment-format.ts
+++ b/src/utils/attachment-format.ts
@@ -1,0 +1,50 @@
+/**
+ * Shared attachment-info display formatter.
+ *
+ * Renders an {@link AttachmentInfo} snapshot into an array of plain strings
+ * suitable for either stdout (`claude-tempo attachment-info`) or the TUI
+ * overlay (`/attachment-info`). Pure — no Temporal, no stdout, no ANSI
+ * colors — so unit tests can assert exact lines without booting a client.
+ *
+ * Lives in `src/utils/` (not `src/cli/`) because both the CLI and TUI
+ * consume it; #264 carved it out of `src/cli/commands.ts` to eliminate the
+ * cross-surface drift where only the CLI rendered heartbeat age.
+ *
+ * `now` is injectable so tests can freeze the clock and assert the
+ * heartbeat-age string deterministically. Heartbeat age uses
+ * {@link formatDurationMs} (same helper the scheduler output uses) suffixed
+ * with "ago" — e.g. `5s ago`, `2m ago`. Clock-skew (heartbeat timestamp in
+ * the future) renders as `just now`; a malformed timestamp renders as
+ * `unknown`.
+ */
+import type { AttachmentInfo } from '../types';
+import { formatDurationMs } from './duration';
+
+export function formatAttachmentInfoForDisplay(
+  name: string,
+  info: AttachmentInfo,
+  now: number = Date.now(),
+): string[] {
+  const lines: string[] = [
+    `${name} — phase: ${info.phase}`,
+    `  in-flight: ${info.inFlightCount}`,
+  ];
+  if (info.currentAttachment) {
+    const a = info.currentAttachment;
+    lines.push(`  attached on: ${a.hostname} (adapter: ${a.adapterId}/${a.adapterClass})`);
+    lines.push(`  attachmentId: ${a.attachmentId}`);
+    lines.push(`  lease expires: ${a.expiresAt}`);
+    lines.push(`  heartbeat: ${formatHeartbeatAge(a.lastHeartbeatAt, now)}`);
+  }
+  if (info.preferredHost) lines.push(`  preferred host: ${info.preferredHost}`);
+  if (info.processingSince) lines.push(`  processing since: ${info.processingSince}`);
+  return lines;
+}
+
+export function formatHeartbeatAge(lastHeartbeatAt: string, now: number): string {
+  const then = Date.parse(lastHeartbeatAt);
+  if (!Number.isFinite(then)) return 'unknown';
+  const ageMs = now - then;
+  if (ageMs < 0) return 'just now'; // adapter clock ran ahead of ours — degrade gracefully
+  return `${formatDurationMs(ageMs)} ago`;
+}

--- a/src/utils/duration.ts
+++ b/src/utils/duration.ts
@@ -11,3 +11,22 @@ export function parseDuration(dur: string): number | null {
     default: return null;
   }
 }
+
+/**
+ * Humanise a millisecond count as a short duration string: `30s` / `5m` /
+ * `2h` / `1d`. Picks the largest unit whose integer-or-fractional value is
+ * ≥ 1. Inverse (roughly) of {@link parseDuration}; matches the output shape
+ * several other surfaces emit (scheduler listings, attachment-info CLI).
+ *
+ * Consolidated here as part of #264 so the shared attachment-info formatter
+ * in `src/utils/attachment-format.ts` doesn't drag the CLI-local duplicate.
+ * Other local duplicates exist at `src/ensemble/saver.ts` and
+ * `src/tools/schedules.ts` — those can be migrated incrementally; leaving
+ * them alone keeps this PR's scope tight.
+ */
+export function formatDurationMs(ms: number): string {
+  if (ms >= 86_400_000) return `${ms / 86_400_000}d`;
+  if (ms >= 3_600_000) return `${ms / 3_600_000}h`;
+  if (ms >= 60_000) return `${ms / 60_000}m`;
+  return `${ms / 1000}s`;
+}

--- a/test/cli-attachment-info.test.ts
+++ b/test/cli-attachment-info.test.ts
@@ -1,7 +1,11 @@
 /**
- * Unit tests for the `claude-tempo attachment-info <name>` CLI command's
- * pure formatter (#138). Tests the extracted `formatAttachmentInfoForCli`
- * helper directly so no Temporal connection or TempoClient is required.
+ * Unit tests for the shared attachment-info display formatter. Originally
+ * added for #138 (CLI heartbeat age); the formatter was relocated to
+ * `src/utils/attachment-format.ts` in #264 so the TUI consumer could reuse
+ * it without drifting. These Mocha cases stay here to keep the CLI-side
+ * workflow/wire-protocol suite validating the pure pure-data-in / string-out
+ * contract; the TUI integration has companion vitest coverage at
+ * `tests/tui/attachment-info.test.ts`.
  *
  * Covers:
  *   - Happy path: currentAttachment present → all fields including heartbeat
@@ -21,13 +25,13 @@
  * the formatter itself is what #138's AC is about.
  */
 import { expect } from 'chai';
-import { formatAttachmentInfoForCli } from '../src/cli/commands';
+import { formatAttachmentInfoForDisplay } from '../src/utils/attachment-format';
 import type { AttachmentInfo } from '../src/types';
 
 // Frozen "now" so heartbeat-age strings are deterministic across CI runs.
 const NOW = Date.parse('2026-04-19T12:00:00.000Z');
 
-describe('formatAttachmentInfoForCli (#138)', function () {
+describe('formatAttachmentInfoForDisplay (#138, #264)', function () {
   it('happy path: attached session — renders all core fields + heartbeat age', function () {
     const info: AttachmentInfo = {
       phase: 'attached',
@@ -44,7 +48,7 @@ describe('formatAttachmentInfoForCli (#138)', function () {
         runId: 'run-xyz',
       },
     };
-    expect(formatAttachmentInfoForCli('tempo-eng', info, NOW)).to.deep.equal([
+    expect(formatAttachmentInfoForDisplay('tempo-eng', info, NOW)).to.deep.equal([
       'tempo-eng — phase: attached',
       '  in-flight: 0',
       '  attached on: main-laptop (adapter: claude-code/interactive)',
@@ -59,7 +63,7 @@ describe('formatAttachmentInfoForCli (#138)', function () {
       phase: 'detached',
       inFlightCount: 0,
     };
-    expect(formatAttachmentInfoForCli('tempo-eng', info, NOW)).to.deep.equal([
+    expect(formatAttachmentInfoForDisplay('tempo-eng', info, NOW)).to.deep.equal([
       'tempo-eng — phase: detached',
       '  in-flight: 0',
     ]);
@@ -83,7 +87,7 @@ describe('formatAttachmentInfoForCli (#138)', function () {
       preferredHost: 'remote-box',
       processingSince: '2026-04-19T11:59:45.000Z',
     };
-    expect(formatAttachmentInfoForCli('tempo-eng', info, NOW)).to.deep.equal([
+    expect(formatAttachmentInfoForDisplay('tempo-eng', info, NOW)).to.deep.equal([
       'tempo-eng — phase: processing',
       '  in-flight: 2',
       '  attached on: remote-box (adapter: copilot/sdk)',
@@ -111,7 +115,7 @@ describe('formatAttachmentInfoForCli (#138)', function () {
         runId: 'run-1',
       },
     };
-    const lines = formatAttachmentInfoForCli('p', info, NOW);
+    const lines = formatAttachmentInfoForDisplay('p', info, NOW);
     expect(lines).to.include('  heartbeat: just now');
   });
 
@@ -131,7 +135,7 @@ describe('formatAttachmentInfoForCli (#138)', function () {
         runId: 'run-1',
       },
     };
-    const lines = formatAttachmentInfoForCli('p', info, NOW);
+    const lines = formatAttachmentInfoForDisplay('p', info, NOW);
     expect(lines).to.include('  heartbeat: unknown');
   });
 });

--- a/tests/tui/attachment-info.test.ts
+++ b/tests/tui/attachment-info.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Vitest integration coverage for the TUI `/attachment-info` handler (#264).
+ *
+ * The shared formatter itself (`src/utils/attachment-format.ts`) already has
+ * Mocha unit coverage at `test/cli-attachment-info.test.ts` for input/output
+ * pairs and heartbeat-age edge cases. This file covers the missing piece:
+ * that the TUI handler ACTUALLY feeds the formatter's output into the
+ * command overlay — the integration the pre-#264 handler forgot to wire up.
+ *
+ * Invocation goes through the public `COMMANDS` registry rather than
+ * importing `handleAttachmentInfo` directly, so we exercise the same
+ * dispatch surface the App uses at runtime.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { COMMANDS, type CommandContext } from '../../src/tui/commands';
+import type { AttachmentInfo } from '../../src/types';
+import type { TempoClient } from '../../src/client';
+import type { TuiAction } from '../../src/tui/store';
+
+// Build a canned TempoClient stub — only `attachmentInfo` is called by the
+// handler, so the rest is `vi.fn()` sentinels that throw if touched (catches
+// handler drift).
+function makeApi(info: AttachmentInfo): TempoClient {
+  const unusedStub = vi.fn(() => {
+    throw new Error('TempoClient method not expected during /attachment-info');
+  });
+  return new Proxy({} as TempoClient, {
+    get(_target, prop: string) {
+      if (prop === 'attachmentInfo') return vi.fn(async () => info);
+      return unusedStub;
+    },
+  });
+}
+
+const CTX: CommandContext = { activeEnsemble: 'demo-ensemble' };
+
+// Fixed "now" for deterministic heartbeat-age assertions. The handler
+// defaults `now` to `Date.now()`, so mock the clock.
+const NOW = Date.parse('2026-04-19T12:00:00.000Z');
+
+describe('/attachment-info handler — TUI integration (#264)', () => {
+  it('surfaces heartbeat age in the command overlay (regression for #264)', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const info: AttachmentInfo = {
+      phase: 'attached',
+      inFlightCount: 0,
+      currentAttachment: {
+        attachmentId: 'att-tui-1',
+        hostname: 'main-laptop',
+        adapterId: 'claude-code',
+        adapterClass: 'interactive',
+        claimedAt: '2026-04-19T11:55:00.000Z',
+        lastHeartbeatAt: '2026-04-19T11:59:30.000Z', // 30s before NOW
+        expiresAt: '2026-04-19T12:02:30.000Z',
+        leaseMs: 180_000,
+        runId: 'run-xyz',
+      },
+    };
+
+    const dispatch = vi.fn<(a: TuiAction) => void>();
+    const handler = COMMANDS['attachment-info'].handler!;
+    await handler(['tempo-eng'], dispatch, makeApi(info), CTX);
+
+    // Assert: dispatch got a SHOW_COMMAND_OVERLAY, and its content includes
+    // the heartbeat-age line — the #264 gap. Title remains "Attachment · <name>".
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const action = dispatch.mock.calls[0][0] as { type: string; title: string; content: string };
+    expect(action.type).toBe('SHOW_COMMAND_OVERLAY');
+    expect(action.title).toBe('Attachment \u00B7 tempo-eng');
+    expect(action.content).toContain('  heartbeat: 30s ago');
+    // Sanity: other fields the pre-#264 handler already rendered are still there.
+    expect(action.content).toContain('tempo-eng — phase: attached');
+    expect(action.content).toContain('  in-flight: 0');
+    expect(action.content).toContain('  attached on: main-laptop (adapter: claude-code/interactive)');
+
+    vi.useRealTimers();
+  });
+
+  it('detached session (no currentAttachment): overlay omits heartbeat line', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+
+    const info: AttachmentInfo = { phase: 'detached', inFlightCount: 0 };
+    const dispatch = vi.fn<(a: TuiAction) => void>();
+    const handler = COMMANDS['attachment-info'].handler!;
+    await handler(['tempo-eng'], dispatch, makeApi(info), CTX);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const action = dispatch.mock.calls[0][0] as { type: string; content: string };
+    expect(action.type).toBe('SHOW_COMMAND_OVERLAY');
+    expect(action.content).toBe(
+      'tempo-eng — phase: detached\n  in-flight: 0',
+    );
+    expect(action.content).not.toContain('heartbeat:');
+
+    vi.useRealTimers();
+  });
+
+  it('usage error when no player name provided', async () => {
+    const dispatch = vi.fn<(a: TuiAction) => void>();
+    const handler = COMMANDS['attachment-info'].handler!;
+    await handler([], dispatch, makeApi({ phase: 'detached', inFlightCount: 0 }), CTX);
+
+    // Usage-error path emits a 'COMMIT_STATIC' (via commitStatic helper) — we
+    // only care that NO overlay was dispatched in this path; the exact error
+    // action shape is already covered by other command tests.
+    const overlays = dispatch.mock.calls.filter(
+      ([a]) => (a as { type: string }).type === 'SHOW_COMMAND_OVERLAY',
+    );
+    expect(overlays.length).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the cross-surface parity gap introduced by PR #263 (#138): the CLI `claude-tempo attachment-info` rendered heartbeat age, the TUI `/attachment-info` did not. Carves the shared formatter out of `src/cli/commands.ts` into `src/utils/attachment-format.ts` so both surfaces now consume the same pure function — no future drift possible.

Closes #264.

## Shape of the change

- `src/utils/attachment-format.ts` — **new file**. Single source of truth: `formatAttachmentInfoForDisplay(name, info, now?)` returns a `string[]` of plain-text lines. Pure — no Temporal, no stdout, no ANSI.
- `src/utils/duration.ts` — exported `formatDurationMs` as a companion to `parseDuration` (the formatter dependency). Two other local duplicates (`src/ensemble/saver.ts`, `src/tools/schedules.ts`) are **left alone** — migrating those is orthogonal.
- `src/cli/commands.ts` — **refactor-in-place** per conductor guidance. Deleted the local `formatAttachmentInfoForCli`, `formatHeartbeatAge`, and `formatDurationMs`. CLI is now a pure consumer of the shared formatter.
- `src/tui/commands.ts` — `handleAttachmentInfo` swaps its inline renderer for `formatAttachmentInfoForDisplay`. Gains heartbeat-age line + a cosmetic fix: `(adapter: claude-code/interactive)` instead of the prior `(claude-code/interactive)`, matching CLI form.
- `test/cli-attachment-info.test.ts` — retargeted to `src/utils/attachment-format`. Describe block renamed; 5 cases unchanged in logic.
- `tests/tui/attachment-info.test.ts` — **new vitest**. 3 cases: overlay shows heartbeat age / detached omits heartbeat / usage error doesn't dispatch overlay. Invokes through the public `COMMANDS['attachment-info']` registry with a mocked `TempoClient` and `vi.useFakeTimers()` for deterministic age assertions.

## Output example (now identical across CLI and TUI)

```
tempo-eng — phase: attached
  in-flight: 0
  attached on: main-laptop (adapter: claude-code/interactive)
  attachmentId: att-abc123
  lease expires: 2026-04-19T12:02:30.000Z
  heartbeat: 30s ago
```

## Scope compliance (per conductor brief)

- ✅ Comms-safe zone only: no `src/workflows/`, no signals/queries, no adapters, no `TempoClient` behavior change
- ✅ MCP tool untouched
- ✅ Refactor-in-place — no duplicate formatter left behind (single source of truth going forward)
- ✅ No env vars, no wire-protocol, no workflow bundle changes (though `npm run build` ran clean regardless)

## Docs note for tempo-docs

The CLI and TUI `/attachment-info` output is now literally identical (same renderer). `docs/tui.md` doesn't currently spec the overlay contents; if tempo-docs wants to lock in the heartbeat line in a subsequent pass, the formatter is the canonical source. No TUI-layout change in this PR.

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx mocha --grep "formatAttachmentInfoForDisplay"` — 5 passing
- [x] `npx vitest run tests/tui/attachment-info.test.ts` — 3 passing
- [x] Spot-revert RED→GREEN: reinstating the pre-#264 inline TUI renderer failed vitest test 1 on the heartbeat-age assertion (the #264 regression); restoring the shared-formatter call → 3 passing
- [ ] CI matrix (6 jobs) — waiting on CI