### PR TITLE
chore: bump version to v0.26.0-beta.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [0.26.0-beta.7] - 2026-04-20
+
+### Fixed
+- `recall` CLI and TUI now enforce `--limit` max=100, matching the MCP tool (closes a parity gap from v0.26.0-beta.6). (#270)
+
 ## [0.26.0-beta.6] - 2026-04-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.6",
+  "version": "0.26.0-beta.7",
   "description": "MCP server for multi-session Claude Code coordination via Temporal",
   "keywords": [
     "mcp",


### PR DESCRIPTION
Version bump for v0.26.0-beta.7. Completes the #128 consistency story by landing the `--limit` parser-layer cap (#270) on npm.

## Changes in this release

### Fixed
- `recall` CLI and TUI now enforce `--limit` max=100, matching the MCP tool (closes a parity gap from v0.26.0-beta.6). (#270)

## Checklist
- [x] `package.json` bumped `0.26.0-beta.6` → `0.26.0-beta.7`
- [x] `CHANGELOG.md` entry added under `## [0.26.0-beta.7] - 2026-04-20`
- [ ] CI green — pending this PR