### PR TITLE
feat(reconcile): extract shared orphan-recovery helper (#93)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-tempo",
-  "version": "0.26.0-beta.3",
+  "version": "0.26.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-tempo",
-      "version": "0.26.0-beta.3",
+      "version": "0.26.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "~1.28.0",

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -567,6 +567,37 @@ export async function start(opts: StartOpts) {
       out.warn(`Lineup player/schedule setup encountered errors: ${err instanceof Error ? err.message : String(err)}`);
     }
   }
+
+  // #93: resume flow — after the conductor is spawned, scan for orphaned
+  // player workflows on this host and enqueue `restart` entries on their
+  // outboxes so the daemon re-attaches. Reuses the same helper the daemon
+  // calls at boot (`reconcileOnBoot`). Only fires when the user explicitly
+  // chose the resume path (`--resume` or `up` option 2).
+  if (opts.conductor && opts.resume && conductorClient) {
+    try {
+      const { restoreOrphansOnce, formatRestoreOutcome } = await import('../reconcile/orphans');
+      const summary = await restoreOrphansOnce(
+        conductorClient,
+        { hostname: hostname(), invokerPlayerId: 'cli', policy: 'auto' },
+      );
+      if (summary.details.length > 0) {
+        console.log();
+        out.heading('Orphaned players');
+        for (const d of summary.details) {
+          const text = `${d.playerId} — ${formatRestoreOutcome(d.outcome)}`;
+          switch (d.outcome.kind) {
+            case 'queued': out.success(text); break;
+            case 'failed': out.warn(text); break;
+            case 'skipped': out.log(`  ${out.dim(text)}`); break;
+          }
+        }
+        out.log(`${summary.reattached} reattached, ${summary.skipped} skipped, ${summary.failed} failed.`);
+      }
+    } catch (err) {
+      out.warn(`Orphan restore scan failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
   if (conductorConnection) {
     try { await conductorConnection.close(); } catch { /* best effort */ }
   }

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -14,12 +14,12 @@ import * as path from 'path';
 import { setTimeout as sleep } from 'timers/promises';
 import { Client } from '@temporalio/client';
 import { WorkflowIdConflictPolicy } from '@temporalio/client';
-import { getConfig, type Config, CLAUDE_TEMPO_HOME, GLOBAL_MAESTRO_WORKFLOW_ID, loadDaemonConfig, isEnsembleAllowed, type DaemonConfig } from './config';
+import { getConfig, type Config, CLAUDE_TEMPO_HOME, GLOBAL_MAESTRO_WORKFLOW_ID, loadDaemonConfig, type DaemonConfig } from './config';
 import { createWorkers } from './worker';
 import { createTemporalConnection } from './connection';
 import { DAEMON_PID_PATH, DAEMON_LOG_PATH, DAEMON_HEARTBEAT_PATH, HEARTBEAT_INTERVAL_MS } from './cli/daemon';
 import { createTempoClient } from './client';
-import { queryOrphanedSessions, type OrphanCandidate } from './reconcile/orphans';
+import { queryOrphanedSessions, restoreOrphansOnce, type OrphanCandidate } from './reconcile/orphans';
 import { listAgentTypes } from './ensemble/agent-types';
 import type { GlobalMaestroInput, HostProfile } from './types';
 
@@ -351,99 +351,37 @@ export async function reconcileOnBoot(
 
   log(`reconcile: scanning for orphans on host="${hostname}" (policy=${daemonConfig.restorePolicy})`);
 
-  let orphans: OrphanCandidate[];
-  try {
-    orphans = await queryOrphanedSessions(client, { hostname }, log);
-  } catch (err) {
-    log('reconcile: orphan query failed (non-fatal):', err instanceof Error ? err.message : String(err));
-    return;
-  }
+  // #93 / #285: the decision loop (cross-host filter, age window, allowlist,
+  // restart via outbox) was extracted to `restoreOrphansOnce` so the CLI
+  // resume flow (`up` option 2, `conduct --resume`) shares the same
+  // behavior. Pass `invokerPlayerId: 'daemon'` to preserve the previous
+  // operator identity, and inject `now` as a closure over the pinned ref
+  // time so the existing rebuild-reboot tests keep their fixture semantics.
+  const summary = await restoreOrphansOnce(
+    client,
+    {
+      hostname,
+      invokerPlayerId: 'daemon',
+      policy: daemonConfig.restorePolicy,
+      autoRestoreMaxAgeHours: daemonConfig.autoRestoreMaxAgeHours,
+      autoRestoreEnsembles: daemonConfig.autoRestoreEnsembles,
+      now: () => now,
+    },
+    log,
+  );
 
-  if (orphans.length === 0) {
+  const total = summary.reattached + summary.skipped + summary.failed;
+  if (total === 0) {
     log('reconcile: no orphans found');
     return;
   }
-
-  log(`reconcile: found ${orphans.length} orphan${orphans.length === 1 ? '' : 's'}`);
-
-  // PR-F cross-host filter (design §16 + brief §8 answer 2). A session whose
-  // `preferredHost` points to a different machine should not be restored by
-  // this daemon — the remote host's daemon is the authoritative restorer.
-  // Log-and-skip only: proactive cross-daemon signaling is a v0.26 feature
-  // (tracked as a follow-up; see brief §6 "reconcileOnBoot cross-host signal
-  // path is out of scope").
-  const originalOrphans = orphans;
-  orphans = originalOrphans.filter((o) => {
-    if (o.summary.preferredHost && o.summary.preferredHost !== hostname) {
-      log(`skipping restore for ${o.workflowId}: preferredHost=${o.summary.preferredHost}, localHost=${hostname}`);
-      return false;
-    }
-    return true;
-  });
-  const crossHostSkipped = originalOrphans.length - orphans.length;
-  if (crossHostSkipped > 0) {
-    log(`reconcile: skipped ${crossHostSkipped} orphan${crossHostSkipped === 1 ? '' : 's'} preferring remote hosts`);
-  }
-  if (orphans.length === 0) {
-    // All candidates filtered out — nothing to do on this host.
-    return;
-  }
-
-  if (daemonConfig.restorePolicy === 'prompt') {
-    for (const o of orphans) {
-      log(
-        `reconcile: [prompt] ${o.workflowId} ` +
-        `— phase=${o.info.phase} detachedSince=${o.summary.detachedSince ?? '(unknown)'} ` +
-        `preferredHost=${o.summary.preferredHost ?? '(unset)'}`,
-      );
-    }
+  log(
+    `reconcile: ${summary.reattached} reattached, ` +
+    `${summary.skipped} skipped, ${summary.failed} failed ` +
+    `(scanned ${total})`,
+  );
+  if (daemonConfig.restorePolicy === 'prompt' && summary.skipped > 0) {
     log('reconcile: [prompt] run `claude-tempo restore` to restore interactively');
-    return;
-  }
-
-  // restorePolicy === 'auto'
-  const ageWindowMs = daemonConfig.autoRestoreMaxAgeHours * 60 * 60 * 1000;
-  const tempo = createTempoClient(client);
-
-  for (const o of orphans) {
-    // Age filter — ignore orphans older than autoRestoreMaxAgeHours.
-    if (o.summary.detachedSince) {
-      const detachedAt = Date.parse(o.summary.detachedSince);
-      if (Number.isFinite(detachedAt) && now - detachedAt > ageWindowMs) {
-        log(`reconcile: [auto] skip ${o.workflowId} — detachedSince out of age window`);
-        continue;
-      }
-    }
-
-    // Ensemble allowlist — simple prefix match per §8 answer 5.
-    const ensemble = o.summary.ensemble;
-    if (!isEnsembleAllowed(ensemble, daemonConfig.autoRestoreEnsembles)) {
-      log(`reconcile: [auto] skip ${o.workflowId} — ensemble "${ensemble}" not in allowlist`);
-      continue;
-    }
-
-    // Restore target — read canonical playerId from OrphanSummary (#143).
-    const playerId = o.summary.playerId;
-    const targetHost = o.summary.preferredHost ?? hostname;
-    try {
-      const result = await tempo.restart(ensemble, playerId, {
-        host: targetHost,
-        invokerPlayerId: 'daemon',
-      });
-      log(
-        `reconcile: [auto] queued restart for "${playerId}" in "${ensemble}" ` +
-        `on host="${targetHost}" (outbox ${result.entryId})`,
-      );
-    } catch (err) {
-      // §10.6: silent backoff on AttachmentConflict. Any other failure logs
-      // but doesn't break the reconcile loop.
-      const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes('AttachmentConflict')) {
-        log(`reconcile: [auto] skip ${o.workflowId} — attachment already claimed (AttachmentConflict)`);
-      } else {
-        log(`reconcile: [auto] restart failed for ${o.workflowId}: ${msg}`);
-      }
-    }
   }
 }
 

--- a/src/reconcile/orphans.ts
+++ b/src/reconcile/orphans.ts
@@ -28,6 +28,8 @@
 import type { Client } from '@temporalio/client';
 import type { AttachmentInfo, OrphanSummary } from '../types';
 import { attachmentInfoQuery, orphanSummaryQuery } from '../workflows/signals';
+import { isEnsembleAllowed } from '../config';
+import { createTempoClient } from '../client';
 
 /**
  * A session workflow observed to be an orphan: the workflow is alive but no
@@ -129,4 +131,217 @@ export async function queryOrphanedSessions(
   }
 
   return orphans;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// Shared orphan-recovery loop (#93, #285)
+// ─────────────────────────────────────────────────────────────────────────
+
+/**
+ * Options for {@link restoreOrphansOnce}. `policy: 'never'` is NOT included
+ * here — callers that want a silent no-op skip the helper entirely. The
+ * daemon's `reconcileOnBoot` short-circuits on `restorePolicy === 'never'`
+ * before reaching this helper.
+ */
+export interface RestoreOrphansOpts {
+  /** Local hostname — matched against the orphan query filter and used as
+   *  the default target when a candidate's `preferredHost` is unset. */
+  hostname: string;
+  /** Passed through to `TempoClient.restart(...)` as the operator identity
+   *  (e.g. `'daemon'`, `'cli'`, or a specific player name). */
+  invokerPlayerId: string;
+  /** `'auto'` — call `restart` on each eligible candidate.
+   *  `'prompt'` — log each candidate; do not call `restart`. */
+  policy: 'auto' | 'prompt';
+  /** Orphans whose `detachedSince` exceeds this window are skipped.
+   *  Default: 24 hours. Ignored when `policy === 'prompt'`. */
+  autoRestoreMaxAgeHours?: number;
+  /** Glob allowlist for ensemble names (`isEnsembleAllowed`). Empty /
+   *  undefined → allow all. Ignored when `policy === 'prompt'`. */
+  autoRestoreEnsembles?: string[];
+  /** Injectable clock for tests. Default: `Date.now`. */
+  now?: () => number;
+  /** Override `createTempoClient` for tests. Default: production factory. */
+  tempoClientFactory?: (client: Client) => {
+    restart: (
+      ensemble: string,
+      playerId: string,
+      opts: { host: string; invokerPlayerId: string },
+    ) => Promise<{ entryId: string; playerId: string }>;
+  };
+}
+
+/**
+ * Structured outcome for a single orphan — discriminated union so callers
+ * can dispatch on `outcome.kind` without parsing strings. Use
+ * {@link formatRestoreOutcome} to render a human-readable form.
+ */
+export type RestoreOutcome =
+  | { kind: 'queued'; entryId: string }
+  | {
+      kind: 'skipped';
+      reason: 'preferredHost' | 'ageWindow' | 'ensembleAllowlist' | 'attachmentConflict' | 'prompt';
+      /** Extra context, e.g. the remote `preferredHost` value. */
+      detail?: string;
+    }
+  | { kind: 'failed'; error: string };
+
+/** Per-orphan outcome produced by {@link restoreOrphansOnce}. */
+export interface RestoreOrphanDetail {
+  playerId: string;
+  ensemble: string;
+  outcome: RestoreOutcome;
+}
+
+/** Render a {@link RestoreOutcome} for human-readable logs / CLI output. */
+export function formatRestoreOutcome(o: RestoreOutcome): string {
+  switch (o.kind) {
+    case 'queued': return `queued (outbox ${o.entryId})`;
+    case 'failed': return `failed: ${o.error}`;
+    case 'skipped':
+      switch (o.reason) {
+        case 'preferredHost': return `skipped: preferredHost=${o.detail ?? '(unknown)'}`;
+        case 'ageWindow': return 'skipped: age window';
+        case 'ensembleAllowlist': return 'skipped: ensemble allowlist';
+        case 'attachmentConflict': return 'skipped: AttachmentConflict';
+        case 'prompt': return 'prompt';
+      }
+  }
+}
+
+/** Summary returned by {@link restoreOrphansOnce}. */
+export interface RestoreOrphansSummary {
+  /** Orphans that successfully enqueued a `restart` outbox entry. */
+  reattached: number;
+  /** Orphans skipped (cross-host, age window, allowlist, AttachmentConflict,
+   *  or `policy: 'prompt'`). */
+  skipped: number;
+  /** Orphans whose `restart` call threw a non-conflict error. */
+  failed: number;
+  /** Per-orphan details in visit order. Useful for UI rendering. */
+  details: RestoreOrphanDetail[];
+}
+
+/**
+ * Run one pass of orphan recovery. Shared by:
+ *   - daemon's `reconcileOnBoot` (passes `invokerPlayerId: 'daemon'`)
+ *   - CLI `up` option 2 and `conduct --resume` (passes `invokerPlayerId: 'cli'`)
+ *
+ * Flow (matches the former body of `reconcileOnBoot`):
+ *   1. Query orphan candidates on this host.
+ *   2. Filter out candidates whose `preferredHost` points elsewhere
+ *      (PR-F §16 — remote host's daemon is the authoritative restorer).
+ *   3. If `policy === 'prompt'`: log each surviving candidate and return.
+ *   4. If `policy === 'auto'`: for each surviving candidate, apply the
+ *      age window + ensemble allowlist filters, then call
+ *      `TempoClient.restart` to enqueue the restart outbox entry.
+ *
+ * Never throws — all per-candidate failures are captured in
+ * {@link RestoreOrphansSummary.details}. The caller picks whether to log,
+ * surface to UI, or aggregate across multiple hosts.
+ *
+ * `AttachmentConflict` is counted as `skipped` (not `failed`) because the
+ * only cause is another operator or daemon having restored concurrently —
+ * the user's intent was satisfied, just not by us.
+ */
+export async function restoreOrphansOnce(
+  client: Client,
+  opts: RestoreOrphansOpts,
+  log: (...args: unknown[]) => void = () => {},
+): Promise<RestoreOrphansSummary> {
+  const summary: RestoreOrphansSummary = {
+    reattached: 0,
+    skipped: 0,
+    failed: 0,
+    details: [],
+  };
+  const now = opts.now ?? Date.now;
+
+  let orphans: OrphanCandidate[];
+  try {
+    orphans = await queryOrphanedSessions(client, { hostname: opts.hostname }, log);
+  } catch (err) {
+    log('restoreOrphansOnce: orphan query failed (non-fatal):', err instanceof Error ? err.message : String(err));
+    return summary;
+  }
+
+  if (orphans.length === 0) {
+    return summary;
+  }
+
+  // Shared emitter so every outcome is recorded + logged identically.
+  const record = (o: OrphanCandidate, outcome: RestoreOutcome): void => {
+    if (outcome.kind === 'queued') summary.reattached++;
+    else if (outcome.kind === 'failed') summary.failed++;
+    else summary.skipped++;
+    summary.details.push({
+      playerId: o.summary.playerId,
+      ensemble: o.summary.ensemble,
+      outcome,
+    });
+    log(`restoreOrphansOnce: ${o.workflowId} — ${formatRestoreOutcome(outcome)}`);
+  };
+
+  // PR-F cross-host filter (design §16). Remote orphans are the remote
+  // daemon's problem; we log-and-skip locally.
+  const candidates: OrphanCandidate[] = [];
+  for (const o of orphans) {
+    if (o.summary.preferredHost && o.summary.preferredHost !== opts.hostname) {
+      record(o, { kind: 'skipped', reason: 'preferredHost', detail: o.summary.preferredHost });
+      continue;
+    }
+    candidates.push(o);
+  }
+
+  if (candidates.length === 0) {
+    return summary;
+  }
+
+  if (opts.policy === 'prompt') {
+    for (const o of candidates) record(o, { kind: 'skipped', reason: 'prompt' });
+    return summary;
+  }
+
+  // policy === 'auto'
+  const ageWindowMs = (opts.autoRestoreMaxAgeHours ?? 24) * 60 * 60 * 1000;
+  const allowlist = opts.autoRestoreEnsembles ?? [];
+  const nowMs = now();
+  const tempo = (opts.tempoClientFactory ?? createTempoClient)(client);
+
+  for (const o of candidates) {
+    // Age filter — skip orphans older than the restore window.
+    if (o.summary.detachedSince) {
+      const detachedAt = Date.parse(o.summary.detachedSince);
+      if (Number.isFinite(detachedAt) && nowMs - detachedAt > ageWindowMs) {
+        record(o, { kind: 'skipped', reason: 'ageWindow' });
+        continue;
+      }
+    }
+
+    // Ensemble allowlist (empty → allow all).
+    if (!isEnsembleAllowed(o.summary.ensemble, allowlist)) {
+      record(o, { kind: 'skipped', reason: 'ensembleAllowlist' });
+      continue;
+    }
+
+    const targetHost = o.summary.preferredHost ?? opts.hostname;
+    try {
+      const result = await tempo.restart(o.summary.ensemble, o.summary.playerId, {
+        host: targetHost,
+        invokerPlayerId: opts.invokerPlayerId,
+      });
+      record(o, { kind: 'queued', entryId: result.entryId });
+    } catch (err) {
+      // §10.6: `AttachmentConflict` is a silent backoff — another restorer
+      // won the race concurrently.
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('AttachmentConflict')) {
+        record(o, { kind: 'skipped', reason: 'attachmentConflict' });
+      } else {
+        record(o, { kind: 'failed', error: msg });
+      }
+    }
+  }
+
+  return summary;
 }

--- a/test/restore-orphans.test.ts
+++ b/test/restore-orphans.test.ts
@@ -1,0 +1,331 @@
+/**
+ * Unit tests for `restoreOrphansOnce` (#93).
+ *
+ * The helper is the shared body of daemon `reconcileOnBoot` and the CLI
+ * resume flow (`up` option 2, `conduct --resume`). It takes a Temporal
+ * `Client`, queries orphan candidates, runs policy-appropriate filters,
+ * and (for `policy: 'auto'`) calls `TempoClient.restart` per candidate.
+ *
+ * These tests inject the `tempoClientFactory` directly, so we don't touch
+ * the `src/client` module namespace — a cleaner wiring than the old
+ * `rebuild-reboot.test.ts` pattern. `Client.workflow.list` + `getHandle`
+ * are stubbed in the same way so we never reach a live Temporal server.
+ */
+import { expect } from 'chai';
+import { restoreOrphansOnce, formatRestoreOutcome } from '../src/reconcile/orphans';
+import type { AttachmentInfo, OrphanSummary } from '../src/types';
+
+const asName = (n: unknown) => typeof n === 'string' ? n : (n as any).name;
+
+interface Fixture {
+  workflowId: string;
+  info: AttachmentInfo;
+  summary: OrphanSummary;
+}
+
+function makeFakeClient(fixtures: Fixture[]): any {
+  const byId: Record<string, Fixture> = {};
+  for (const f of fixtures) byId[f.workflowId] = f;
+  return {
+    workflow: {
+      getHandle(workflowId: string) {
+        const f = byId[workflowId];
+        return {
+          workflowId,
+          async query(name: unknown) {
+            const n = asName(name);
+            if (n === 'attachmentInfo') return f?.info;
+            if (n === 'orphanSummary') return f?.summary;
+            return undefined;
+          },
+        };
+      },
+      async *list() {
+        for (const f of fixtures) yield { workflowId: f.workflowId };
+      },
+    },
+  };
+}
+
+/**
+ * Build a tracked `tempoClientFactory` stub. `restart` records its args
+ * into `calls` and returns a fake `{ entryId }`. `rejectWith(err)` flips
+ * the stub into failure mode so we can test the `AttachmentConflict` +
+ * non-conflict-error branches.
+ */
+function stubTempo() {
+  const calls: Array<{ ensemble: string; playerId: string; opts: any }> = [];
+  let rejection: Error | null = null;
+  const factory = () => ({
+    restart: async (ensemble: string, playerId: string, opts: any) => {
+      calls.push({ ensemble, playerId, opts });
+      if (rejection) throw rejection;
+      return { playerId, entryId: `entry-${calls.length}` };
+    },
+  });
+  return {
+    factory,
+    calls,
+    rejectWith(err: Error | null) { rejection = err; },
+  };
+}
+
+const HOST = 'host-1';
+const NOW = Date.parse('2026-04-21T12:00:00Z');
+
+function fx(opts: {
+  id?: string;
+  ensemble: string;
+  playerId: string;
+  phase?: AttachmentInfo['phase'];
+  detachedSince?: string;
+  preferredHost?: string;
+}): Fixture {
+  return {
+    workflowId: opts.id ?? `claude-session-${opts.ensemble}-${opts.playerId}`,
+    info: { phase: opts.phase ?? 'detached', inFlightCount: 0 },
+    summary: {
+      ensemble: opts.ensemble,
+      playerId: opts.playerId,
+      ...(opts.detachedSince !== undefined ? { detachedSince: opts.detachedSince } : {}),
+      ...(opts.preferredHost !== undefined ? { preferredHost: opts.preferredHost } : {}),
+    },
+  };
+}
+
+describe('restoreOrphansOnce', function () {
+  it('no orphans → zero counts, empty details', async function () {
+    const client = makeFakeClient([]);
+    const tempo = stubTempo();
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(summary).to.deep.equal({ reattached: 0, skipped: 0, failed: 0, details: [] });
+    expect(tempo.calls).to.have.length(0);
+  });
+
+  it("policy 'auto' — queues restart, increments reattached, records outbox id in detail", async function () {
+    const client = makeFakeClient([
+      fx({ ensemble: 'e1', playerId: 'alice', detachedSince: new Date(NOW - 60_000).toISOString() }),
+    ]);
+    const tempo = stubTempo();
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(summary.reattached).to.equal(1);
+    expect(summary.skipped).to.equal(0);
+    expect(summary.failed).to.equal(0);
+    expect(summary.details).to.have.length(1);
+    expect(summary.details[0].playerId).to.equal('alice');
+    expect(summary.details[0].ensemble).to.equal('e1');
+    expect(summary.details[0].outcome).to.deep.equal({ kind: 'queued', entryId: 'entry-1' });
+    // invokerPlayerId passes through to restart
+    expect(tempo.calls[0].opts.invokerPlayerId).to.equal('cli');
+    expect(tempo.calls[0].opts.host).to.equal(HOST);
+  });
+
+  it("policy 'prompt' — never calls restart; details show outcome.reason='prompt'", async function () {
+    const client = makeFakeClient([
+      fx({ ensemble: 'e1', playerId: 'alice', detachedSince: new Date(NOW - 60_000).toISOString() }),
+      fx({ ensemble: 'e2', playerId: 'bob', detachedSince: new Date(NOW - 60_000).toISOString() }),
+    ]);
+    const tempo = stubTempo();
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'daemon',
+      policy: 'prompt',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls).to.have.length(0);
+    expect(summary.reattached).to.equal(0);
+    expect(summary.skipped).to.equal(2);
+    expect(summary.details.every((d) => d.outcome.kind === 'skipped' && d.outcome.reason === 'prompt')).to.equal(true);
+  });
+
+  it('cross-host orphan — skipped with reason=preferredHost + detail, never reaches restart', async function () {
+    const client = makeFakeClient([
+      fx({
+        ensemble: 'e1',
+        playerId: 'remote',
+        detachedSince: new Date(NOW - 60_000).toISOString(),
+        preferredHost: 'other-host',
+      }),
+    ]);
+    const tempo = stubTempo();
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls).to.have.length(0);
+    expect(summary.skipped).to.equal(1);
+    expect(summary.details[0].outcome).to.deep.equal({
+      kind: 'skipped',
+      reason: 'preferredHost',
+      detail: 'other-host',
+    });
+  });
+
+  it('age filter — orphan detached beyond autoRestoreMaxAgeHours is skipped', async function () {
+    const client = makeFakeClient([
+      fx({ ensemble: 'e1', playerId: 'stale', detachedSince: '2020-01-01T00:00:00Z' }),
+    ]);
+    const tempo = stubTempo();
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      autoRestoreMaxAgeHours: 24,
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls).to.have.length(0);
+    expect(summary.skipped).to.equal(1);
+    expect(summary.details[0].outcome).to.deep.equal({ kind: 'skipped', reason: 'ageWindow' });
+  });
+
+  it('ensemble allowlist — glob match passes, mismatch skipped', async function () {
+    const client = makeFakeClient([
+      fx({ ensemble: 'my-team', playerId: 'alice', detachedSince: new Date(NOW - 60_000).toISOString() }),
+      fx({ ensemble: 'other-team', playerId: 'bob', detachedSince: new Date(NOW - 60_000).toISOString() }),
+    ]);
+    const tempo = stubTempo();
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      autoRestoreEnsembles: ['my-*'],
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls).to.have.length(1);
+    expect(tempo.calls[0].ensemble).to.equal('my-team');
+    expect(summary.reattached).to.equal(1);
+    expect(summary.skipped).to.equal(1);
+    expect(summary.details.find((d) => d.playerId === 'bob')?.outcome).to.deep.equal({
+      kind: 'skipped',
+      reason: 'ensembleAllowlist',
+    });
+  });
+
+  it('AttachmentConflict — counted as skipped, not failed', async function () {
+    const client = makeFakeClient([
+      fx({ ensemble: 'e1', playerId: 'alice', detachedSince: new Date(NOW - 60_000).toISOString() }),
+    ]);
+    const tempo = stubTempo();
+    tempo.rejectWith(new Error('AttachmentConflict: host-2 holds lease'));
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls).to.have.length(1);
+    expect(summary.reattached).to.equal(0);
+    expect(summary.skipped).to.equal(1);
+    expect(summary.failed).to.equal(0);
+    expect(summary.details[0].outcome).to.deep.equal({ kind: 'skipped', reason: 'attachmentConflict' });
+  });
+
+  it('non-conflict error — counted as failed; loop continues to next candidate', async function () {
+    const client = makeFakeClient([
+      fx({ ensemble: 'e1', playerId: 'alice', detachedSince: new Date(NOW - 60_000).toISOString() }),
+      fx({ ensemble: 'e1', playerId: 'bob', detachedSince: new Date(NOW - 60_000).toISOString() }),
+    ]);
+    const tempo = stubTempo();
+    // Fail the first call; succeed on the second. The stub rejects for every
+    // call while `rejection` is set, so switch it off mid-loop via a counter.
+    let n = 0;
+    tempo.factory = () => ({
+      restart: async (ensemble: string, playerId: string, opts: any) => {
+        tempo.calls.push({ ensemble, playerId, opts });
+        n++;
+        if (n === 1) throw new Error('transient network error');
+        return { playerId, entryId: `entry-${n}` };
+      },
+    });
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls).to.have.length(2);
+    expect(summary.reattached).to.equal(1);
+    expect(summary.failed).to.equal(1);
+    expect(summary.details[0].outcome).to.deep.equal({ kind: 'failed', error: 'transient network error' });
+    expect(summary.details[1].outcome).to.deep.equal({ kind: 'queued', entryId: 'entry-2' });
+  });
+
+  it('preferredHost defaults to local hostname when unset in summary', async function () {
+    const client = makeFakeClient([
+      fx({ ensemble: 'e1', playerId: 'alice', detachedSince: new Date(NOW - 60_000).toISOString() }),
+    ]);
+    const tempo = stubTempo();
+    await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls[0].opts.host).to.equal(HOST);
+  });
+
+  describe('formatRestoreOutcome', function () {
+    it('renders queued with entry id', function () {
+      expect(formatRestoreOutcome({ kind: 'queued', entryId: 'entry-7' }))
+        .to.equal('queued (outbox entry-7)');
+    });
+    it('renders failed with error message', function () {
+      expect(formatRestoreOutcome({ kind: 'failed', error: 'boom' }))
+        .to.equal('failed: boom');
+    });
+    it('renders skip reasons', function () {
+      expect(formatRestoreOutcome({ kind: 'skipped', reason: 'preferredHost', detail: 'other' }))
+        .to.equal('skipped: preferredHost=other');
+      expect(formatRestoreOutcome({ kind: 'skipped', reason: 'ageWindow' }))
+        .to.equal('skipped: age window');
+      expect(formatRestoreOutcome({ kind: 'skipped', reason: 'ensembleAllowlist' }))
+        .to.equal('skipped: ensemble allowlist');
+      expect(formatRestoreOutcome({ kind: 'skipped', reason: 'attachmentConflict' }))
+        .to.equal('skipped: AttachmentConflict');
+      expect(formatRestoreOutcome({ kind: 'skipped', reason: 'prompt' }))
+        .to.equal('prompt');
+    });
+  });
+
+  it('preferredHost === local hostname — not filtered as cross-host', async function () {
+    const client = makeFakeClient([
+      fx({
+        ensemble: 'e1',
+        playerId: 'alice',
+        detachedSince: new Date(NOW - 60_000).toISOString(),
+        preferredHost: HOST,
+      }),
+    ]);
+    const tempo = stubTempo();
+    const summary = await restoreOrphansOnce(client, {
+      hostname: HOST,
+      invokerPlayerId: 'cli',
+      policy: 'auto',
+      now: () => NOW,
+      tempoClientFactory: tempo.factory,
+    });
+    expect(tempo.calls).to.have.length(1);
+    expect(summary.reattached).to.equal(1);
+  });
+});


### PR DESCRIPTION
## Summary

Lowest-risk slice of #285's TUI-first maestro consolidation: extract the
orphan-recovery decision loop from daemon `reconcileOnBoot` into a shared
`restoreOrphansOnce()` helper in `src/reconcile/orphans.ts`, and wire it
into the CLI resume flow so `claude-tempo up <ens>` option 2 and
`claude-tempo conduct --resume` restart orphaned player sessions after
spawning the conductor — matching what the daemon already does at boot.

Closes the user-facing gap called out in #93: resuming a conductor used
to leave orphaned player workflows dangling until the next daemon
restart. Now the CLI reuses the same proven auto-restore path.

## What changed

- **`src/reconcile/orphans.ts`** — new `restoreOrphansOnce()` that owns
  the cross-host filter, policy dispatch (`auto` / `prompt`),
  age-window + ensemble-allowlist filters, `TempoClient.restart` call,
  and `AttachmentConflict` silent-backoff. Returns a structured summary
  with per-orphan `RestoreOutcome` — a discriminated union
  (`{ kind: 'queued' | 'skipped' | 'failed'; … }`) so callers dispatch
  on `outcome.kind` instead of parsing strings. Ships with
  `formatRestoreOutcome()` for consistent human-readable output across
  daemon logs and CLI.
- **`src/daemon.ts`** — `reconcileOnBoot()` becomes a ~20-line delegate:
  preserves the `never` short-circuit + existing log prefix, passes
  `invokerPlayerId: 'daemon'` through. Removed ~90 lines of duplicated
  decision logic.
- **`src/cli/commands.ts`** — ~30-line block inside `start()` that only
  fires on `opts.conductor && opts.resume && conductorClient`.
  Dynamic-imports the helper, runs one pass with
  `invokerPlayerId: 'cli', policy: 'auto'`, prints per-orphan status
  lines + `N reattached, M skipped, K failed` summary. Silent on zero
  orphans, non-fatal on scan failure.

## Scope guardrails (architect's spec)

- [x] No new MCP tools
- [x] No new CLI verbs
- [x] No wire-protocol changes (signals/queries/updates unchanged)
- [x] No workflow code touched — `workflow-bundle.js` rebuild confirms
      no drift
- [x] Diff under 500 lines (184 lines net src / +370 with new tests)
- [x] Reuses existing `tempo.restart` path; no new `restoreOneOrphan` helper
- [x] `reconcileOnBoot` behavior preserved — rebuild-reboot tests green
      unchanged

## Test plan

- [x] `npm run build` green — full TS + workflow-bundle rebuild
- [x] `npm run build:test && npx mocha dist-test/test/restore-orphans.test.js dist-test/test/rebuild-reboot.test.js dist-test/test/orphan-query.test.js` — **31 passing**
  - 10 new tests for `restoreOrphansOnce` (auto, prompt, cross-host,
    age, allowlist, AttachmentConflict, non-conflict error, defaults)
  - 3 new tests for `formatRestoreOutcome`
  - 10 pre-existing `reconcileOnBoot` tests green (delegation preserves
    behavior)
  - 5 pre-existing `queryOrphanedSessions` + 2 `buildOrphanQuery` + 1
    `isAdapterProcessAliveStub` unchanged
- [ ] Local Temporal-server integration suites (TestWorkflowEnvironment)
  not run here due to a Windows ephemeral-server-access-denied on my
  worktree unrelated to this change; none of my changes touch workflow
  code so no regression expected. CI will run them.
- [ ] Manual smoke: kill a player adapter, run
  `claude-tempo conduct --resume`, observe orphan restart in console
  output.

## Cross-agent notes

- **#93 comments** — implements exactly the architect's 3-file spec
  (`restoreOrphansOnce` signature, extract-and-reuse, zero new API
  surface).
- **/simplify review** — addressed the `stringly-typed outcome` must-fix
  by converting to a discriminated union + `formatRestoreOutcome()`
  helper; deferred minor nice-to-haves (consolidation with the existing
  `restore` CLI verb's `restoreOneOrphan`, parameter-sprawl polish) to
  later slices per the scope guardrails above.
- **Foundation for #285** — next slices (restore MCP tool, TUI home-view)
  can call `restoreOrphansOnce` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)