### PR TITLE
chore: declare npm as canonical package manager (#533)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,16 @@ npm run check:all   # runs every CI gate locally (build, tests, drift checks, li
 > production code"; the hook's doc-comment should restate that explicitly. Hooks
 > are never surfaced through barrels or `TempoClient`.
 
+> **Project standard is npm** (declared via `package.json#packageManager`,
+> enforced in CI by `lint:lockfile-canonical`). If `npm` is blocked locally
+> (e.g. corp networks), `pnpm` works as a personal workaround — `pnpm-lock.yaml`
+> is gitignored, so it can exist on disk but must NOT be committed. The
+> `lint:lockfile-canonical` step inside `check:all` fails if any non-npm
+> lockfile (`pnpm-lock.yaml`, `yarn.lock`, or their `dashboard/` counterparts)
+> appears in `git ls-files`. The `dashboard/` subworkspace also uses npm and
+> ships its own `package-lock.json` — see `.github/workflows/ci.yml` for why
+> the install is intentionally independent.
+
 See [docs/development.md](docs/development.md) for full setup (Temporal dev server command,
 daemon worker notes, `npx ts-node` dev runner).
 

--- a/package.json
+++ b/package.json
@@ -78,8 +78,9 @@
     "lint:test-ensemble-literals": "bash scripts/check-test-ensemble-literals.sh",
     "lint:skip-reasons": "node scripts/lint-skip-reasons.js",
     "lint:lockstep-version": "node -e \"const r=require('./package.json').version,d=require('./dashboard/package.json').version;if(r!==d){console.error('Version drift: root='+r+' dashboard='+d+'. Bump dashboard/package.json#version to match root.');process.exit(1);}console.log('Lockstep OK: '+r);\"",
+    "lint:lockfile-canonical": "bash scripts/check-lockfile-canonical.sh",
     "lint:dashboard-css-sync": "npm run build:scripts && node dist/scripts/check-components-css-sync.js",
-    "check:all": "npm run lint:test-ensemble-literals && npm run lint:skip-reasons && npm run lint:lockstep-version && npm run lint:surface-drift && npm run build && npm run lint:dashboard-css-sync && npm test && npm --prefix dashboard run lint && npm --prefix dashboard run test && npm run size-limit && npm run verify-tarball"
+    "check:all": "npm run lint:test-ensemble-literals && npm run lint:skip-reasons && npm run lint:lockstep-version && npm run lint:lockfile-canonical && npm run lint:surface-drift && npm run build && npm run lint:dashboard-css-sync && npm test && npm --prefix dashboard run lint && npm --prefix dashboard run test && npm run size-limit && npm run verify-tarball"
   },
   "optionalDependencies": {
     "@github/copilot-sdk": "^0.2.0",
@@ -158,6 +159,7 @@
   "engines": {
     "node": ">=20"
   },
+  "packageManager": "npm@10.9.2",
   "license": "MIT",
   "trustedDependencies": [
     "@swc/core",

--- a/scripts/check-lockfile-canonical.sh
+++ b/scripts/check-lockfile-canonical.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# CI lint — fail if a non-canonical (non-npm) lockfile is tracked in git.
+#
+# Project standard is npm; see CLAUDE.md and `package.json#packageManager`.
+# `pnpm-lock.yaml` is gitignored at the repo root (see .gitignore) so it can
+# legitimately exist on disk for contributors who personally use pnpm — but it
+# must NEVER appear in the git index. Same goes for any future yarn lockfile,
+# and for the same files inside the dashboard/ subworkspace.
+#
+# Why git-tracked vs filesystem: pnpm-lock.yaml is gitignored on purpose, so a
+# plain `[ -f pnpm-lock.yaml ]` check would false-positive on a perfectly fine
+# local-only file. The policy violation is the file appearing in the index, not
+# its existence on disk. Hence `git ls-files` — sees only what's tracked.
+#
+# Keep the script Bash-portable — CI runs on GitHub-hosted Ubuntu, but the same
+# script should work on macOS (bash 3.2) and Git Bash on Windows for local runs.
+#
+# See #533 for the policy-gap that motivated this lint.
+
+set -euo pipefail
+
+# `git ls-files` only emits paths that are tracked. `2>/dev/null || true`
+# guards the (unlikely) edge case of running outside a git repo.
+files=$(
+  git ls-files \
+    pnpm-lock.yaml \
+    yarn.lock \
+    'dashboard/pnpm-lock.yaml' \
+    'dashboard/yarn.lock' \
+    2>/dev/null || true
+)
+
+if [ -n "$files" ]; then
+  echo "ERROR: non-canonical lockfile tracked in git:"
+  printf '  %s\n' $files
+  echo
+  echo "Project standard is npm. See CLAUDE.md and package.json#packageManager."
+  echo "Remove the offending lockfile(s) with: git rm <path>"
+  exit 1
+fi
+
+echo "Lockfile-canonical OK: only npm lockfiles are tracked."


### PR DESCRIPTION
## Summary

Closes #533.

The repo carried both `pnpm-lock.yaml` and `package-lock.json` with no `"packageManager"` field — guaranteed drift on every install. This PR closes the policy gap **without disturbing any existing lockfile**.

- **`package.json`** — declare `"packageManager": "npm@10.9.2"` (Corepack will enforce locally + in CI).
- **`scripts/check-lockfile-canonical.sh`** — new bash lint that fails if any non-npm lockfile (`pnpm-lock.yaml`, `yarn.lock`, or their `dashboard/` counterparts) appears in `git ls-files`. Tracked-file check, not a filesystem check, because `pnpm-lock.yaml` is gitignored by design — it can legitimately exist on disk for contributors who use pnpm as a personal workaround. Only the appearance in the index is the policy violation.
- **`package.json#scripts`** — wire `lint:lockfile-canonical` into `check:all` after `lint:lockstep-version`, matching the existing lint-chain pattern.
- **`CLAUDE.md`** — one-paragraph note in the Development section (npm canonical, personal-pnpm escape hatch is OK, enforcement path).

## Why no lockfile changes

- `package-lock.json` (root) is canonical — last refreshed 2026-05-08, left as-is.
- `pnpm-lock.yaml` is already gitignored at `.gitignore:46` and was never tracked in this branch, so there is nothing to `git rm`.
- `dashboard/package-lock.json` is intentionally a separate install — `.github/workflows/ci.yml` lines 86–89 document the rationale (independent npm-ci so the main TS build doesn't pay the dashboard's install cost). Same canonical manager, separate lock — no change needed.

## Why npm (and not pnpm)

CI is already 100% `npm ci` (`ci.yml:128, :294, :368, :517, :570`). Every command in `CLAUDE.md`'s Development section is `npm`. The on-disk pnpm shape was an accident of contributor preference, not a project standard. Picking npm here just declares what CI has been treating as canonical all along.

## CI integration

No `.github/workflows/*.yml` changes. The new lint runs as part of `npm run check:all`, which CI already executes (e.g. `ci.yml` build-and-test shards). CI's strict `npm ci` will also catch any lockfile drift on push.

## Local verification

```
$ bash scripts/check-lockfile-canonical.sh
Lockfile-canonical OK: only npm lockfiles are tracked.

$ # Negative path (synthetic git scratch with a tracked pnpm-lock.yaml):
ERROR: non-canonical lockfile tracked in git:
  pnpm-lock.yaml

Project standard is npm. See CLAUDE.md and package.json#packageManager.
Remove the offending lockfile(s) with: git rm <path>
exit=1
```

## Test plan

- [x] New lint passes on this branch (no non-canonical lockfiles tracked).
- [x] New lint fails on a synthetic git scratch with a tracked `pnpm-lock.yaml` (exit 1, clear remediation).
- [x] Executable bit on `scripts/check-lockfile-canonical.sh` is in the index (`100755`).
- [ ] CI green — fresh `npm ci` + full `check:all` on Linux + Windows runners across the Node 20/22/24 matrix.
- [ ] Corepack accepts the `packageManager` pin on each Node matrix entry.

## Acceptance criteria (from #533)

- [x] `"packageManager"` declared in `package.json` (`npm@10.9.2`).
- [x] Off-brand lockfile not tracked in git (was already gitignored at `.gitignore:46`).
- [x] CI lint that fails when a non-canonical lockfile is tracked, wired into `check:all`.
- [x] CLAUDE.md note added (one paragraph).
- [x] PR notes `dashboard/package-lock.json` as intentionally a separate install under the same canonical manager.
- [ ] Smoke check: fresh clone + `npm ci` on Linux + Windows runners — left for CI to validate.

## File pointers

| File | Change |
|---|---|
| `package.json` | `+packageManager`, `+lint:lockfile-canonical`, chained into `check:all` |
| `scripts/check-lockfile-canonical.sh` | new (mode 100755) |
| `CLAUDE.md` | +1 blockquote paragraph in Development section |

---

> _Authored via the tempo-impl ensemble (lead + composer + tuner + conductor). PR opened under maintainer identity because GitHub App credentials weren't provisioned at PR-open time._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
