### PR TITLE
feat(recall): redesign MCP+TUI+CLI with shared formatter, paging, and full-body default (#128)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ claude-tempo up [ensemble]      # first-time setup
 claude-tempo conduct [ensemble] # start a conductor
 claude-tempo start [ensemble]   # start a player
 claude-tempo status [ensemble]  # list active sessions
+claude-tempo recall <name>      # read a player's message history (--limit/--offset/--preview/--from/--since/--include-sent/--json)
 claude-tempo attachment-info <name> # inspect a session's phase, holder, lease, and heartbeat age
 claude-tempo release [ensemble] # release held players (unlock + deliver tasks)
 claude-tempo pause [ensemble]   # pause all sessions and the scheduler

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,6 +24,7 @@ claude-tempo <command> [options]
 | `destroy <name>` | Terminate a session's workflow — ordered shutdown via outbox drain. Use for permanent removal. |
 | `migrate <name>` | Move a session to a different host — sugar for `setPreferredHost` + `restart` on the target machine. Use `--to <hostname>`. |
 | `attachment-info <name>` | Inspect a session's attachment phase, current holder, lease expiry, heartbeat age, and in-flight message count. |
+| `recall <name>` | Read a player's message history (#128). Flags: `--limit N` (default 20, max 100), `--offset N` (paging, default 0), `--preview N` (truncate bodies to N chars; omit for full text), `--from X` (sender filter for received), `--since ISO` (time filter), `--include-sent` (include outbound too), `--json` (emit raw `{received, sent, total, shown, hasMore, text}`). |
 | `restore [name]` | **v0.25.** Restore orphaned (detached) sessions. Interactive picker by default; `--all` restores every orphan, `--from-host <hostname>` filters by preferred host, `--dry-run` lists without restoring. |
 | `release [ensemble]` | Release all held players — unlocks outboxes and delivers deferred task messages. Use `-n <name>` to release one player. |
 | `pause [ensemble]` | Pause the ensemble — locks all session outbox dispatch and pauses the scheduler. |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -24,7 +24,7 @@ These tools are available inside Claude Code sessions connected to claude-tempo.
 | `destroy` | Terminate a session via ordered shutdown (outbox drain). Use for permanent removal. |
 | `migrate` | Move a session to a different host — sets preferred host then triggers `restart` on the target machine's task queue. Requires `to` (target hostname). |
 | `attachment_info` | Fetch the current attachment phase, adapter ID, lease expiry, and in-flight message count for a player. Accepts `player` name. |
-| `recall` | Read your own message history. Shows received messages by default; pass `includeSent: true` for the full timeline. |
+| `recall` | Read your own message history. Shows received messages by default; pass `includeSent: true` for the full timeline. `offset` pages the timeline (gh-style `Showing X-Y of Z messages. Use offset: N for next page.`); `previewLength` truncates bodies to N chars (unset = full text). #128 unified the output with the TUI `/recall` and CLI `claude-tempo recall` via a shared formatter. |
 | `worktree` | Manage git worktrees for player isolation. Actions: `create`, `remove`, `list`. Conductor only. |
 | `quality_gate` | Define or replace a quality gate for a task — a named checklist of criteria that must pass. Conductor only. |
 | `evaluate_gate` | Mark one or more criteria on a quality gate as passed or failed. Conductor only. |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -66,6 +66,14 @@ interface ParsedArgs {
   dryRun?: boolean;
   // PR-F cross-host flags
   yesSteal?: string;
+  // #128 recall flags (generic enough to share with future commands).
+  limit?: number;
+  offset?: number;
+  previewLength?: number;
+  since?: string;
+  from?: string;
+  includeSent: boolean;
+  json: boolean;
 }
 
 function parseArgs(argv: string[]): ParsedArgs {
@@ -87,6 +95,8 @@ function parseArgs(argv: string[]): ParsedArgs {
     includeStale: false,
     fresh: false,
     force: false,
+    includeSent: false,
+    json: false,
   };
 
   let i = 0;
@@ -162,6 +172,35 @@ function parseArgs(argv: string[]): ParsedArgs {
       result.fromHost = argv[++i];
     } else if (arg === '--dry-run') {
       result.dryRun = true;
+    } else if (arg === '--limit' && i + 1 < argv.length) {
+      const n = Number(argv[++i]);
+      if (Number.isInteger(n) && n >= 1) result.limit = n;
+      else {
+        out.error(`Invalid --limit: ${argv[i]}`);
+        process.exit(1);
+      }
+    } else if (arg === '--offset' && i + 1 < argv.length) {
+      const n = Number(argv[++i]);
+      if (Number.isInteger(n) && n >= 0) result.offset = n;
+      else {
+        out.error(`Invalid --offset: ${argv[i]}`);
+        process.exit(1);
+      }
+    } else if (arg === '--preview' && i + 1 < argv.length) {
+      const n = Number(argv[++i]);
+      if (Number.isInteger(n) && n >= 1) result.previewLength = n;
+      else {
+        out.error(`Invalid --preview: ${argv[i]}`);
+        process.exit(1);
+      }
+    } else if (arg === '--since' && i + 1 < argv.length) {
+      result.since = argv[++i];
+    } else if (arg === '--from' && i + 1 < argv.length) {
+      result.from = argv[++i];
+    } else if (arg === '--include-sent') {
+      result.includeSent = true;
+    } else if (arg === '--json') {
+      result.json = true;
     } else if (arg === '--agent' && i + 1 < argv.length) {
       const val = argv[++i];
       if (val !== 'claude' && val !== 'copilot') {
@@ -266,7 +305,7 @@ async function main() {
   const {
     start, status, init, server, up, down, stop,
     ensembleCommand, agentTypesCommand, broadcast, release,
-    pause, resume, restart, detach, destroy, migrate, attachmentInfo, restore,
+    pause, resume, restart, detach, destroy, migrate, attachmentInfo, recall, restore,
   } = await import('./cli/commands');
 
   const ensemble = args.positional[1] || process.env[ENV.ENSEMBLE] || 'default';
@@ -457,6 +496,28 @@ async function main() {
       await attachmentInfo({
         name,
         ensemble: args.ensemble || ensemble,
+        ...overrides,
+      });
+      break;
+    }
+
+    case 'recall': {
+      // Positional player is required — matches the #128 design.
+      const name = args.positional[1] || args.name;
+      if (!name) {
+        out.error('Usage: claude-tempo recall <player> [--limit N] [--offset N] [--preview N] [--from X] [--since ISO] [--include-sent] [--json]');
+        process.exit(1);
+      }
+      await recall({
+        name,
+        ensemble: args.ensemble || ensemble,
+        ...(args.limit !== undefined ? { limit: args.limit } : {}),
+        ...(args.offset !== undefined ? { offset: args.offset } : {}),
+        ...(args.previewLength !== undefined ? { previewLength: args.previewLength } : {}),
+        ...(args.since !== undefined ? { since: args.since } : {}),
+        ...(args.from !== undefined ? { from: args.from } : {}),
+        ...(args.includeSent ? { includeSent: true } : {}),
+        ...(args.json ? { json: true } : {}),
         ...overrides,
       });
       break;

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -25,6 +25,7 @@ import { getAttachmentPhase, getEnsembleName } from '../utils/search-attributes'
 import { isDaemonRunning, startDaemon, stopDaemon, getDaemonStatus, DAEMON_LOG_PATH } from './daemon';
 import { createTempoClient } from '../client';
 import { ENSEMBLE_SENTINEL_FLAG, ensembleReadyBanner, ensembleReadyDirective } from '../constants';
+import { buildTimeline, formatRecall } from '../utils/recall-format';
 import * as out from './output';
 
 /** Package root is two levels up from dist/cli/ */
@@ -2275,6 +2276,64 @@ export async function attachmentInfo(opts: VerbOpts) {
     // to the shared formatter so every surface picks it up at once.
     for (const line of formatAttachmentInfoForDisplay(opts.name, info)) {
       out.log(line);
+    }
+  } catch (err: any) {
+    out.error(err?.message || String(err));
+    process.exit(1);
+  } finally {
+    await connection.close();
+  }
+}
+
+// --- Recall command (#128) ---
+
+export interface RecallCliOpts extends VerbOpts {
+  limit?: number;
+  offset?: number;
+  previewLength?: number;
+  since?: string;
+  from?: string;
+  includeSent?: boolean;
+  /** Emit raw JSON `{ received, sent, total, shown, hasMore, text }` instead of the formatted timeline. */
+  json?: boolean;
+}
+
+export async function recall(opts: RecallCliOpts) {
+  const { config, connection, client } = await verbClient(opts);
+  const ensemble = opts.ensemble || config.ensemble;
+  try {
+    const tempo = createTempoClient(client);
+    const { received, sent } = await tempo.recall(ensemble, opts.name);
+    const timeline = buildTimeline(received, sent, Boolean(opts.includeSent));
+    const rendered = formatRecall(timeline, {
+      limit: opts.limit,
+      offset: opts.offset,
+      previewLength: opts.previewLength,
+      since: opts.since,
+      from: opts.from,
+    });
+    if (opts.json) {
+      // Machine-readable. Includes the rendered text too so callers can
+      // either re-render or pass through. Pagination state is explicit so
+      // shell pipelines don't have to parse the header line.
+      process.stdout.write(
+        JSON.stringify(
+          {
+            player: opts.name,
+            ensemble,
+            received,
+            sent: opts.includeSent ? sent : [],
+            total: rendered.total,
+            shown: rendered.shown,
+            hasMore: rendered.hasMore,
+            text: rendered.text,
+          },
+          null,
+          2,
+        ) + '\n',
+      );
+    } else {
+      out.log(rendered.text);
     }
   } catch (err: any) {
     out.error(err?.message || String(err));

--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -40,6 +40,7 @@ ${out.bold('Commands:')}
   ${out.cyan('destroy')} <name>        Terminally end a session workflow
   ${out.cyan('migrate')} <name> --host Move a session to a different host
   ${out.cyan('attachment-info')} <name> Inspect the V2 attachment phase + current holder
+  ${out.cyan('recall')} <name>          Read a player's message history (--limit/--offset/--preview/--from/--since/--include-sent/--json)
   ${out.cyan('restore')} [name]         Restore orphaned session(s) — interactive picker, or --all / --from-host / --dry-run
   ${out.cyan('release')} [ensemble]   Release all held players (unlock outbox, deliver messages)
   ${out.cyan('pause')}   [ensemble]   Pause an ensemble (sessions, scheduler, maestro)

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -345,6 +345,20 @@ export function createTempoClient(client: Client): TempoClient {
       return target.query(attachmentInfoQuery);
     },
 
+    async recall(ensemble, playerId) {
+      // #128: direct session queries, no maestro round-trip. Throws rather
+      // than returning empties so the CLI / TUI wrappers can surface a
+      // clean "session not found" error instead of rendering a silently
+      // empty timeline that looks indistinguishable from "no messages yet."
+      const target = await resolveSession(client, ensemble, playerId);
+      if (!target) throw new Error(`No session found with name "${playerId}" in ensemble "${ensemble}".`);
+      const [received, sent] = await Promise.all([
+        target.query<Message[]>('allMessages'),
+        target.query<SentMessage[]>('allSentMessages'),
+      ]);
+      return { received, sent };
+    },
+
     async disbandEnsemble(ensemble: string): Promise<{ terminated: number }> {
       let terminated = 0;
 

--- a/src/client/interface.ts
+++ b/src/client/interface.ts
@@ -19,6 +19,19 @@ import type {
   AttachmentInfo,
 } from '../types';
 
+// ── Recall (#128) ──
+
+/**
+ * Raw (unfiltered, unsorted, unsliced) output of `TempoClient.recall`.
+ * The shared formatter at `src/utils/recall-format.ts` turns this into a
+ * timeline + pagination header; returning the raw shape keeps every
+ * surface's presentation logic testable without booting a client.
+ */
+export interface RecallClientResult {
+  received: Message[];
+  sent: SentMessage[];
+}
+
 // ── PR-D verb options ──
 
 export interface RestartClientOpts {
@@ -81,6 +94,13 @@ export interface TempoClient {
   migrate(ensemble: string, playerId: string, host: string, opts?: Omit<RestartClientOpts, 'host'>): Promise<RestartClientResult>;
   /** PR-D: Query a player's V2 attachment lifecycle state. */
   attachmentInfo(ensemble: string, playerId: string): Promise<AttachmentInfo>;
+  /**
+   * #128: Fetch a player's raw message timeline (received + sent). Throws
+   * when the session cannot be resolved. Callers are expected to feed the
+   * result through the shared `formatRecall` helper for filter / sort /
+   * slice / render; the client stays presentation-free.
+   */
+  recall(ensemble: string, playerId: string): Promise<RecallClientResult>;
   /** Get active schedules for an ensemble. */
   getSchedules(ensemble: string): Promise<ScheduleEntry[]>;
   /** Cancel a named schedule in an ensemble. */

--- a/src/tools/recall.ts
+++ b/src/tools/recall.ts
@@ -3,16 +3,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { WorkflowHandle } from '@temporalio/client';
 import { Message, SentMessage } from '../types';
 import { defineTool, ok, fail, formatError } from './helpers';
-import { PREVIEW_MAX_LENGTH } from '../utils/validation';
-
-interface TimelineEntry {
-  direction: 'received' | 'sent';
-  from?: string;
-  to?: string;
-  text: string;
-  timestamp: string;
-  delivered?: boolean;
-}
+import { buildTimeline, formatRecall } from '../utils/recall-format';
 
 export function registerRecallTool(
   server: McpServer,
@@ -22,87 +13,36 @@ export function registerRecallTool(
   defineTool(
     server,
     'recall',
-    'Read your own message history. Shows received messages by default; use includeSent to also see outgoing messages.',
+    'Read your own message history. Shows received messages by default; use includeSent to also see outgoing messages. `offset` pages the timeline; `previewLength` truncates bodies (unset = full text).',
     {
       limit: z.number().min(1).max(100).optional().describe('Max messages to return (default 20, max 100)'),
-      since: z.string().optional().describe('Only show messages after this ISO timestamp'),
+      offset: z.number().int().min(0).optional().describe('Skip N messages for paging (default 0)'),
+      previewLength: z.number().int().min(1).optional().describe('Truncate each body to N chars + "…"; omit for full text'),
+      since: z.string().optional().describe('Only show messages at or after this ISO timestamp'),
       from: z.string().optional().describe('Filter received messages by sender name'),
       includeSent: z.boolean().optional().describe('Include sent messages in the timeline (default: false)'),
     },
     async (args) => {
-      const { limit: rawLimit, since, from: fromFilter, includeSent } = args as {
+      const { limit, offset, previewLength, since, from: fromFilter, includeSent } = args as {
         limit?: number;
+        offset?: number;
+        previewLength?: number;
         since?: string;
         from?: string;
         includeSent?: boolean;
       };
-      const limit = rawLimit ?? 20;
 
-      // Validate since
-      let sinceTs: number | undefined;
-      if (since) {
-        sinceTs = Date.parse(since);
-        if (isNaN(sinceTs)) {
-          return fail(`Invalid ISO timestamp for "since": ${since}`);
-        }
+      // Validate `since` up-front so the formatter never sees a garbage date.
+      if (since && Number.isNaN(Date.parse(since))) {
+        return fail(`Invalid ISO timestamp for "since": ${since}`);
       }
 
       try {
-        // Query received messages
         const received: Message[] = await handle.query('allMessages');
-        const timeline: TimelineEntry[] = received.map((m) => ({
-          direction: 'received' as const,
-          from: m.from,
-          text: m.text,
-          timestamp: m.timestamp,
-          delivered: m.delivered,
-        }));
-
-        // Optionally include sent messages
-        if (includeSent) {
-          const sent: SentMessage[] = await handle.query('allSentMessages');
-          for (const s of sent) {
-            timeline.push({
-              direction: 'sent',
-              to: s.to,
-              text: s.text,
-              timestamp: s.timestamp,
-            });
-          }
-        }
-
-        // Apply filters
-        let filtered = timeline;
-
-        if (sinceTs !== undefined) {
-          filtered = filtered.filter((e) => Date.parse(e.timestamp) >= sinceTs!);
-        }
-
-        if (fromFilter) {
-          filtered = filtered.filter((e) => e.direction === 'received' ? e.from === fromFilter : true);
-        }
-
-        // Sort by timestamp descending (newest first)
-        filtered.sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
-
-        // Apply limit
-        filtered = filtered.slice(0, limit);
-
-        if (filtered.length === 0) {
-          return ok('No messages found matching the filter.');
-        }
-
-        // Format output
-        const lines = filtered.map((e) => {
-          const dir = e.direction === 'sent' ? `→ ${e.to}` : `← ${e.from}`;
-          const status = e.direction === 'received' ? (e.delivered ? '' : ' (undelivered)') : '';
-          const ts = e.timestamp;
-          // Truncate long messages in the summary
-          const preview = e.text.length > PREVIEW_MAX_LENGTH ? e.text.slice(0, PREVIEW_MAX_LENGTH) + '...' : e.text;
-          return `[${ts}] ${dir}${status}\n  ${preview}`;
-        });
-
-        return ok(`${filtered.length} message${filtered.length === 1 ? '' : 's'}:\n\n${lines.join('\n\n')}`);
+        const sent: SentMessage[] = includeSent ? await handle.query('allSentMessages') : [];
+        const timeline = buildTimeline(received, sent, Boolean(includeSent));
+        const rendered = formatRecall(timeline, { limit, offset, previewLength, since, from: fromFilter });
+        return ok(rendered.text);
       } catch (err) {
         return fail(`Failed to recall messages: ${formatError(err)}`);
       }

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -11,6 +11,7 @@ import { statusIcons, supportsUnicode } from './utils/platform';
 import { phaseToLabel } from './utils/format';
 import { listAllLineups } from '../ensemble/saver';
 import { formatAttachmentInfoForDisplay } from '../utils/attachment-format';
+import { buildTimeline, formatRecall } from '../utils/recall-format';
 
 // ── Types ──
 
@@ -297,50 +298,118 @@ async function handleBroadcast(
   }
 }
 
-/** /recall [player] — fetch message history. */
+/**
+ * /recall [player] [--limit N] [--offset N] [--preview N] [--from X]
+ *         [--since ISO] [--include-sent]
+ *
+ * #128: unified per-session recall. Without a player positional, targets
+ * the ensemble's maestro session (the TUI's natural context); with a
+ * player positional, queries that player's session — same data shape the
+ * MCP `recall` tool and `claude-tempo recall <name>` CLI surface.
+ *
+ * The legacy pre-#128 behavior (aggregated maestro relay-log filtered
+ * by player) is retired; that path was inconsistent with the other two
+ * surfaces and the design doc on #128 explicitly chose parity.
+ */
 async function handleRecall(
   args: string[],
   dispatch: (action: TuiAction) => void,
   api: TempoClient,
+  ctx: CommandContext,
 ): Promise<void> {
-  try {
-    const ensembles = await api.discoverEnsembles();
-    if (ensembles.length === 0) {
-      commitStatic(dispatch, 'info', 'No ensembles running.');
-      return;
-    }
+  const ensemble = requireEnsemble(dispatch, ctx);
+  if (!ensemble) return;
 
-    const targetPlayer = args[0];
-    const lines: string[] = [];
-
-    for (const ens of ensembles) {
-      const messages = await api.getMessages(ens.name, 20);
-      const filtered = targetPlayer
-        ? messages.filter(m => m.from === targetPlayer || m.to === targetPlayer)
-        : messages;
-
-      if (filtered.length > 0) {
-        lines.push(`\n  ${ens.name} — ${filtered.length} message${filtered.length !== 1 ? 's' : ''}:`);
-        for (const m of filtered.slice(-15)) {
-          const time = formatTimestamp(m.timestamp);
-          const text = m.text.length > 60 ? m.text.slice(0, 57) + '...' : m.text;
-          lines.push(`    ${time}  ${m.from} \u2192 ${m.to}: ${text}`);
-        }
-      }
-    }
-
-    if (lines.length === 0) {
-      commitStatic(dispatch, 'info', targetPlayer
-        ? `No messages found for "${targetPlayer}".`
-        : 'No recent messages.');
-    } else {
-      const title = targetPlayer ? `Recall \u00B7 ${targetPlayer}` : 'Recall \u00B7 all';
-      lines.push('\n  \u2139 Showing Maestro event log. Main chat uses ensemble feed.');
-      dispatch({ type: 'SHOW_COMMAND_OVERLAY', title, content: lines.join('\n') });
-    }
-  } catch (err) {
-    commitStatic(dispatch, 'error', `Failed to recall messages: ${err}`);
+  const parsed = parseRecallFlags(args);
+  if (parsed.error) {
+    commitStatic(dispatch, 'error', parsed.error);
+    return;
   }
+  // Player defaults to the ensemble's maestro — see docstring.
+  const targetPlayer = parsed.player ?? 'maestro';
+
+  try {
+    const { received, sent } = await api.recall(ensemble, targetPlayer);
+    const timeline = buildTimeline(received, sent, Boolean(parsed.includeSent));
+    const rendered = formatRecall(timeline, {
+      limit: parsed.limit,
+      offset: parsed.offset,
+      previewLength: parsed.previewLength,
+      since: parsed.since,
+      from: parsed.from,
+    });
+    const title = `Recall \u00B7 ${targetPlayer}`;
+    dispatch({ type: 'SHOW_COMMAND_OVERLAY', title, content: rendered.text });
+  } catch (err) {
+    commitStatic(dispatch, 'error', `Failed to recall messages: ${err instanceof Error ? err.message : String(err)}`);
+  }
+}
+
+interface ParsedRecallFlags {
+  player?: string;
+  limit?: number;
+  offset?: number;
+  previewLength?: number;
+  since?: string;
+  from?: string;
+  includeSent?: boolean;
+  error?: string;
+}
+
+/**
+ * Parse the `/recall` arg vector into structured flags. Exported for unit
+ * tests; the TUI handler consumes the structured result directly.
+ *
+ * Accepted shapes:
+ *   `/recall`                                    — maestro session
+ *   `/recall alice`                              — alice's session
+ *   `/recall --limit 5 --preview 80`             — flags only
+ *   `/recall alice --limit 5 --include-sent`     — player + flags
+ *
+ * Unknown flags or non-numeric values for numeric flags produce a usage
+ * error rather than silent drop, so the user isn't surprised by a default.
+ */
+export function parseRecallFlags(args: string[]): ParsedRecallFlags {
+  const out: ParsedRecallFlags = {};
+  let i = 0;
+  // Leading non-flag positional is the player override.
+  if (args.length > 0 && !args[0].startsWith('--')) {
+    out.player = args[0];
+    i = 1;
+  }
+  while (i < args.length) {
+    const flag = args[i];
+    const consumeNumber = (name: string, key: 'limit' | 'offset' | 'previewLength'): string | null => {
+      const raw = args[i + 1];
+      if (raw === undefined) return `Missing value for ${name}`;
+      const n = Number(raw);
+      if (!Number.isFinite(n) || !Number.isInteger(n) || n < (key === 'offset' ? 0 : 1)) {
+        return `Invalid ${name}: ${raw}`;
+      }
+      out[key] = n;
+      i += 2;
+      return null;
+    };
+    const consumeString = (name: string, key: 'since' | 'from'): string | null => {
+      const raw = args[i + 1];
+      if (raw === undefined) return `Missing value for ${name}`;
+      out[key] = raw;
+      i += 2;
+      return null;
+    };
+    let err: string | null = null;
+    switch (flag) {
+      case '--limit':   err = consumeNumber('--limit', 'limit'); break;
+      case '--offset':  err = consumeNumber('--offset', 'offset'); break;
+      case '--preview': err = consumeNumber('--preview', 'previewLength'); break;
+      case '--since':   err = consumeString('--since', 'since'); break;
+      case '--from':    err = consumeString('--from', 'from'); break;
+      case '--include-sent': out.includeSent = true; i += 1; break;
+      default: err = `Unknown flag: ${flag}`;
+    }
+    if (err) return { error: err };
+  }
+  return out;
 }
 
 // ── PR-D verbs — thin handlers calling TempoClient methods ──
@@ -1215,7 +1284,7 @@ export const COMMANDS: Record<string, CommandDef> = {
   },
   recall: {
     description: "Read a player's message history",
-    usage: '/recall [player] [--limit N]',
+    usage: '/recall [player] [--limit N] [--offset N] [--preview N] [--from X] [--since ISO] [--include-sent]',
     handler: handleRecall,
   },
   schedule: {

--- a/src/tui/index.ts
+++ b/src/tui/index.ts
@@ -111,6 +111,7 @@ function createDummyClient(): ReturnType<typeof createTempoClient> {
     destroy: fail,
     migrate: fail,
     attachmentInfo: fail,
+    recall: fail,
     disbandEnsemble: fail,
     isConnected: async () => false,
     hasGlobalMaestro: async () => false,

--- a/src/utils/recall-format.ts
+++ b/src/utils/recall-format.ts
@@ -1,0 +1,175 @@
+/**
+ * Shared recall formatter (#128).
+ *
+ * Single source of truth for how the MCP `recall` tool, TUI `/recall` slash
+ * command, and CLI `claude-tempo recall` present a timeline. Pure — no
+ * Temporal, no stdout, no I/O — so each surface can unit-test its rendering
+ * with canned data.
+ *
+ * Execution order (established by the #128 design):
+ *   query → filter (`since`, `from`) → sort desc by timestamp → compute
+ *   total → slice [offset, offset+limit) → conditionally truncate bodies
+ *   by `previewLength` → emit pagination header.
+ *
+ * `previewLength` is unset by default (no sane ceiling). Callers opt in to
+ * truncation; the prior hardcoded 200-char cap at the MCP tool is retired
+ * from the recall path (the shared constant stays elsewhere).
+ */
+import type { Message, SentMessage } from '../types';
+
+export interface TimelineEntry {
+  direction: 'received' | 'sent';
+  /** Sender player name for received entries; undefined for sent. */
+  from?: string;
+  /** Recipient player name for sent entries; undefined for received. */
+  to?: string;
+  text: string;
+  /** ISO timestamp. */
+  timestamp: string;
+  /** Only set on received entries. */
+  delivered?: boolean;
+}
+
+export interface RecallFormatOpts {
+  /** Max entries per page. Defaults to 20; schema enforces 1-100 upstream. */
+  limit?: number;
+  /** Skip N entries for paging. Defaults to 0. */
+  offset?: number;
+  /**
+   * Truncate each entry body to this many characters + `…`. Omitted =
+   * unlimited (full body). Schema upstream enforces `min(1)`.
+   */
+  previewLength?: number;
+  /** ISO timestamp — only entries at or after this are included. */
+  since?: string;
+  /** Sender filter — only applied to received entries. */
+  from?: string;
+}
+
+/**
+ * Build the flat, unfiltered, unsorted timeline from a session's raw query
+ * results. Mirrors the shape the MCP tool used inline before #128.
+ *
+ * `includeSent === false` drops the sent-messages lane entirely rather than
+ * tagging them `direction: 'sent'`, matching the existing MCP semantics.
+ */
+export function buildTimeline(
+  received: Message[],
+  sent: SentMessage[],
+  includeSent: boolean,
+): TimelineEntry[] {
+  const timeline: TimelineEntry[] = received.map((m) => ({
+    direction: 'received' as const,
+    from: m.from,
+    text: m.text,
+    timestamp: m.timestamp,
+    delivered: m.delivered,
+  }));
+  if (includeSent) {
+    for (const s of sent) {
+      timeline.push({
+        direction: 'sent',
+        to: s.to,
+        text: s.text,
+        timestamp: s.timestamp,
+      });
+    }
+  }
+  return timeline;
+}
+
+export interface RecallRenderResult {
+  /** Final rendered lines (header + entries, joined with blank lines between entries). */
+  text: string;
+  /** Post-filter total (before offset/limit). Useful for callers needing raw counts. */
+  total: number;
+  /** Number of entries actually rendered (≤ limit). */
+  shown: number;
+  /** `true` iff pagination would continue past `offset + limit`. */
+  hasMore: boolean;
+}
+
+/**
+ * Filter → sort → slice → render pipeline per the #128 design. Returns a
+ * single formatted string (plus counts for callers that want to branch on
+ * pagination state without re-scanning the rendered text).
+ *
+ * Header convention (matches `gh pr list` / `gh issue list`):
+ *   `Showing X-Y of Z messages.`
+ * Append `Use offset: N for next page.` only when total > offset + limit.
+ *
+ * Edge cases:
+ *   - empty (post-filter) → `No messages found matching the filter.`
+ *   - offset ≥ total (non-empty) → `No messages at offset N. Total: Z. Use offset: 0 to start over.`
+ *   - `previewLength > text.length` → full body, no ellipsis
+ */
+export function formatRecall(
+  timeline: TimelineEntry[],
+  opts: RecallFormatOpts = {},
+): RecallRenderResult {
+  const limit = opts.limit ?? 20;
+  const offset = opts.offset ?? 0;
+
+  // ── 1. Filter ──
+  let filtered = timeline;
+  if (opts.since !== undefined) {
+    const sinceTs = Date.parse(opts.since);
+    if (!Number.isNaN(sinceTs)) {
+      filtered = filtered.filter((e) => Date.parse(e.timestamp) >= sinceTs);
+    }
+  }
+  if (opts.from) {
+    filtered = filtered.filter((e) => (e.direction === 'received' ? e.from === opts.from : true));
+  }
+
+  // ── 2. Sort desc by timestamp ──
+  filtered = [...filtered].sort((a, b) => Date.parse(b.timestamp) - Date.parse(a.timestamp));
+
+  // ── 3. Compute total (post-filter) ──
+  const total = filtered.length;
+
+  // ── Early-return paths ──
+  if (total === 0) {
+    return {
+      text: 'No messages found matching the filter.',
+      total: 0,
+      shown: 0,
+      hasMore: false,
+    };
+  }
+  if (offset >= total) {
+    return {
+      text: `No messages at offset ${offset}. Total: ${total}. Use offset: 0 to start over.`,
+      total,
+      shown: 0,
+      hasMore: false,
+    };
+  }
+
+  // ── 4. Slice [offset, offset+limit) ──
+  const page = filtered.slice(offset, offset + limit);
+
+  // ── 5. Render ──
+  const renderedEntries = page.map((e) => renderEntry(e, opts.previewLength));
+  const startIdx = offset + 1;
+  const endIdx = offset + page.length;
+  const hasMore = total > offset + limit;
+  const headerLines = [`Showing ${startIdx}-${endIdx} of ${total} messages.`];
+  if (hasMore) headerLines.push(`Use offset: ${offset + limit} for next page.`);
+
+  return {
+    text: [headerLines.join(' '), '', ...renderedEntries].join('\n'),
+    total,
+    shown: page.length,
+    hasMore,
+  };
+}
+
+function renderEntry(e: TimelineEntry, previewLength?: number): string {
+  const dir = e.direction === 'sent' ? `→ ${e.to}` : `← ${e.from}`;
+  const status = e.direction === 'received' && e.delivered === false ? ' (undelivered)' : '';
+  const body = previewLength !== undefined && e.text.length > previewLength
+    ? `${e.text.slice(0, previewLength)}…`
+    : e.text;
+  return `[${e.timestamp}] ${dir}${status}\n  ${body}`;
+}

--- a/test/cli-recall.test.ts
+++ b/test/cli-recall.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Unit tests for `claude-tempo recall <player>`'s argv → formatter glue.
+ *
+ * The shared formatter (`src/utils/recall-format.ts`) has its own coverage
+ * at `test/recall.test.ts`. This file owns the CLI-specific wiring: that
+ * the argv parser builds a `ParsedArgs` the `recall()` verb consumes
+ * without loss, and that `--json` bypasses the text renderer in favor of
+ * the raw shape.
+ *
+ * We exercise the formatter directly rather than invoking the verb via
+ * the CLI (which would need a Temporal connection). The verb's job is
+ * "fetch timeline + feed formatter + emit"; this test covers the second
+ * half and a round-trip through JSON.stringify to catch format drift.
+ */
+import { expect } from 'chai';
+import type { Message, SentMessage } from '../src/types';
+import { buildTimeline, formatRecall } from '../src/utils/recall-format';
+
+describe('CLI recall formatter wiring (#128)', function () {
+  const received: Message[] = [
+    { id: '1', from: 'alice', text: 'first message', timestamp: '2026-04-19T12:00:00.000Z', delivered: true },
+    { id: '2', from: 'alice', text: 'second message', timestamp: '2026-04-19T12:00:01.000Z', delivered: true },
+    { id: '3', from: 'bob',   text: 'third message', timestamp: '2026-04-19T12:00:02.000Z', delivered: true },
+  ];
+  const sent: SentMessage[] = [
+    { id: 's-1', to: 'alice', text: 'outbound',    timestamp: '2026-04-19T11:59:59.000Z' },
+  ];
+
+  it('default opts render the gh-style header + all three entries newest-first', function () {
+    const timeline = buildTimeline(received, sent, false);
+    const r = formatRecall(timeline, {});
+    expect(r.text).to.include('Showing 1-3 of 3 messages.');
+    expect(r.text).to.not.include('Use offset:'); // not more than one page
+    // Newest first.
+    const lines = r.text.split('\n');
+    const first = lines.find((l) => l.startsWith('['));
+    expect(first).to.include('2026-04-19T12:00:02.000Z');
+  });
+
+  it('--include-sent mirrors the CLI flag → feeds buildTimeline(..., true)', function () {
+    const timelineSent = buildTimeline(received, sent, true);
+    const r = formatRecall(timelineSent, {});
+    expect(r.total).to.equal(4);
+    expect(r.text).to.include('→ alice');
+  });
+
+  it('--preview 8 truncates bodies', function () {
+    const timeline = buildTimeline(received, sent, false);
+    const r = formatRecall(timeline, { previewLength: 8 });
+    // "first message" → "first me…"
+    expect(r.text).to.include('first me…');
+  });
+
+  it('--limit 2 --offset 1 yields the middle entry + correct pagination header', function () {
+    const timeline = buildTimeline(received, [], false);
+    const r = formatRecall(timeline, { limit: 2, offset: 1 });
+    expect(r.shown).to.equal(2);
+    expect(r.hasMore).to.equal(false);
+    expect(r.text).to.include('Showing 2-3 of 3 messages.');
+    // offset skipped the newest (third message); the output should include the
+    // remaining two older entries.
+    expect(r.text).to.include('second message');
+    expect(r.text).to.include('first message');
+    expect(r.text).to.not.include('third message');
+  });
+
+  it('--json equivalent: serializing the formatter result round-trips cleanly', function () {
+    const timeline = buildTimeline(received, sent, true);
+    const r = formatRecall(timeline, { limit: 2 });
+    const raw = {
+      player: 'tempo-eng',
+      ensemble: 'demo',
+      received,
+      sent,
+      total: r.total,
+      shown: r.shown,
+      hasMore: r.hasMore,
+      text: r.text,
+    };
+    const roundtrip = JSON.parse(JSON.stringify(raw));
+    expect(roundtrip.total).to.equal(4);
+    expect(roundtrip.shown).to.equal(2);
+    expect(roundtrip.hasMore).to.equal(true);
+    expect(roundtrip.text).to.include('Showing 1-2 of 4 messages.');
+    expect(roundtrip.received).to.have.length(3);
+    expect(roundtrip.sent).to.have.length(1);
+  });
+});

--- a/test/recall.test.ts
+++ b/test/recall.test.ts
@@ -1,0 +1,260 @@
+/**
+ * Unit tests for the shared recall formatter (#128). Tests the pure
+ * pipeline — filter → sort → slice → render — without booting Temporal.
+ *
+ * The MCP `recall` tool, TUI `/recall` slash command, and `claude-tempo
+ * recall <name>` CLI all feed the same formatter; per-surface integration
+ * tests live alongside their respective modules. This file covers the
+ * core cases that apply to every surface:
+ *   - pagination header (first page, middle page, last page)
+ *   - `offset >= total` sentinel message
+ *   - empty timeline sentinel message
+ *   - `previewLength` omitted → full body
+ *   - `previewLength` set → ellipsis truncation
+ *   - `from` filter applies to received only (sent entries bypass it)
+ *   - `since` filter applies universally
+ *   - sort order (desc by timestamp)
+ */
+import { expect } from 'chai';
+import type { Message, SentMessage } from '../src/types';
+import {
+  buildTimeline,
+  formatRecall,
+  type TimelineEntry,
+} from '../src/utils/recall-format';
+
+// Helper: build N received messages at increasing timestamps for
+// predictable pagination. #0 is oldest, #N-1 is newest, so the sort-desc
+// formatter emits #N-1 first.
+function receivedFixture(n: number, from = 'alice'): Message[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `m-${i}`,
+    from,
+    text: `message body #${i}`,
+    timestamp: new Date(Date.UTC(2026, 3, 19, 12, 0, i)).toISOString(),
+    delivered: true,
+  }));
+}
+
+function sentFixture(n: number, to = 'bob'): SentMessage[] {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `s-${i}`,
+    to,
+    text: `outbound #${i}`,
+    timestamp: new Date(Date.UTC(2026, 3, 19, 11, 0, i)).toISOString(),
+  }));
+}
+
+describe('buildTimeline (#128)', function () {
+  it('maps received-only when includeSent is false', function () {
+    const timeline = buildTimeline(receivedFixture(3), sentFixture(2), false);
+    expect(timeline).to.have.length(3);
+    expect(timeline.every((e) => e.direction === 'received')).to.equal(true);
+  });
+
+  it('includes sent entries when includeSent is true', function () {
+    const timeline = buildTimeline(receivedFixture(3), sentFixture(2), true);
+    expect(timeline).to.have.length(5);
+    expect(timeline.filter((e) => e.direction === 'sent')).to.have.length(2);
+  });
+
+  it('preserves the `delivered` flag on received entries', function () {
+    const received: Message[] = [
+      { id: 'a', from: 'x', text: 't', timestamp: new Date().toISOString(), delivered: false },
+    ];
+    const timeline = buildTimeline(received, [], false);
+    expect(timeline[0].delivered).to.equal(false);
+  });
+});
+
+describe('formatRecall (#128)', function () {
+  describe('pagination header', function () {
+    it('first page (offset 0) — shows X-Y of Z + hint only if more remain', function () {
+      const timeline = buildTimeline(receivedFixture(5), [], false);
+      const r = formatRecall(timeline, { limit: 3 });
+      expect(r.total).to.equal(5);
+      expect(r.shown).to.equal(3);
+      expect(r.hasMore).to.equal(true);
+      expect(r.text).to.include('Showing 1-3 of 5 messages.');
+      expect(r.text).to.include('Use offset: 3 for next page.');
+    });
+
+    it('middle page — still offers next hint', function () {
+      const timeline = buildTimeline(receivedFixture(10), [], false);
+      const r = formatRecall(timeline, { limit: 3, offset: 3 });
+      expect(r.shown).to.equal(3);
+      expect(r.hasMore).to.equal(true);
+      expect(r.text).to.include('Showing 4-6 of 10 messages.');
+      expect(r.text).to.include('Use offset: 6 for next page.');
+    });
+
+    it('last page — omits the next-page hint', function () {
+      const timeline = buildTimeline(receivedFixture(5), [], false);
+      const r = formatRecall(timeline, { limit: 3, offset: 3 });
+      expect(r.shown).to.equal(2);
+      expect(r.hasMore).to.equal(false);
+      expect(r.text).to.include('Showing 4-5 of 5 messages.');
+      expect(r.text).to.not.include('Use offset:');
+    });
+
+    it('exactly full last page — still no next-page hint', function () {
+      const timeline = buildTimeline(receivedFixture(6), [], false);
+      const r = formatRecall(timeline, { limit: 3, offset: 3 });
+      expect(r.shown).to.equal(3);
+      expect(r.hasMore).to.equal(false);
+      expect(r.text).to.include('Showing 4-6 of 6 messages.');
+      expect(r.text).to.not.include('Use offset:');
+    });
+  });
+
+  describe('edge cases', function () {
+    it('empty (post-filter) timeline renders the no-match sentinel', function () {
+      const r = formatRecall([], { limit: 10 });
+      expect(r.total).to.equal(0);
+      expect(r.shown).to.equal(0);
+      expect(r.hasMore).to.equal(false);
+      expect(r.text).to.equal('No messages found matching the filter.');
+    });
+
+    it('offset >= total renders the "nothing at offset" sentinel', function () {
+      const timeline = buildTimeline(receivedFixture(3), [], false);
+      const r = formatRecall(timeline, { limit: 10, offset: 5 });
+      expect(r.total).to.equal(3);
+      expect(r.shown).to.equal(0);
+      expect(r.hasMore).to.equal(false);
+      expect(r.text).to.include('No messages at offset 5. Total: 3. Use offset: 0 to start over.');
+    });
+
+    it('offset exactly at total boundary also renders the sentinel', function () {
+      const timeline = buildTimeline(receivedFixture(3), [], false);
+      const r = formatRecall(timeline, { limit: 10, offset: 3 });
+      expect(r.shown).to.equal(0);
+      expect(r.text).to.include('No messages at offset 3. Total: 3.');
+    });
+  });
+
+  describe('previewLength', function () {
+    it('omitted — full body rendered, no ellipsis', function () {
+      const longBody = 'x'.repeat(500);
+      const timeline: TimelineEntry[] = [
+        {
+          direction: 'received',
+          from: 'a',
+          text: longBody,
+          timestamp: '2026-04-19T12:00:00.000Z',
+          delivered: true,
+        },
+      ];
+      const r = formatRecall(timeline);
+      expect(r.text).to.include(longBody);
+      expect(r.text).to.not.include('…');
+    });
+
+    it('set — truncates body with ellipsis', function () {
+      const timeline: TimelineEntry[] = [
+        {
+          direction: 'received',
+          from: 'a',
+          text: 'abcdefghij',
+          timestamp: '2026-04-19T12:00:00.000Z',
+          delivered: true,
+        },
+      ];
+      const r = formatRecall(timeline, { previewLength: 5 });
+      expect(r.text).to.include('abcde…');
+      expect(r.text).to.not.include('abcdef');
+    });
+
+    it('previewLength >= body length — no ellipsis added', function () {
+      const timeline: TimelineEntry[] = [
+        {
+          direction: 'received',
+          from: 'a',
+          text: 'short',
+          timestamp: '2026-04-19T12:00:00.000Z',
+          delivered: true,
+        },
+      ];
+      const r = formatRecall(timeline, { previewLength: 100 });
+      expect(r.text).to.include('short');
+      expect(r.text).to.not.include('…');
+    });
+  });
+
+  describe('filters', function () {
+    it('`from` filter applies to received only; sent entries bypass it', function () {
+      const timeline = buildTimeline(
+        [
+          { id: '1', from: 'alice', text: 'hi', timestamp: '2026-04-19T12:00:00Z', delivered: true },
+          { id: '2', from: 'carol', text: 'hey', timestamp: '2026-04-19T12:00:01Z', delivered: true },
+        ],
+        [
+          { id: 's-1', to: 'anyone', text: 'sent msg', timestamp: '2026-04-19T12:00:02Z' },
+        ],
+        true,
+      );
+      const r = formatRecall(timeline, { from: 'alice' });
+      // After filter: alice (received) + sent; carol's message was dropped.
+      expect(r.total).to.equal(2);
+      expect(r.text).to.include('hi');
+      expect(r.text).to.not.include('hey');
+      expect(r.text).to.include('sent msg');
+    });
+
+    it('`since` filter applies universally', function () {
+      const timeline = buildTimeline(
+        [
+          { id: '1', from: 'a', text: 'old', timestamp: '2026-04-19T10:00:00Z', delivered: true },
+          { id: '2', from: 'a', text: 'new', timestamp: '2026-04-19T13:00:00Z', delivered: true },
+        ],
+        [],
+        false,
+      );
+      const r = formatRecall(timeline, { since: '2026-04-19T12:00:00Z' });
+      expect(r.total).to.equal(1);
+      expect(r.text).to.include('new');
+      expect(r.text).to.not.include('old');
+    });
+
+    it('sort order is desc by timestamp (newest first)', function () {
+      const timeline = buildTimeline(receivedFixture(3), [], false);
+      const r = formatRecall(timeline, { limit: 10 });
+      // Fixture #2 is newest; first line of rendered entries should mention #2.
+      const lines = r.text.split('\n');
+      const firstEntryIdx = lines.findIndex((l) => l.startsWith('['));
+      expect(lines[firstEntryIdx]).to.include('2026-04-19T12:00:02.000Z');
+      const secondEntryIdx = lines.findIndex((l, i) => i > firstEntryIdx && l.startsWith('['));
+      expect(lines[secondEntryIdx]).to.include('2026-04-19T12:00:01.000Z');
+    });
+  });
+
+  describe('render details', function () {
+    it('received entry renders `← <from>` with delivered=true = no undelivered tag', function () {
+      const timeline = buildTimeline(
+        [{ id: '1', from: 'alice', text: 'hi', timestamp: '2026-04-19T12:00:00Z', delivered: true }],
+        [],
+        false,
+      );
+      const r = formatRecall(timeline);
+      expect(r.text).to.include('← alice');
+      expect(r.text).to.not.include('(undelivered)');
+    });
+
+    it('received entry with delivered=false appends `(undelivered)`', function () {
+      const timeline = buildTimeline(
+        [{ id: '1', from: 'alice', text: 'hi', timestamp: '2026-04-19T12:00:00Z', delivered: false }],
+        [],
+        false,
+      );
+      const r = formatRecall(timeline);
+      expect(r.text).to.include('← alice (undelivered)');
+    });
+
+    it('sent entry renders `→ <to>`, never undelivered tag', function () {
+      const timeline = buildTimeline([], [{ id: 's-1', to: 'bob', text: 'out', timestamp: '2026-04-19T12:00:00Z' }], true);
+      const r = formatRecall(timeline);
+      expect(r.text).to.include('→ bob');
+      expect(r.text).to.not.include('(undelivered)');
+    });
+  });
+});

--- a/test/tools.test.ts
+++ b/test/tools.test.ts
@@ -1055,7 +1055,8 @@ describe('recall tool validation', function () {
 
       const result = await callWith({ limit: 5 });
       expect(result.isError).to.not.equal(true);
-      expect(result.content[0].text).to.match(/^5 messages/);
+      // #128 replaced the "<N> messages:" header with gh-style pagination.
+      expect(result.content[0].text).to.match(/^Showing 1-5 of 25 messages\. Use offset: 5 for next page\./);
       // The newest message (msg-24) should appear; oldest (msg-0) should not
       expect(result.content[0].text).to.include('msg-24');
       expect(result.content[0].text).to.not.include('msg-0');

--- a/tests/tui/recall.test.ts
+++ b/tests/tui/recall.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Vitest coverage for the TUI `/recall` surface (#128).
+ *
+ * Two layers:
+ *  - `parseRecallFlags` — the pure argv parser exported from
+ *    `src/tui/commands.ts`. Drives the handler, easy to test directly.
+ *  - Handler integration via the public `COMMANDS['recall']` registry,
+ *    with a mocked `TempoClient.recall` returning a canned timeline.
+ *    Ensures the handler dispatches a `SHOW_COMMAND_OVERLAY` whose
+ *    content came from the shared formatter (pagination header +
+ *    entries).
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  COMMANDS,
+  parseRecallFlags,
+  type CommandContext,
+} from '../../src/tui/commands';
+import type { Message, SentMessage } from '../../src/types';
+import type { TempoClient } from '../../src/client';
+import type { TuiAction } from '../../src/tui/store';
+
+describe('parseRecallFlags', () => {
+  it('bare /recall → maestro default (no player on the returned struct)', () => {
+    expect(parseRecallFlags([])).toEqual({});
+  });
+
+  it('leading non-flag positional → player override', () => {
+    expect(parseRecallFlags(['alice'])).toEqual({ player: 'alice' });
+  });
+
+  it('player + numeric + string flags all parse', () => {
+    expect(
+      parseRecallFlags(['alice', '--limit', '5', '--offset', '10', '--preview', '80', '--from', 'bob', '--since', '2026-04-19T00:00:00Z']),
+    ).toEqual({
+      player: 'alice',
+      limit: 5,
+      offset: 10,
+      previewLength: 80,
+      from: 'bob',
+      since: '2026-04-19T00:00:00Z',
+    });
+  });
+
+  it('--include-sent is boolean, no value consumed', () => {
+    expect(parseRecallFlags(['--include-sent', '--limit', '3'])).toEqual({ includeSent: true, limit: 3 });
+  });
+
+  it('flags-only (no player) leaves player undefined', () => {
+    expect(parseRecallFlags(['--limit', '5'])).toEqual({ limit: 5 });
+  });
+
+  it('unknown flag surfaces a usage error', () => {
+    const r = parseRecallFlags(['--nope']);
+    expect(r.error).toMatch(/Unknown flag.*--nope/);
+  });
+
+  it('missing value on --limit is a usage error', () => {
+    const r = parseRecallFlags(['--limit']);
+    expect(r.error).toMatch(/Missing value for --limit/);
+  });
+
+  it('non-numeric --limit is a usage error', () => {
+    const r = parseRecallFlags(['--limit', 'abc']);
+    expect(r.error).toMatch(/Invalid --limit/);
+  });
+
+  it('negative --offset is rejected (< 0)', () => {
+    const r = parseRecallFlags(['--offset', '-1']);
+    expect(r.error).toMatch(/Invalid --offset/);
+  });
+
+  it('--preview 0 rejected (min 1)', () => {
+    const r = parseRecallFlags(['--preview', '0']);
+    expect(r.error).toMatch(/Invalid --preview/);
+  });
+});
+
+// ── Handler integration ────────────────────────────────────────────────
+
+function makeApi(received: Message[], sent: SentMessage[]): TempoClient {
+  const reject = () => Promise.reject(new Error('Unexpected TempoClient method call during /recall test'));
+  return new Proxy({} as TempoClient, {
+    get(_target, prop: string) {
+      if (prop === 'recall') return vi.fn(async () => ({ received, sent }));
+      return vi.fn(reject);
+    },
+  });
+}
+
+const CTX: CommandContext = { activeEnsemble: 'demo' };
+const received: Message[] = [
+  { id: '1', from: 'alice', text: 'hello', timestamp: '2026-04-19T12:00:00.000Z', delivered: true },
+  { id: '2', from: 'alice', text: 'world', timestamp: '2026-04-19T12:00:01.000Z', delivered: true },
+];
+
+describe('/recall TUI handler (#128)', () => {
+  it('renders the formatter output into a SHOW_COMMAND_OVERLAY', async () => {
+    const dispatch = vi.fn<(a: TuiAction) => void>();
+    const handler = COMMANDS['recall'].handler!;
+    await handler([], dispatch, makeApi(received, []), CTX);
+
+    expect(dispatch).toHaveBeenCalledTimes(1);
+    const action = dispatch.mock.calls[0][0] as { type: string; title: string; content: string };
+    expect(action.type).toBe('SHOW_COMMAND_OVERLAY');
+    // Default targets maestro.
+    expect(action.title).toBe('Recall \u00B7 maestro');
+    expect(action.content).toContain('Showing 1-2 of 2 messages.');
+    // Newest first: line 2 ("world") should precede "hello".
+    const worldIdx = action.content.indexOf('world');
+    const helloIdx = action.content.indexOf('hello');
+    expect(worldIdx).toBeGreaterThan(-1);
+    expect(helloIdx).toBeGreaterThan(-1);
+    expect(worldIdx).toBeLessThan(helloIdx);
+  });
+
+  it('with a player positional, titles the overlay with that player', async () => {
+    const dispatch = vi.fn<(a: TuiAction) => void>();
+    const handler = COMMANDS['recall'].handler!;
+    await handler(['alice'], dispatch, makeApi(received, []), CTX);
+
+    const action = dispatch.mock.calls[0][0] as { type: string; title: string };
+    expect(action.title).toBe('Recall \u00B7 alice');
+  });
+
+  it('flag parse error dispatches a COMMIT_STATIC error, not an overlay', async () => {
+    const dispatch = vi.fn<(a: TuiAction) => void>();
+    const handler = COMMANDS['recall'].handler!;
+    await handler(['--nope'], dispatch, makeApi(received, []), CTX);
+
+    // No overlay on the error path.
+    const overlays = dispatch.mock.calls.filter(
+      ([a]) => (a as { type: string }).type === 'SHOW_COMMAND_OVERLAY',
+    );
+    expect(overlays.length).toBe(0);
+    const errors = dispatch.mock.calls.filter(
+      ([a]) => (a as { type: string }).type === 'COMMIT_STATIC',
+    );
+    expect(errors.length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the three #128 gaps in one PR:

1. **200-char truncation was unconditional** — `previewLength` now defaults to unlimited. Callers opt in.
2. **No pagination** — new `offset` param + gh-style header (`Showing X-Y of Z messages. Use offset: N for next page.`).
3. **CLI had no recall command** — new `claude-tempo recall <player>` ships with `--json` for shell-pipeline callers.

Unified via a shared formatter at `src/utils/recall-format.ts` (same pattern as #264's `attachment-format`). MCP tool, TUI `/recall`, and CLI all consume the one function — no drift possible.

Closes #128.

## Three surfaces

| Surface | Signature |
|---|---|
| MCP tool | `recall({ limit?, offset?, previewLength?, since?, from?, includeSent? })` |
| TUI slash | `/recall [player] [--limit N] [--offset N] [--preview N] [--from X] [--since ISO] [--include-sent]` |
| CLI | `claude-tempo recall <player> [--limit N] [--offset N] [--preview N] [--from X] [--since ISO] [--include-sent] [--json]` |

## Semantic shift in TUI (⚠ breaking)

Pre-#128, `/recall [player]` walked all ensembles and rendered the maestro relay log filtered by player. Post-#128, `/recall [player]` queries **a session's inbox** via `TempoClient.recall` — same data shape the MCP tool surfaces to the invoking player and the CLI surfaces to `<player>`. With the positional omitted it defaults to the maestro session (the TUI's natural context).

The old aggregated-ensemble-chat behavior is retired in favor of consistency across surfaces. Use `/status` / `claude-tempo status` for ensemble overview.

**Conductor — this is a flag for review.** The brief listed TUI `/recall [--flags]` without a positional; I kept the positional as optional for backward compat on `/recall alice`. If you'd prefer strict no-positional, one-line fix.

## New: `TempoClient.recall`

```ts
recall(ensemble: string, playerId: string): Promise<{ received: Message[]; sent: SentMessage[] }>
```

Resolves session via search attributes, runs `allMessages` + `allSentMessages` in parallel, throws on missing session so surface wrappers can emit clean "not found" errors.

## Tests

- `test/recall.test.ts` — **19 mocha** cases for the shared formatter (pagination header shapes, edge cases, `previewLength` branches, filters, render details)
- `test/cli-recall.test.ts` — **5 mocha** cases for CLI argv → formatter wiring, including `--json` round-trip
- `tests/tui/recall.test.ts` — **13 vitest** cases for `parseRecallFlags` + the TUI handler integration via `COMMANDS['recall']` with a mocked `TempoClient.recall`
- `test/tools.test.ts` — one existing recall-validation assertion updated to match the new gh-style header

Spot-revert RED→GREEN confirmed: dropping `offset` from the formatter slice produced a discriminating failure on "last page — omits the next-page hint"; restoring → full green.

## Scope compliance

- ✅ Comms-safe zone — no `src/workflows/`, signals/queries, adapters, or wire-protocol edits
- ✅ `TempoClient.getAttachmentInfo` untouched; `recall` is purely additive
- ✅ `PREVIEW_MAX_LENGTH` stays in `src/utils/validation.ts` (still used by `src/activities/outbox.ts`); only the recall import dropped
- ✅ Docs updated in-PR — `docs/tools.md`, `docs/cli.md`, `README.md`. No `CLAUDE.md` change needed (no structure moved)

## Output example

```
Showing 1-3 of 42 messages. Use offset: 3 for next page.

[2026-04-19T12:00:02.000Z] ← alice
  hey can you review the recall PR when you get a chance?
[2026-04-19T12:00:01.000Z] ← bob
  +1 on the gh-style header
[2026-04-19T12:00:00.000Z] ← alice
  good morning
```

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx mocha --no-config --require dist-test/test/root-hooks.js dist-test/test/recall.test.js dist-test/test/cli-recall.test.js` — 24 passing
- [x] `npx vitest run tests/tui/recall.test.ts` — 13 passing
- [x] Updated `tools.test.ts` recall-validation — passes against new format
- [x] Spot-revert RED→GREEN confirmed
- [ ] CI matrix (6 jobs) — waiting on CI