### PR TITLE
fix(recall): enforce --limit max=100 on CLI + TUI to match MCP schema (#270)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,7 @@ claude-tempo <command> [options]
 | `destroy <name>` | Terminate a session's workflow — ordered shutdown via outbox drain. Use for permanent removal. |
 | `migrate <name>` | Move a session to a different host — sugar for `setPreferredHost` + `restart` on the target machine. Use `--to <hostname>`. |
 | `attachment-info <name>` | Inspect a session's attachment phase, current holder, lease expiry, heartbeat age, and in-flight message count. |
-| `recall <name>` | Read a player's message history (#128). Flags: `--limit N` (default 20, max 100 — CLI does not enforce this cap yet; see #270), `--offset N` (paging, default 0), `--preview N` (truncate bodies to N chars; omit for full text), `--from X` (sender filter for received), `--since ISO` (time filter), `--include-sent` (include outbound too), `--json` (emit raw `{received, sent, total, shown, hasMore, text}`). |
+| `recall <name>` | Read a player's message history (#128). Flags: `--limit N` (default 20, max 100), `--offset N` (paging, default 0), `--preview N` (truncate bodies to N chars; omit for full text), `--from X` (sender filter for received), `--since ISO` (time filter), `--include-sent` (include outbound too), `--json` (emit raw `{received, sent, total, shown, hasMore, text}`). |
 | `restore [name]` | **v0.25.** Restore orphaned (detached) sessions. Interactive picker by default; `--all` restores every orphan, `--from-host <hostname>` filters by preferred host, `--dry-run` lists without restoring. |
 | `release [ensemble]` | Release all held players — unlocks outboxes and delivers deferred task messages. Use `-n <name>` to release one player. |
 | `pause [ensemble]` | Pause the ensemble — locks all session outbox dispatch and pauses the scheduler. |

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -61,7 +61,7 @@ Use `/players <name>` to open a scrollable message history for any player.
 | `/players [name]` | Show detailed player info; no args opens interactive picker |
 | `/ensemble [name]` | Switch active ensemble context; no args opens picker |
 | `/status` | Show dismissible overlay with all players, status, type, and part |
-| `/recall [player]` | Query a player's inbox directly. Omit player to target the maestro session. Flags: `--limit N` (default 20), `--offset N` (paging), `--preview N` (truncate bodies; omit = full text), `--from X`, `--since ISO`, `--include-sent`. (#128: unified semantics with MCP `recall` and `claude-tempo recall` CLI.) |
+| `/recall [player]` | Query a player's inbox directly. Omit player to target the maestro session. Flags: `--limit N` (default 20, max 100), `--offset N` (paging), `--preview N` (truncate bodies; omit = full text), `--from X`, `--since ISO`, `--include-sent`. (#128: unified semantics with MCP `recall` and `claude-tempo recall` CLI.) |
 | `/search <term>` | Search message history across the ensemble |
 | `/schedule [create \| delete <name>]` | List active schedules (interactive overlay); `create` launches the schedule wizard; `delete <name>` cancels a named schedule |
 | `/lineup load <file> \| save [file]` | Load or save an ensemble lineup |

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -173,12 +173,20 @@ function parseArgs(argv: string[]): ParsedArgs {
     } else if (arg === '--dry-run') {
       result.dryRun = true;
     } else if (arg === '--limit' && i + 1 < argv.length) {
-      const n = Number(argv[++i]);
-      if (Number.isInteger(n) && n >= 1) result.limit = n;
-      else {
-        out.error(`Invalid --limit: ${argv[i]}`);
+      const raw = argv[++i];
+      const n = Number(raw);
+      if (!Number.isInteger(n) || n < 1) {
+        out.error(`Invalid --limit: ${raw}`);
         process.exit(1);
       }
+      // #270: cap at 100 to match the MCP Zod schema. Recall queries load
+      // the full inbox/sent history from the workflow; the cap bounds the
+      // worst-case payload across every surface. Use `--offset` to page.
+      if (n > 100) {
+        out.error(`--limit exceeds max (100). Use --offset N to page through more results.`);
+        process.exit(1);
+      }
+      result.limit = n;
     } else if (arg === '--offset' && i + 1 < argv.length) {
       const n = Number(argv[++i]);
       if (Number.isInteger(n) && n >= 0) result.offset = n;

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -386,6 +386,14 @@ export function parseRecallFlags(args: string[]): ParsedRecallFlags {
       if (!Number.isFinite(n) || !Number.isInteger(n) || n < (key === 'offset' ? 0 : 1)) {
         return `Invalid ${name}: ${raw}`;
       }
+      // #270: cap --limit at 100 to match the MCP Zod schema. Recall queries
+      // load the full inbox/sent history from the workflow; the cap bounds
+      // the worst-case payload across every surface. Error message matches
+      // the CLI parser at `src/cli.ts` verbatim so operators see the same
+      // suggestion regardless of entry point.
+      if (key === 'limit' && n > 100) {
+        return `--limit exceeds max (100). Use --offset N to page through more results.`;
+      }
       out[key] = n;
       i += 2;
       return null;

--- a/test/cli-recall.test.ts
+++ b/test/cli-recall.test.ts
@@ -13,8 +13,16 @@
  * half and a round-trip through JSON.stringify to catch format drift.
  */
 import { expect } from 'chai';
+import { spawnSync } from 'child_process';
+import * as path from 'path';
 import type { Message, SentMessage } from '../src/types';
 import { buildTimeline, formatRecall } from '../src/utils/recall-format';
+
+// `__dirname` at runtime is `<repo>/dist-test/test`. Repo root is two levels up,
+// matching the pattern `test/wire-protocol.test.ts` and `test/cli-spawn-sentinel.test.ts`
+// already use for source-path resolution.
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const CLI_ENTRY = path.join(REPO_ROOT, 'dist', 'cli.js');
 
 describe('CLI recall formatter wiring (#128)', function () {
   const received: Message[] = [
@@ -62,6 +70,38 @@ describe('CLI recall formatter wiring (#128)', function () {
     expect(r.text).to.include('second message');
     expect(r.text).to.include('first message');
     expect(r.text).to.not.include('third message');
+  });
+
+  // ── Parser-cap tests (#270) ────────────────────────────────────────
+  // Exercise the real CLI argv parser as a subprocess so we get the
+  // production `process.exit(1)` semantics. The rejection happens in
+  // `parseArgs` before the command dispatch, so the subprocess exits
+  // without touching Temporal — safe to run without a dev server.
+  describe('--limit cap (#270)', function () {
+    this.timeout(10_000);
+
+    it('rejects --limit 101 with the shared max=100 error', function () {
+      const result = spawnSync(process.execPath, [CLI_ENTRY, 'recall', 'alice', '--limit', '101'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+      expect(result.status).to.equal(1, `expected exit 1; got ${result.status}; stderr=${result.stderr}`);
+      // Error message must match the TUI parser verbatim so operators see the
+      // same suggestion regardless of entry point. (Exact string, not substring.)
+      expect(result.stderr).to.include('--limit exceeds max (100). Use --offset N to page through more results.');
+    });
+
+    it('accepts --limit 100 (the exact boundary) without parser error', function () {
+      // At 100 the parser must pass; the command will still fail downstream
+      // because there's no Temporal connection in the test env — we assert
+      // the error is NOT the parser's cap error.
+      const result = spawnSync(process.execPath, [CLI_ENTRY, 'recall', 'alice', '--limit', '100'], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 8_000,
+      });
+      expect(result.stderr).to.not.include('--limit exceeds max');
+    });
   });
 
   it('--json equivalent: serializing the formatter result round-trips cleanly', function () {

--- a/tests/tui/recall.test.ts
+++ b/tests/tui/recall.test.ts
@@ -74,6 +74,17 @@ describe('parseRecallFlags', () => {
     const r = parseRecallFlags(['--preview', '0']);
     expect(r.error).toMatch(/Invalid --preview/);
   });
+
+  it('--limit 101 rejected with max=100 hint (#270)', () => {
+    const r = parseRecallFlags(['--limit', '101']);
+    // Exact message is shared with the CLI parser — tested for substring to
+    // catch both "exceeds max (100)" and the "--offset" workaround hint.
+    expect(r.error).toBe('--limit exceeds max (100). Use --offset N to page through more results.');
+  });
+
+  it('--limit 100 is still accepted (boundary)', () => {
+    expect(parseRecallFlags(['--limit', '100'])).toEqual({ limit: 100 });
+  });
 });
 
 // ── Handler integration ────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

tempo-qa's #269 review flagged that the MCP tool enforces `limit.max(100)` via Zod while the CLI argv parser and the TUI `parseRecallFlags` only enforced `min >= 1` — so `--limit 500` silently flowed through the shared formatter and returned 500 entries. Fixes the parsers and drops the stale `#270` TODO in `docs/cli.md`.

Closes #270.

## Change shape

| Surface | Before | After |
|---|---|---|
| MCP tool (Zod) | `min(1).max(100)` ✅ | unchanged |
| CLI `src/cli.ts` | `n >= 1` only | adds `n > 100` → `process.exit(1)` |
| TUI `parseRecallFlags` | `n < 1` only | `key === 'limit' && n > 100` → usage error |

## Error message (byte-for-byte identical across CLI + TUI)

```
--limit exceeds max (100). Use --offset N to page through more results.
```

Pointing the user at `--offset` turns what would otherwise be a "try harder" dead-end into an actionable workaround.

## Tests

- `tests/tui/recall.test.ts` — 2 new vitest cases (`--limit 101` rejected with exact message; `--limit 100` boundary still accepted)
- `test/cli-recall.test.ts` — 2 new mocha subprocess cases via `spawnSync(process.execPath, [CLI_ENTRY, …])`. The CLI parser's `process.exit(1)` semantics are load-bearing; testing through the real binary is the honest way.

Spot-revert RED→GREEN: stripping the cap from both parsers fails the new tests with distinct, informative errors; restoring → full green (15 vitest, 7 mocha cli-recall).

## Scope compliance

- ✅ Comms-safe: no workflow/signal/adapter touched. Pure parser-layer.
- ✅ Shared formatter untouched — the cap is rightly enforced at the edge (parser), not the core.
- ✅ `docs/cli.md` TODO removed — the cap is now accurate end-to-end.
- ✅ ~72 LOC delta, 2 test cases per surface. Within brief.

## Test plan

- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vitest run tests/tui/recall.test.ts` — **15 passing** (13 existing + 2 new)
- [x] `npx mocha --no-config … dist-test/test/cli-recall.test.js` — **7 passing** (5 existing + 2 new)
- [x] Spot-revert RED→GREEN confirmed on both surfaces
- [ ] CI matrix (6 jobs) — waiting on CI