### PR TITLE
chore: bump version to v0.26.0-beta.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.0-beta.6] - 2026-04-19
+
+### Added
+- `recall` MCP tool: new `offset` (paging) and `previewLength` (body truncation) parameters (#128).
+- New `claude-tempo recall <player>` CLI command — reads a player's inbox with full flag parity to the MCP tool (`--limit`, `--offset`, `--preview`, `--from`, `--since`, `--include-sent`, `--json`) (#128).
+- TUI `/attachment-info` now renders heartbeat age, matching the CLI and MCP surfaces (#264).
+
+### Changed
+- **Breaking (TUI):** `/recall [player]` semantics changed — now queries the named player's inbox directly (or the maestro session if omitted), matching MCP and CLI. Previously rendered an aggregated maestro relay-log view filtered by player name. (#128)
+- `recall` no longer truncates message bodies by default — full text is returned unless `previewLength` is set (#128).
+- `attachment-info` output is now identical across CLI, TUI, and MCP, rendered by a single shared formatter (`src/utils/attachment-format.ts`) (#264).
+
 ## [0.26.0-beta.5] - 2026-04-19
 
 ### Added

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,7 @@ claude-tempo <command> [options]
 | `destroy <name>` | Terminate a session's workflow — ordered shutdown via outbox drain. Use for permanent removal. |
 | `migrate <name>` | Move a session to a different host — sugar for `setPreferredHost` + `restart` on the target machine. Use `--to <hostname>`. |
 | `attachment-info <name>` | Inspect a session's attachment phase, current holder, lease expiry, heartbeat age, and in-flight message count. |
-| `recall <name>` | Read a player's message history (#128). Flags: `--limit N` (default 20, max 100), `--offset N` (paging, default 0), `--preview N` (truncate bodies to N chars; omit for full text), `--from X` (sender filter for received), `--since ISO` (time filter), `--include-sent` (include outbound too), `--json` (emit raw `{received, sent, total, shown, hasMore, text}`). |
+| `recall <name>` | Read a player's message history (#128). Flags: `--limit N` (default 20, max 100 — CLI does not enforce this cap yet; see #270), `--offset N` (paging, default 0), `--preview N` (truncate bodies to N chars; omit for full text), `--from X` (sender filter for received), `--since ISO` (time filter), `--include-sent` (include outbound too), `--json` (emit raw `{received, sent, total, shown, hasMore, text}`). |
 | `restore [name]` | **v0.25.** Restore orphaned (detached) sessions. Interactive picker by default; `--all` restores every orphan, `--from-host <hostname>` filters by preferred host, `--dry-run` lists without restoring. |
 | `release [ensemble]` | Release all held players — unlocks outboxes and delivers deferred task messages. Use `-n <name>` to release one player. |
 | `pause [ensemble]` | Pause the ensemble — locks all session outbox dispatch and pauses the scheduler. |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -23,8 +23,8 @@ These tools are available inside Claude Code sessions connected to claude-tempo.
 | `detach` | Gracefully detach a player's adapter — triggers draining and clean handoff. Use before a planned `migrate` or host maintenance. |
 | `destroy` | Terminate a session via ordered shutdown (outbox drain). Use for permanent removal. |
 | `migrate` | Move a session to a different host — sets preferred host then triggers `restart` on the target machine's task queue. Requires `to` (target hostname). |
-| `attachment_info` | Fetch the current attachment phase, adapter ID, lease expiry, and in-flight message count for a player. Accepts `player` name. |
-| `recall` | Read your own message history. Shows received messages by default; pass `includeSent: true` for the full timeline. `offset` pages the timeline (gh-style `Showing X-Y of Z messages. Use offset: N for next page.`); `previewLength` truncates bodies to N chars (unset = full text). #128 unified the output with the TUI `/recall` and CLI `claude-tempo recall` via a shared formatter. |
+| `attachment_info` | Fetch the current attachment phase, adapter ID, lease expiry, heartbeat age, and in-flight message count for a player. Accepts `player` name. Output matches CLI and TUI surfaces (shared formatter, #264). |
+| `recall` | Read your own message history. Shows received messages by default; pass `includeSent: true` for the full timeline. `limit` caps results (default 20, max 100); `offset` pages the timeline (gh-style `Showing X-Y of Z messages. Use offset: N for next page.`); `previewLength` truncates bodies to N chars (unset = full text). #128 unified the output with the TUI `/recall` and CLI `claude-tempo recall` via a shared formatter. |
 | `worktree` | Manage git worktrees for player isolation. Actions: `create`, `remove`, `list`. Conductor only. |
 | `quality_gate` | Define or replace a quality gate for a task — a named checklist of criteria that must pass. Conductor only. |
 | `evaluate_gate` | Mark one or more criteria on a quality gate as passed or failed. Conductor only. |

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -56,12 +56,12 @@ Use `/players <name>` to open a scrollable message history for any player.
 | `/detach <player>` | Gracefully detach a player's adapter — triggers draining and clean handoff. |
 | `/destroy <player>` | Terminate a session via ordered shutdown (outbox drain). Use for permanent removal. |
 | `/migrate <player> --to <hostname>` | Move a session to a different host. Requires target host to have an active daemon. |
-| `/attachment-info <player>` | Show the current attachment phase, lease expiry, and in-flight count for a player. |
+| `/attachment-info <player>` | Show the current attachment phase, lease expiry, heartbeat age, and in-flight count for a player. Output matches CLI and MCP surfaces (shared formatter, #264). |
 | `/disband` | Tear down the current ensemble — all sessions, scheduler, and Maestro |
 | `/players [name]` | Show detailed player info; no args opens interactive picker |
 | `/ensemble [name]` | Switch active ensemble context; no args opens picker |
 | `/status` | Show dismissible overlay with all players, status, type, and part |
-| `/recall [player]` | Show recent message history (optionally filtered to one player) |
+| `/recall [player]` | Query a player's inbox directly. Omit player to target the maestro session. Flags: `--limit N` (default 20), `--offset N` (paging), `--preview N` (truncate bodies; omit = full text), `--from X`, `--since ISO`, `--include-sent`. (#128: unified semantics with MCP `recall` and `claude-tempo recall` CLI.) |
 | `/search <term>` | Search message history across the ensemble |
 | `/schedule [create \| delete <name>]` | List active schedules (interactive overlay); `create` launches the schedule wizard; `delete <name>` cancels a named schedule |
 | `/lineup load <file> \| save [file]` | Load or save an ensemble lineup |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.5",
+  "version": "0.26.0-beta.6",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Version bump for v0.26.0-beta.6. Bundles the doc consolidation commit (`fa3c182`) from tempo-docs with the version bump + CHANGELOG entry.

## What's in this release

Covers #128 (recall redesign) and #264 (attachment-info formatter parity). #233 was internal test refactor — omitted from CHANGELOG per conductor guidance.

### Added
- `recall` MCP tool: new `offset` (paging) and `previewLength` (body truncation) parameters (#128).
- New `claude-tempo recall <player>` CLI command with full flag parity (#128).
- TUI `/attachment-info` now renders heartbeat age, matching CLI and MCP surfaces (#264).

### Changed
- **Breaking (TUI):** `/recall [player]` semantics changed — queries named player's inbox directly (#128).
- `recall` no longer truncates message bodies by default (#128).
- `attachment-info` output unified across CLI, TUI, and MCP via shared formatter (#264).

## Checklist
- [x] `package.json` bumped `0.26.0-beta.5` → `0.26.0-beta.6`
- [x] `CHANGELOG.md` entry added (verbatim from conductor brief)
- [x] Doc consolidation commit `fa3c182` from tempo-docs included
- [ ] CI green — pending this PR