### PR TITLE
docs(#292): S8 docs sweep — CLI minimal surface, MCP renames, TUI slash, CHANGELOG draft

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- **CLI minimal surface** (#288): `stop`, `restart`, `detach`, `migrate`, `conduct`, `start`,
+  `pause`, `resume`, and `disband` are removed from the CLI. Use the TUI slash commands
+  (`/restart`, `/shutdown`, `/destroy`, `/pause`, `/play`, `/recruit`) instead. A migration
+  table is at [github.com/vinceblank/claude-tempo/issues/285](https://github.com/vinceblank/claude-tempo/issues/285).
+- **MCP tool renames** (#287): `pause_ensemble` renamed to `pause`; `resume_ensemble` renamed
+  to `play`. Update any scripts or prompts that call these tools by name.
+- **Lineup schema: conductor required** (#286): Lineup YAML files must now include a top-level
+  `conductor` field. Lineups without one are rejected at load time with a schema validation
+  error.
+
+### Changed
+
+- **Bootstrap preflight slimmed** (#289): Bare `claude-tempo` invocation no longer probes for
+  the `claude` binary at startup — redundant with `resolveClaudePath()` and too strict for
+  Copilot-only setups. Missing `claude` is now surfaced at spawn time with a clearer
+  per-recruit error. Preflight hard requirements remain Node ≥ 20 and a writable
+  `~/.claude-tempo`.
+- **`down --destroy`** (#288): `claude-tempo down` gains a `--destroy` flag that terminates
+  every workflow across every ensemble before tearing down infrastructure. Replaces the
+  previous multi-step `destroy` + `down` sequence.
+- **`restore` rewritten to ensemble-scope** (#288): `claude-tempo restore <ensemble>` now
+  targets a single ensemble on this host. The interactive multi-flag picker (`--all`,
+  `--from-host`, `--dry-run`) is replaced by the TUI home-view restore modal.
+
+### Added
+
+- **TUI home view** (#290): Bare `claude-tempo` invocation launches a two-list home screen
+  (all running ensembles + players) with a restore modal for orphaned sessions. Connects to
+  the global Maestro for cross-ensemble discovery.
+- **TUI slash commands aligned with MCP surface** (#291): New commands — `/play`, `/shutdown`,
+  `/restore`, `/home` — mirror the renamed/new MCP tools. `/destroy` extended to accept an
+  ensemble name in addition to a player name. Legacy commands (`/detach`, `/disband`,
+  `/resume`, `/pause_ensemble`, `/resume_ensemble`) show migration hints.
+- **`TempoClient.spawnConductor` + `ensureConductorSpawned`** (#291): New helpers on the
+  `TempoClient` interface for orchestrating conductor lifecycle from the TUI restore flow and
+  bootstrap state machine.
+- **`TempoClient.restore()`** (#302): Wired through `TempoClient` so the TUI restore modal
+  and CLI `restore` command share a single implementation path.
+- **Auto-provisioning bootstrap state machine** (#289): Six-step idempotent sequence
+  (preflight → MCP config → Temporal reachability → search attributes → daemon → conductor)
+  runs on bare `claude-tempo` invocation and produces a `BootstrapResult` consumed by the
+  home view as initial props.
+
+### Fixed
+
+- **Orphan-recovery helper extracted to shared module** (#93): `reconcileOrphans` logic moved
+  to `src/reconcile/orphans.ts` and reused by both daemon reconcile-on-boot and the new CLI
+  `restore` command, eliminating the previous duplication.
+
 ## [0.26.0] - 2026-04-20
 
 > **Upgrade guide:** [`docs/ops/v0.26-migration.md`](docs/ops/v0.26-migration.md) —

--- a/README.md
+++ b/README.md
@@ -59,11 +59,10 @@ claude-tempo up
 This starts Temporal, registers the MCP server, launches the daemon, and opens a conductor session. Then add players:
 
 ```bash
-claude-tempo start          # open a player session
 claude-tempo status         # see who's active
 ```
 
-Or ask the conductor to `recruit` players from inside Claude Code.
+Or use the TUI to recruit players, or ask the conductor to `recruit` from inside Claude Code.
 
 ### Manual setup
 
@@ -71,8 +70,7 @@ Or ask the conductor to `recruit` players from inside Claude Code.
 claude-tempo server         # start Temporal dev server
 claude-tempo init           # register MCP server globally
 claude-tempo preflight      # verify environment
-claude-tempo conduct        # start a conductor
-claude-tempo start          # start a player
+claude-tempo up             # launch conductor via auto-provisioning
 ```
 
 ## Upgrading
@@ -90,11 +88,14 @@ claude-tempo upgrade 0.22.0
 ## Stopping & Tear Down
 
 ```bash
-# Stop a specific player session
-claude-tempo stop my-ensemble player-name
+# Terminate all sessions in an ensemble
+claude-tempo destroy my-ensemble
 
 # Tear down everything (all sessions, schedulers, and Maestro workflows)
 claude-tempo down --all
+
+# Tear down and terminate all workflows in one step
+claude-tempo down --destroy -y
 
 # Stop the background daemon
 claude-tempo daemon stop
@@ -107,17 +108,17 @@ claude-tempo daemon stop
 ## Core Concepts
 
 - **Player** — A Claude Code session registered as a Temporal workflow
-- **Conductor** — An optional orchestration hub (one per ensemble); receives `report` calls and connects to external interfaces
+- **Conductor** — Required orchestration hub (one per ensemble); receives `report` calls and connects to external interfaces. Lineup schema enforces its presence.
 - **Ensemble** — A named group of players isolated from other ensembles; defaults to `default`
 - **Cue** — A message sent to a player by name via Temporal signal
 - **Lineup** — A YAML file that defines a full team and recruits them in one step
 - **Player Type** — A reusable agent definition (`.md` with YAML frontmatter) that gives a player a named role
 
-Players in one ensemble cannot see or message players in another:
+Players in one ensemble cannot see or message players in another. Launch `claude-tempo` to open the TUI and switch between ensembles, or target a specific ensemble directly:
 
 ```bash
-claude-tempo conduct frontend   # conduct the "frontend" ensemble
-claude-tempo start backend      # join the "backend" ensemble
+claude-tempo up frontend        # provision and launch conductor in "frontend"
+claude-tempo up backend         # provision and launch conductor in "backend"
 ```
 
 ## MCP Tools
@@ -139,17 +140,16 @@ Tools available inside Claude Code sessions connected to claude-tempo:
 ## CLI
 
 ```bash
-claude-tempo up [ensemble]      # first-time setup
-claude-tempo conduct [ensemble] # start a conductor
-claude-tempo start [ensemble]   # start a player
+claude-tempo                    # launch TUI (auto-provisions on first run)
+claude-tempo up [ensemble]      # provision infrastructure and launch conductor
+claude-tempo down [--destroy]   # tear down infrastructure (--destroy also terminates workflows)
 claude-tempo status [ensemble]  # list active sessions
+claude-tempo destroy <ensemble> # terminate all sessions in an ensemble
+claude-tempo restore <ensemble> # restore orphaned sessions on this host
 claude-tempo hosts              # list daemons polling this Temporal namespace (--all/--json)
-claude-tempo recall <name>      # read a player's message history (--limit/--offset/--preview/--from/--since/--include-sent/--json)
+claude-tempo recall <name>      # read a player's message history (--limit/--offset/--preview/--json)
 claude-tempo attachment-info <name> # inspect a session's phase, holder, lease, and heartbeat age
 claude-tempo release [ensemble] # release held players (unlock + deliver tasks)
-claude-tempo pause [ensemble]   # pause all sessions and the scheduler
-claude-tempo resume [ensemble]  # resume a paused ensemble (--release also releases held players)
-claude-tempo tui                # open the terminal UI
 claude-tempo daemon <sub>       # manage the worker daemon
 claude-tempo upgrade            # update to latest
 ```
@@ -240,7 +240,7 @@ claude-tempo tui --ensemble my-ensemble   # direct ensemble mode
 The TUI provides a chat-focused shell for managing your ensemble:
 
 - **Ensemble chat feed** — live aggregated view of conductor + player traffic; type bare text to message the conductor, `@player message` to message directly
-- **Slash commands** — `/recruit`, `/status`, `/schedule`, `/gates`, `/stages`, `/worktree`, `/go` (release held), `/pause`, `/resume`, and more; type `/help` for the full list
+- **Slash commands** — `/recruit`, `/status`, `/schedule`, `/gates`, `/stages`, `/worktree`, `/go` (release held), `/pause`, `/play`, `/shutdown`, `/restore`, `/home`, and more; type `/help` for the full list
 - **Interactive overlays and wizards** — step-by-step flows for recruiting players, creating schedules, and managing ensembles
 
 📖 [TUI reference → docs/tui.md](docs/tui.md)

--- a/README.md
+++ b/README.md
@@ -249,10 +249,10 @@ The TUI provides a chat-focused shell for managing your ensemble:
 
 > **Experimental** — subject to breaking changes.
 
-GitHub Copilot CLI sessions can join an ensemble using `--agent copilot`:
+GitHub Copilot CLI sessions can join an ensemble using `--agent copilot`. Recruit one from the TUI:
 
-```bash
-claude-tempo start myband --agent copilot -n copilot-1
+```
+/recruit copilot-1 --agent copilot
 ```
 
 📖 [Copilot bridge setup and limitations → docs/copilot.md](docs/copilot.md)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -9,35 +9,33 @@ claude-tempo <command> [options]
 | Command | Description |
 |---------|-------------|
 | `up [ensemble]` | First-time setup: start Temporal, configure MCP, launch conductor. Use `--lineup` to load a lineup. |
-| `down [ensemble]` | Full teardown — stop all sessions, daemon, and Temporal. Use `--all` to stop all ensembles and Temporal, `--keep-mcp` to preserve MCP config, `--keep-daemon` to leave the daemon running, `-y`/`--yes` to skip confirmation. |
+| `down [ensemble]` | Full teardown — stop all sessions, daemon, and Temporal. Use `--all` to stop all ensembles and Temporal, `--keep-mcp` to preserve MCP config, `--keep-daemon` to leave the daemon running, `-y`/`--yes` to skip confirmation. Add `--destroy` to also terminate every workflow before tearing down. |
 | `server` | Start the Temporal dev server and register search attributes |
-| `conduct [ensemble]` | Start a conductor session (one per ensemble). Use `--resume` or `--replace` if one exists. Use `--lineup` to load a lineup with hold-on-startup semantics; `--no-hold` for immediate start. |
-| `start [ensemble]` | Start a player session |
 | `status [ensemble]` | Show active sessions and Temporal health |
 | `config` | Configure Temporal connection settings (interactive or `set`/`show`) |
-| `stop [ensemble]` | Stop sessions only — recoverable via `restart`. Use `-n <name>` for one, `--all` for all. |
 | `init` | Register claude-tempo MCP server globally (`--project` for per-directory) |
 | `preflight` | Run environment checks |
 | `broadcast <msg>` | Send a message to all active players. Use `--type` to filter by player type, `--include-stale` to include stale sessions. |
-| `restart <name>` | Restart a player session — detaches current adapter and re-spawns. Works from any non-`gone` attachment phase. Use `--host` to target a remote machine. |
-| `detach <name>` | Gracefully detach the adapter for a session — triggers draining and clean handoff. Use when migrating a session to another host. |
-| `destroy <name>` | Terminate a session's workflow — ordered shutdown via outbox drain. Use for permanent removal. |
-| `migrate <name>` | Move a session to a different host — sugar for `setPreferredHost` + `restart` on the target machine. Use `--to <hostname>`. |
+| `destroy <ensemble> [-y]` | Terminate every workflow in an ensemble — ordered shutdown via outbox drain. Prompts for typed confirmation; `-y` skips. |
 | `attachment-info <name>` | Inspect a session's attachment phase, current holder, lease expiry, heartbeat age, and in-flight message count. |
 | `recall <name>` | Read a player's message history (#128). Flags: `--limit N` (default 20, max 100), `--offset N` (paging, default 0), `--preview N` (truncate bodies to N chars; omit for full text), `--from X` (sender filter for received), `--since ISO` (time filter), `--include-sent` (include outbound too), `--json` (emit raw `{received, sent, total, shown, hasMore, text}`). |
 | `hosts` | **#274.** List daemons polling this Temporal namespace with their advertised capabilities. Flags: `--all` includes stale hosts; `--json` emits raw `HostInfo[]`. Output matches MCP `hosts` tool and TUI `/hosts` (shared formatter). |
 | `refresh-host-profile` | **#274.** Re-advertise this daemon's capability profile to the global Maestro. Useful after editing `~/.claude-tempo/config.json` or adding/removing player-type files without restarting the daemon. Exits 0 on confirmed refresh, 1 on signal failure or unconfirmed after the 10s poll. |
-| `restore [name]` | **v0.25.** Restore orphaned (detached) sessions. Interactive picker by default; `--all` restores every orphan, `--from-host <hostname>` filters by preferred host, `--dry-run` lists without restoring. |
+| `restore <ensemble>` | Restore orphaned (detached) sessions in one ensemble on this host — re-attaches a fresh adapter to every matching `detached` session. (#288) |
 | `release [ensemble]` | Release all held players — unlocks outboxes and delivers deferred task messages. Use `-n <name>` to release one player. |
-| `pause [ensemble]` | Pause the ensemble — locks all session outbox dispatch and pauses the scheduler. |
-| `resume [ensemble]` | Resume a paused ensemble — unlocks outbox dispatch and restarts the scheduler. Use `--release` to also release any held players in the same call. |
 | `ensemble <sub>` | Manage saved lineups (`save`, `list`, `show`) |
 | `agent-types <sub>` | Manage player types (`list`, `show <name>`, `init`) |
 | `daemon <sub>` | Manage the worker daemon (`start [--force]`, `stop`, `status`, `logs`) |
-| `tui [--ensemble <name>]` | Launch the interactive TUI — chat-focused shell with slash commands for managing players and ensembles |
 | `upgrade [version]` | Graceful self-update — stops daemon, installs new version, restarts daemon |
 | `version` | Print the installed version |
 | `help` | Show usage info |
+
+> **Removed commands — use the TUI instead** (since v0.27 / #288):
+> - `stop` / `restart` / `detach` / `migrate` → TUI `/destroy` · `/restart` · `/shutdown`
+> - `conduct` / `start` / `recruit` / `disband` → launch `claude-tempo` · TUI `/recruit` · `/destroy`
+> - `pause` / `resume` → TUI `/pause` · `/play`
+>
+> See [github.com/vinceblank/claude-tempo/issues/285](https://github.com/vinceblank/claude-tempo/issues/285) for the full migration table.
 
 ## Global Options
 
@@ -47,17 +45,15 @@ claude-tempo <command> [options]
 --temporal-api-key <key>      Temporal Cloud API key
 --temporal-tls-cert <path>    mTLS client certificate path
 --temporal-tls-key <path>     mTLS client key path
--n, --name <name>             Set the player name (start/conduct/up)
+-n, --name <name>             Set the session name (up only)
 --agent <claude|copilot>      Agent backend to use (default: claude)
---skip-preflight              Skip preflight checks (start/conduct)
+--skip-preflight              Skip preflight checks
 -d, --dir <path>              Target directory (default: cwd)
 --background                  Run Temporal in background (server only)
 --keep-mcp                    Preserve MCP config when tearing down (down only)
---lineup <name|file>          Load an ensemble lineup by name or file path (up and conduct)
---no-hold                     Skip hold-on-startup: deliver lineup instructions immediately without pausing the ensemble (up --lineup and conduct --lineup)
---release                     Also release held players when resuming (resume only) — combines resume_ensemble + release into one call
---resume                      Resume an existing conductor session (conduct only)
---replace                     Stop existing conductor and start fresh (conduct only)
+--destroy                     Also terminate every workflow (down only)
+--lineup <name|file>          Load an ensemble lineup by name or file path (up)
+--no-hold                     Skip hold-on-startup: deliver lineup instructions immediately (up --lineup)
 -v, --version                 Print version and exit
 ```
 
@@ -84,9 +80,8 @@ Launching conductor in ensemble myband...
   Ensemble: myband
 
   What next?
-  claude-tempo start myband    Add a player session
   claude-tempo status myband   See who's active
-  Or ask the conductor to recruit players for you
+  Or use the TUI to recruit players (/recruit)
 ```
 
 If a conductor is already running in the target ensemble, `up` detects it and prompts with options: join as a player, reconnect to the existing conductor, tear down and start fresh, or cancel. This prevents two sessions from silently sharing the same Temporal workflow.
@@ -128,7 +123,7 @@ Ensemble: myband
 
 ### `claude-tempo preflight`
 
-Verifies your environment: Node.js >= 18, Temporal reachable, `claude` on PATH, `claude-tempo-server` on PATH, `.mcp.json` configured.
+Verifies your environment: Node.js >= 20, Temporal reachable, `~/.claude-tempo` writable, `.mcp.json` configured. Missing `claude` binary is now reported at spawn time rather than preflight.
 
 ### `claude-tempo init`
 
@@ -148,10 +143,29 @@ Full teardown — stops all sessions, the daemon, and Temporal, then removes MCP
 ```bash
 claude-tempo down                  # full teardown (current ensemble)
 claude-tempo down --all            # stop all ensembles, daemon, and Temporal
+claude-tempo down --destroy -y     # terminate every workflow, then tear down (skip confirmation)
 claude-tempo down --keep-mcp       # preserve MCP config
 claude-tempo down --keep-daemon    # stop sessions and Temporal, but leave daemon running
-claude-tempo down -y               # skip confirmation prompt
 ```
+
+### `claude-tempo destroy`
+
+Terminates every workflow in an ensemble via ordered shutdown (outbox drain). Prompts for typed confirmation; use `-y` to skip:
+
+```bash
+claude-tempo destroy myband        # terminate all sessions in "myband"
+claude-tempo destroy myband -y     # skip confirmation
+```
+
+### `claude-tempo restore`
+
+Restores orphaned (detached) sessions in one ensemble on this host — re-attaches a fresh adapter to every matching `detached` session:
+
+```bash
+claude-tempo restore myband        # restore all orphans in "myband" on this host
+```
+
+The daemon auto-restores orphans on boot when `restorePolicy` is configured; `restore` lets you trigger it manually.
 
 ### `claude-tempo upgrade`
 
@@ -161,61 +175,6 @@ Graceful self-update — stops the daemon, installs the latest (or specified) ve
 claude-tempo upgrade            # install latest version
 claude-tempo upgrade 0.20.0     # install a specific version
 ```
-
-### `claude-tempo restart`
-
-Detaches the current adapter and re-spawns a fresh process — functionally replaces the retired `encore` command. Works from any non-`gone` attachment phase (including `attached`, `awaiting`, `processing`, and `detached`):
-
-```bash
-claude-tempo restart alice             # restart on same host
-claude-tempo restart alice --host bob-mac   # restart on remote host
-```
-
-The existing Temporal workflow is preserved — message history and metadata carry over.
-
-### `claude-tempo detach`
-
-Signals the adapter to drain and detach gracefully:
-
-```bash
-claude-tempo detach alice
-```
-
-Triggers the `requestDetach` signal → adapter enters `draining` → `detached`. Use before a planned `migrate` or host maintenance.
-
-### `claude-tempo destroy`
-
-Terminates a session's workflow via ordered shutdown (outbox drain):
-
-```bash
-claude-tempo destroy alice
-```
-
-Prefer `destroy` over `stop` for permanent removal — it respects the v0.25 outbox and attachment lifecycle rather than force-terminating.
-
-### `claude-tempo restore`
-
-Re-attaches a fresh adapter to a session whose previous adapter exited uncleanly (crash, OS kill, host reboot). Message history and metadata are preserved.
-
-```bash
-claude-tempo restore                    # interactive picker
-claude-tempo restore alice              # restore a specific player by name
-claude-tempo restore --all              # restore every orphan on this host
-claude-tempo restore --from-host web-01 # filter by preferred host
-claude-tempo restore --dry-run          # list candidates without restoring
-```
-
-The daemon auto-restores orphans on boot when `restorePolicy` is configured; `restore` lets you trigger it manually.
-
-### `claude-tempo migrate`
-
-Moves a session to a different host — sets the preferred host then triggers `restart` on the target machine's task queue:
-
-```bash
-claude-tempo migrate alice --to build-server
-```
-
-Requires the target host to have an active claude-tempo daemon. See [PR-F multi-host docs](https://github.com/vinceblank/claude-tempo) for cross-host setup.
 
 ## Related
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -34,15 +34,25 @@ These tools are available inside Claude Code sessions connected to claude-tempo.
 | `stages` | List stages and their status. Conductor only. |
 | `cancel_stage` | Cancel an active stage by name. Conductor only. |
 | `release` | Release held player sessions — unlocks their outboxes and delivers deferred task messages. Omit `player` to release all held sessions. |
-| `pause_ensemble` | Pause all sessions in the ensemble: locks outbox dispatch and pauses the scheduler. `destroy` commands still go through. |
-| `resume_ensemble` | Resume a paused ensemble — unlocks outbox dispatch and resumes the scheduler. Buffered outbox entries are dispatched. Pass `release: true` to also release any held sessions (deliver deferred task messages and unlock their outboxes) in the same call — idempotent on non-held sessions. |
+| `pause` | Pause all sessions in the ensemble: locks outbox dispatch and pauses the scheduler. `destroy` commands still go through. (#287) |
+| `play` | Resume a paused ensemble — unlocks outbox dispatch and resumes the scheduler. Buffered outbox entries are dispatched. Pass `release: true` to also release any held sessions in the same call — idempotent on non-held sessions. (#287) |
+| `shutdown` | Gracefully shut down the entire ensemble — signals all players to drain and detach, then stops the conductor. Use instead of per-player `detach` calls when tearing down. (#287) |
+| `restore` | Restore orphaned sessions in one ensemble on this host — re-attaches a fresh adapter to every `detached` session whose preferred host matches. Pass `ensemble` to target a specific ensemble. (#287, #288) |
 
-## v0.25 Changes
+## Version History
+
+### v0.27 Changes (#285–#291)
+
+- **`pause_ensemble` renamed to `pause`**, **`resume_ensemble` renamed to `play`** — shorter names, consistent with TUI `/pause` and `/play` slash commands.
+- **`shutdown` added** — ensemble-scope graceful teardown; replaces per-player `detach` chains.
+- **`restore` added** — ensemble-scope orphan recovery; replaces the v0.25 interactive CLI flow.
+
+### v0.25 Changes
 
 > **Breaking change in v0.25.0-beta.1**: The wire protocol between sessions and workers changed. If you are upgrading from v0.24.x, run `claude-tempo down` and `claude-tempo up` to reinitialize. Sessions from different versions cannot interoperate.
 
 - **`encore` removed** — replaced by `restart`. The `restart` tool works from any non-`gone` attachment phase and is not limited to stale sessions.
-- **`stop` removed** — use `destroy` (ordered shutdown) or `detach` (graceful adapter reap) instead.
+- **`stop` removed** — use `destroy` (ordered shutdown) instead.
 - **New lifecycle verbs**: `restart`, `detach`, `destroy`, `migrate`, and `attachment_info` expose the v0.25 attachment state machine directly.
 
 ## Related

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -86,7 +86,7 @@ Interactive overlays (`/schedule`, `/gates`, `/stages`, `/worktree`) support arr
 - **`/restore` added** — ensemble-scope orphan recovery via the home view modal or directly.
 - **`/home` added** — multi-ensemble home screen with two-list layout (ensembles + players) and restore modal. (#290)
 - **`/destroy <player|ensemble>`** — extended to accept an ensemble name in addition to a player name.
-- **Removed**: `/stop`, `/detach`, `/disband`, `/pause_ensemble`, `/resume_ensemble` — each shows a migration hint pointing to the replacement command.
+- **Removed**: `/resume`, `/detach`, `/disband`, `/pause_ensemble`, `/resume_ensemble` — each shows a migration hint pointing to the replacement command.
 - **Bare `claude-tempo` invocation** launches the TUI directly (with auto-provisioning); `claude-tempo tui` is a synonym.
 
 ### v0.25 Changes

--- a/docs/tui.md
+++ b/docs/tui.md
@@ -51,13 +51,14 @@ Use `/players <name>` to open a scrollable message history for any player.
 | `/broadcast <message>` | Send a message to all active players in the current ensemble |
 | `/recruit [name] [--type <type>] [--dir <path>]` | Spawn a new player (launches wizard if args omitted) |
 | `/recruit-conductor` | Recruit a conductor for the current ensemble |
-| `/stop <player>` | Hard-terminate a workflow — bypasses v0.25 outbox drain. Prefer `/destroy` for ordered shutdown. |
-| `/restart <player>` | Restart a player — detaches current adapter and re-spawns. Works from any non-`gone` phase. |
-| `/detach <player>` | Gracefully detach a player's adapter — triggers draining and clean handoff. |
-| `/destroy <player>` | Terminate a session via ordered shutdown (outbox drain). Use for permanent removal. |
+| `/restart <player> [--fresh] [--force]` | Restart a player — detaches current adapter and re-spawns. Works from any non-`gone` phase. |
+| `/destroy <player\|ensemble> [reason]` | Terminate a player session (ordered shutdown) or the entire ensemble. Prompts for confirmation. |
 | `/migrate <player> --to <hostname>` | Move a session to a different host. Requires target host to have an active daemon. |
+| `/pause [ensemble]` | Pause the ensemble — locks outbox dispatch and pauses the scheduler. |
+| `/play [ensemble]` | Resume a paused ensemble — unlocks outbox dispatch and restarts the scheduler. (#287) |
+| `/shutdown [ensemble]` | Gracefully shut down the entire ensemble — drains all players and stops the conductor. (#287) |
+| `/restore [ensemble]` | Restore orphaned sessions on this host for the given ensemble. (#287, #288) |
 | `/attachment-info <player>` | Show the current attachment phase, lease expiry, heartbeat age, and in-flight count for a player. Output matches CLI and MCP surfaces (shared formatter, #264). |
-| `/disband` | Tear down the current ensemble — all sessions, scheduler, and Maestro |
 | `/players [name]` | Show detailed player info; no args opens interactive picker |
 | `/ensemble [name]` | Switch active ensemble context; no args opens picker |
 | `/status` | Show dismissible overlay with all players, status, type, and part |
@@ -69,19 +70,31 @@ Use `/players <name>` to open a scrollable message history for any player.
 | `/gates` | List quality gates and their criteria status |
 | `/stages` | List stages and per-player report status |
 | `/worktree [list \| create <player> \| remove <player>]` | List active git worktrees; `create`/`remove` delegate to the conductor |
-| `/back` | Return to the main ensemble view |
+| `/home` | Navigate to the home view — multi-ensemble overview with restore modal. (#290, #291) |
+| `/back` | Return to the previous view |
 | `/help [command]` | Show all commands; pass a command name for detailed usage (e.g. `/help recruit`) |
 | `/quit` | Exit the TUI |
 
 Interactive overlays (`/schedule`, `/gates`, `/stages`, `/worktree`) support arrow-key navigation and action keys shown in the overlay hint bar (e.g. `n=new  d=delete  esc=close`).
 
-## v0.25 Changes
+## Version History
+
+### v0.27 Changes (#285–#291)
+
+- **`/play` added** — replaces `/resume` and `/resume_ensemble`. `/resume` now shows a migration hint.
+- **`/shutdown` added** — ensemble-scope graceful teardown; replaces per-player `/detach` chains. `/detach` now shows a migration hint.
+- **`/restore` added** — ensemble-scope orphan recovery via the home view modal or directly.
+- **`/home` added** — multi-ensemble home screen with two-list layout (ensembles + players) and restore modal. (#290)
+- **`/destroy <player|ensemble>`** — extended to accept an ensemble name in addition to a player name.
+- **Removed**: `/stop`, `/detach`, `/disband`, `/pause_ensemble`, `/resume_ensemble` — each shows a migration hint pointing to the replacement command.
+- **Bare `claude-tempo` invocation** launches the TUI directly (with auto-provisioning); `claude-tempo tui` is a synonym.
+
+### v0.25 Changes
 
 > **Breaking change in v0.25.0-beta.1**: The wire protocol changed. If upgrading from v0.24.x, run `claude-tempo down` and `claude-tempo up` to reinitialize before launching the TUI.
 
 - **`/encore` removed** — use `/restart` instead. Restart works from any non-`gone` attachment phase.
-- **`/stop` semantics changed** — now hard-terminates the workflow directly (bypasses outbox drain). Prefer `/destroy` for ordered shutdown.
-- **New lifecycle commands**: `/restart`, `/detach`, `/destroy`, `/migrate`, `/attachment-info` expose the v0.25 attachment state machine.
+- **New lifecycle commands**: `/restart`, `/destroy`, `/migrate`, `/attachment-info` expose the v0.25 attachment state machine.
 
 ## How the TUI Gets Data
 
@@ -97,7 +110,7 @@ The TUI's API layer (`src/tui/client.ts`) wraps these queries behind a `TempoCli
 - **Routing**: Bare text routes to the conductor via `sendCommand`. Prefix with `@player` to message a specific player directly (e.g. `@alice can you review this?`). When no conductor is present, bare text shows an error; use `@player` to message directly.
 - **Schedule management**: `/schedule` is the single entry point — no standalone `/unschedule`. Subcommands: `/schedule` (show overlay), `/schedule create` (wizard), `/schedule delete <name>` (cancel).
 - **Interactive overlays**: `/status`, `/schedule`, `/gates`, `/stages`, `/worktree` display dismissible overlays. `/player`, `/ensemble` open full-screen interactive pickers.
-- **Removed aliases**: `/home`, `/maestro`, `/dashboard`, `/exit`, and `/unschedule` are **not** registered commands. Using them produces a "command not found" error. Use `/back`, `/quit`, and `/schedule delete` respectively.
+- **Removed aliases**: `/maestro`, `/dashboard`, `/exit`, and `/unschedule` are **not** registered commands. Using them produces a "command not found" error. Use `/home`, `/back`, `/quit`, and `/schedule delete` respectively. Legacy commands (`/detach`, `/disband`, `/resume`, `/pause_ensemble`, `/resume_ensemble`) show migration hints instead of "command not found".
 - **`/help <command>`**: `/help` alone shows all commands; `/help recruit` (or `/help /recruit`) shows the usage and description for a specific command in an overlay.
 - **NO_COLOR**: Set `NO_COLOR=1` to disable all color output — respected in both the TUI theme (`src/tui/utils/theme.ts`) and CLI output helpers (`src/cli/output.ts`). Follows the https://no-color.org/ convention.
 - **Terminal size requirement**: The TUI requires a minimum terminal size of **80×24**. If the terminal is smaller at launch, the process exits with code 1. A soft in-app warning appears at 60×15 during resize.


### PR DESCRIPTION
## Summary

- **docs/tools.md** — rename `pause_ensemble`→`pause`, `resume_ensemble`→`play`; add `shutdown`, `restore`, `play` rows; add v0.27 Changes section (#287)
- **docs/cli.md** — remove 8 retired commands (`conduct`, `start`, `stop`, `restart`, `detach`, `migrate`, `pause`, `resume`); add migration-hint block; update `down` (`--destroy` flag), `destroy` (ensemble-scope), `restore` (ensemble-scope, drop v0.25 badge); remove stale Command Details sections; fix Node >= 18 → >= 20 (#288, #289)
- **README.md** — fix `claude-tempo stop` → `destroy`; conductor "optional" → "required" (#286); replace `conduct`/`start` examples with `up`/TUI flow; update CLI list and TUI slash mention (#291)
- **docs/tui.md** — add `/play`, `/shutdown`, `/restore`, `/home`; update `/destroy` scope; remove `/stop`, `/detach`, `/disband` from active table; add v0.27 Changes section; fix `/home` "not a command" inversion (#290, #291)
- **CHANGELOG.md** — draft `## [Unreleased]` with Breaking/Changed/Added/Fixed for all 8 S8 slices (version number omitted — devops call)

## Test plan

- [ ] All tool names in `docs/tools.md` match `src/tools/*.ts` `defineTool` call names
- [ ] All CLI commands in `docs/cli.md` table match `src/cli/help-text.ts` Commands section
- [ ] No removed commands (`conduct`, `start`, `stop`, `restart`, `detach`, `migrate`, `pause`, `resume`) appear in table rows (migration-hint block is fine)
- [ ] All TUI slash commands in `docs/tui.md` table match `src/tui/commands.ts` `usage:` registrations
- [ ] `/home` appears as a real command (not in "not registered" list)
- [ ] CHANGELOG Breaking/Added/Fixed entries reference correct PR numbers
- [ ] `README.md` conductor description reads "Required" not "optional"

Closes #292

---
🎼 _Posted by [claude-tempo\[bot\]](https://github.com/apps/claude-tempo) —
an AI ensemble acting on behalf of @vinceblank. For a human, mention @vinceblank directly._