### PR TITLE
fix: copilot adapter pre-flight + host-profile probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- copilot adapter: recruit pre-flight now fails fast with an actionable error
+  when `@github/copilot-sdk` is not installed; daemon host profile correctly
+  advertises copilot when the SDK is available — closes the gap where
+  cross-host `recruit { agent: 'copilot', host: 'X' }` was rejected with a
+  misleading "Host \"X\" cannot run copilot" message even on hosts where the
+  SDK was installed and Copilot was logged in. (#532)
+
 ## [0.28.0-beta.16] - 2026-05-03
 
 ### Added

--- a/src/daemon-adapter-versions.ts
+++ b/src/daemon-adapter-versions.ts
@@ -162,21 +162,54 @@ async function defaultRunCommand(cmd: string, args: string[]): Promise<string> {
   return stdout;
 }
 
-/** Try to resolve the Copilot SDK's package.json version. Returns
- * `undefined` when the optional dep isn't installed (covers npm
- * installs that opted out, dev environments without the bridge, etc.). */
-async function defaultResolveCopilotSdkVersion(): Promise<string | undefined> {
+/**
+ * Synchronous companion to {@link defaultResolveCopilotSdkVersion}.
+ * Returns the Copilot SDK's `package.json#version` if the optional
+ * dependency is installed, or `undefined` when the require fails.
+ *
+ * Exported for #532 PR-2 — `src/daemon.ts` `computeHostProfile()` is
+ * synchronous (matches the existing `claude-code-headless` block at
+ * `daemon.ts:278-288`, which uses synchronous probes from
+ * `src/adapters/claude-code-headless/pre-flight.ts`). Awaiting an
+ * async helper from a sync function isn't possible without cascading
+ * the change to all `computeHostProfile` call sites; instead, this
+ * sync helper is the single require-source-of-truth, and the async
+ * `defaultResolveCopilotSdkVersion` (kept for the
+ * `ProbeAdapterVersionsDeps['resolveCopilotSdkVersion']` contract)
+ * delegates to it.
+ *
+ * Tests stub this directly via the `resolveCopilotSdkVersionSync` dep
+ * on `computeHostProfile` (see `test/daemon-boot.test.ts`).
+ *
+ * Never throws — a `try/catch` swallows MODULE_NOT_FOUND and any
+ * other failure mode to `undefined`. A throw here would crash the
+ * daemon-boot critical path.
+ */
+export function resolveCopilotSdkVersionSync(): string | undefined {
   try {
     // `require` rather than ESM `import` so we read the package.json
     // synchronously without the await + dynamic-import-of-JSON dance.
-    // The wrapper IIFE keeps the require inside a try block so a
+    // The wrapper try/catch keeps the require inside a guard so a
     // bundler that statically analyzes imports still treats it as
     // optional.
-    const pkg = require('@github/copilot-sdk/package.json') as { version?: string };
+    const pkg = require('@github/copilot-sdk/package.json') as {
+      version?: string;
+    };
     return pkg.version;
   } catch {
     return undefined;
   }
+}
+
+/** Try to resolve the Copilot SDK's package.json version. Returns
+ * `undefined` when the optional dep isn't installed (covers npm
+ * installs that opted out, dev environments without the bridge, etc.).
+ *
+ * Delegates to {@link resolveCopilotSdkVersionSync} so the require
+ * call has a single source of truth — see that function's docstring
+ * for why the sync sibling exists. */
+async function defaultResolveCopilotSdkVersion(): Promise<string | undefined> {
+  return resolveCopilotSdkVersionSync();
 }
 
 function defaultLog(...args: unknown[]): void {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -32,7 +32,10 @@ import { createTempoClient } from './client';
 import { queryOrphanedSessions, restoreOrphansOnce, type OrphanCandidate } from './reconcile/orphans';
 import { listAgentTypes } from './ensemble/agent-types';
 import { probeClaudeBinary, probeClaudeAuth } from './adapters/claude-code-headless/pre-flight';
-import { probeAdapterVersions } from './daemon-adapter-versions';
+import {
+  probeAdapterVersions,
+  resolveCopilotSdkVersionSync,
+} from './daemon-adapter-versions';
 import type { GlobalMaestroInput, HostProfile } from './types';
 
 const log = (...args: unknown[]) => console.error(`[claude-tempo:daemon ${new Date().toISOString()}]`, ...args);
@@ -250,6 +253,29 @@ function daemonVersion(): string {
 }
 
 /**
+ * Test-only dependency-injection seam for {@link computeHostProfile}.
+ *
+ * Production callers omit `deps` entirely; the defaults resolve to the
+ * real probes in `daemon-adapter-versions.ts`. Tests inject stubs to
+ * exercise installed-vs-not-installed scenarios deterministically
+ * without touching the host filesystem. Mirrors the
+ * `ProbeAdapterVersionsDeps` shape from `daemon-adapter-versions.ts`,
+ * but only includes synchronous probes — `computeHostProfile` is sync
+ * by contract.
+ *
+ * Added in #532 PR-2 for the copilot host-profile probe.
+ */
+export interface ComputeHostProfileDeps {
+  /**
+   * Synchronous Copilot SDK version probe. Default:
+   * {@link resolveCopilotSdkVersionSync} from `daemon-adapter-versions.ts`.
+   * Returns the SDK's `package.json#version` when installed, or
+   * `undefined` when missing or unresolvable.
+   */
+  resolveCopilotSdkVersionSync?: () => string | undefined;
+}
+
+/**
  * Build the daemon's capability profile from its config + runtime env.
  * Result is NOT scrubbed — call `scrubHostProfile` before signaling.
  *
@@ -257,7 +283,12 @@ function daemonVersion(): string {
  * `runDaemonBoot(client, deps)` which provides this as the default
  * `computeHostProfile` dep.
  */
-export function computeHostProfile(config: Config): HostProfile {
+export function computeHostProfile(
+  config: Config,
+  deps: ComputeHostProfileDeps = {},
+): HostProfile {
+  const resolveCopilotSync =
+    deps.resolveCopilotSdkVersionSync ?? resolveCopilotSdkVersionSync;
   const agentTypes = (() => {
     try {
       return listAgentTypes().map((a) => a.name);
@@ -287,16 +318,37 @@ export function computeHostProfile(config: Config): HostProfile {
     // Probe machinery should never throw, but guard anyway — host-profile
     // computation is on the critical boot path.
   }
+  // #532 PR-2 — copilot probe. Reuses the same sync require-source-of-
+  // truth as `defaultResolveCopilotSdkVersion` (which it delegates to);
+  // resolves to a version string when `@github/copilot-sdk` is
+  // installed, or `undefined` when missing. Closes the gap where
+  // cross-host recruit of `agent: 'copilot'` was rejected with a
+  // misleading "host cannot run copilot" message even on hosts where
+  // the SDK was installed and Copilot was logged in. Pattern mirrors
+  // the claude-code-headless block above.
+  try {
+    const copilotVersion = resolveCopilotSync();
+    if (copilotVersion && !availableAgentTypes.includes('copilot')) {
+      availableAgentTypes.push('copilot');
+    }
+  } catch {
+    // Defensive — `resolveCopilotSdkVersionSync` already swallows
+    // require failures, but the boot path must not crash on any
+    // surprise here.
+  }
 
   return {
     hostname: os.hostname(),
     version: daemonVersion(),
     defaultAgent: config.defaultAgent,
-    // #520 — was: `[config.defaultAgent]`. Now grows when the optional
-    // claude-code-headless probe passes. Future PRs can extend the same
-    // pattern for `copilot` / `claude-api` / `opencode` (e.g. probe
-    // `@anthropic-ai/sdk` install + ANTHROPIC_API_KEY env). Recording as
-    // an array keeps the wire shape forward-compatible.
+    // #520 + #532 PR-2 — was: `[config.defaultAgent]`. Now grows when
+    // the optional probes pass: `claude-code-headless` (when `claude`
+    // is on PATH AND logged in), `copilot` (when `@github/copilot-sdk`
+    // is installed). Future PRs can extend the same pattern for
+    // `claude-api` (probe `@anthropic-ai/sdk` install +
+    // ANTHROPIC_API_KEY env) and `opencode` (probe `@opencode-ai/sdk`
+    // install + `opencode` binary on PATH). Recording as an array
+    // keeps the wire shape forward-compatible.
     availableAgentTypes,
     availablePlayerTypes: agentTypes,
     claudeBin: config.claudeBin,

--- a/src/tools/recruit.ts
+++ b/src/tools/recruit.ts
@@ -235,6 +235,27 @@ export function registerRecruitTool(
           return fail(`agent: "claude-code-headless" pre-flight failed: ${authProbe.error} Use \`force: true\` to bypass.`);
         }
       }
+      // #532 — copilot pre-flight. SDK-only probe (mirrors claude-api's
+      // pattern; copilot has no subprocess CLI on PATH). The bridge
+      // subprocess hard-requires `@github/copilot-sdk` at module load
+      // (`src/adapters/copilot/adapter.ts:71`), so without this gate the
+      // user only learns of the missing dep AFTER bridge spawn —
+      // adapter crashes with `process.exit(1)` and the player sits in
+      // `booting` until lease timeout. We use `probeSdkInstall` (FS walk)
+      // rather than `require.resolve` because pnpm layouts without a
+      // top-level hoisted link otherwise false-negative; see issue #532
+      // investigation footnote. GITHUB_TOKEN / Copilot CLI login are
+      // intentionally NOT checked: the SDK falls through to the
+      // logged-in user (`adapter.ts:31, :263`), so token presence is not
+      // a hard requirement. Cross-host recruits skip — the target
+      // daemon's `availableAgentTypes` is the gate there.
+      if (agent === 'copilot' && !host && !force) {
+        if (!probeSdkInstall('@github/copilot-sdk')) {
+          return fail(
+            `agent: "copilot" requires the @github/copilot-sdk optional dependency. Install with \`npm install @github/copilot-sdk\` and retry, or use \`force: true\` to bypass this check.`,
+          );
+        }
+      }
 
       // Resolve agent type if provided
       let agentDefinition: string | undefined;

--- a/test/daemon-boot.test.ts
+++ b/test/daemon-boot.test.ts
@@ -29,10 +29,12 @@ import type { Client } from '@temporalio/client';
 import type { HostProfile } from '../src/types';
 import {
   advertiseHostProfile,
+  computeHostProfile,
   runDaemonBoot,
   scrubHostProfile,
   warnIfDevNamespaceDrift,
 } from '../src/daemon';
+import type { Config } from '../src/config';
 import { DEV_TEMPORAL_NAMESPACE, ENV } from '../src/config';
 
 // Empty proxy stands in for a Client: reaching into it would throw, which
@@ -153,6 +155,76 @@ describe('scrubHostProfile (#274 AC5c / M10 — privacy)', function () {
       expect(field, `leaked 'bob' in: ${field}`).to.not.include('bob');
       expect(field, `leaked 'eve' in: ${field}`).to.not.include('eve');
     }
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────
+// computeHostProfile — copilot probe (#532 PR-2)
+// ────────────────────────────────────────────────────────────────────────
+//
+// Asserts the host-profile probe correctly advertises 'copilot' in
+// `availableAgentTypes` when the SDK is installed, and excludes it
+// when the SDK is missing. The probe itself lives in
+// `src/daemon-adapter-versions.ts:resolveCopilotSdkVersionSync`; here
+// we exercise the daemon-side glue via the `ComputeHostProfileDeps`
+// dep-injection seam that #532 PR-2 added to keep `computeHostProfile`
+// synchronous (matching the existing `claude-code-headless` block).
+
+describe('computeHostProfile copilot probe (#532 PR-2)', function () {
+  // Minimal Config — `computeHostProfile` only reads `defaultAgent`
+  // and `claudeBin` from it. Everything else can stay undefined.
+  const baseConfig = {
+    defaultAgent: 'claude' as const,
+    claudeBin: 'claude',
+  } as unknown as Config;
+
+  it('advertises `copilot` in availableAgentTypes when the SDK probe returns a version', function () {
+    const profile = computeHostProfile(baseConfig, {
+      resolveCopilotSdkVersionSync: () => '0.2.0',
+    });
+    expect(profile.availableAgentTypes).to.include('copilot');
+  });
+
+  it('excludes `copilot` from availableAgentTypes when the SDK probe returns undefined', function () {
+    const profile = computeHostProfile(baseConfig, {
+      resolveCopilotSdkVersionSync: () => undefined,
+    });
+    expect(profile.availableAgentTypes).to.not.include('copilot');
+  });
+
+  // Tripwire — `resolveCopilotSdkVersionSync` is contracted to never
+  // throw (it swallows MODULE_NOT_FOUND etc.), but `computeHostProfile`
+  // is on the daemon-boot critical path and must survive any surprise
+  // from a future loosening of that guard.
+  it('does NOT crash when the SDK probe throws — `copilot` is excluded', function () {
+    const profile = computeHostProfile(baseConfig, {
+      resolveCopilotSdkVersionSync: () => {
+        throw new Error('synthetic failure');
+      },
+    });
+    expect(profile.availableAgentTypes).to.not.include('copilot');
+  });
+
+  it('does not double-add `copilot` when it is also the configured defaultAgent', function () {
+    const profile = computeHostProfile(
+      { ...baseConfig, defaultAgent: 'copilot' as const } as unknown as Config,
+      { resolveCopilotSdkVersionSync: () => '0.2.0' },
+    );
+    const copilotEntries = (profile.availableAgentTypes ?? []).filter(
+      (a) => a === 'copilot',
+    );
+    expect(copilotEntries).to.have.length(1);
+  });
+
+  it('uses the production helper when no `resolveCopilotSdkVersionSync` dep is passed (smoke test)', function () {
+    // Production callers omit `deps` entirely. We don't assert on the
+    // outcome (host environment may or may not have @github/copilot-sdk
+    // installed), only that the call doesn't crash and returns a
+    // well-shaped profile. The DI seam is what's under test — the
+    // default fall-through path is critical for the daemon-boot path.
+    const profile = computeHostProfile(baseConfig);
+    expect(profile.availableAgentTypes).to.be.an('array');
+    expect(profile.availableAgentTypes).to.include('claude'); // defaultAgent always present
   });
 });
 

--- a/tests/tools/recruit-preflight.test.ts
+++ b/tests/tools/recruit-preflight.test.ts
@@ -1,0 +1,365 @@
+/**
+ * Parametrized recruit pre-flight gate coverage (#532).
+ *
+ * Closes the long-standing gap where the four SDK-class adapters'
+ * pre-flight gates in `src/tools/recruit.ts` had no direct unit tests.
+ * Adds the **copilot** gate from #532 and locks down the existing
+ * **claude-api** / **opencode** / **claude-code-headless** gates as
+ * regression tripwires, all in a single parametrized harness.
+ *
+ * Why parametrize: the four gates share an identical contract surface —
+ * `agent === <name> && !host && !force` → fail with an actionable npm
+ * install / env-var hint mentioning `force: true`. Copy-pasting one
+ * `describe` per adapter would let drift creep in (e.g. some gates
+ * mention the bypass hint, some don't). One table-driven harness keeps
+ * the contract uniform.
+ *
+ * What's NOT covered (out of scope for this PR):
+ *   - The opencode `hasOpencodeOnPath()` second probe is internal to
+ *     `recruit.ts` (uses `spawnSync`) and isn't easily mockable without
+ *     a fresh DI seam. We test the SDK-miss branch only — that's the
+ *     branch shared with copilot/opencode parity.
+ *   - The claude-api `require.resolve('@anthropic-ai/sdk')` SDK-miss
+ *     branch needs the optional dep to actually be uninstalled, which
+ *     can't be flipped per-test in vitest without monkey-patching the
+ *     loader. We test the env-var branch instead — that's the FIRST
+ *     check in the gate, so it covers the common "user forgot
+ *     ANTHROPIC_API_KEY" failure mode.
+ *
+ * Failure-mode philosophy: each adapter's "missing" path returns a
+ * `fail(...)` result. We assert the message contains the package
+ * name + `force: true` substrings rather than a verbatim match — the
+ * exact wording can shift across releases without breaking the
+ * contract; what mustn't shift is the actionable hint.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Client, WorkflowHandle } from '@temporalio/client';
+
+// ── Hoisted mocks. `vi.mock()` is hoisted above imports by vitest's
+//    transform, so the SUT (`registerRecruitTool`) sees the mocked
+//    modules at first import. ─────────────────────────────────────────
+vi.mock('../../src/utils/sdk-probe', () => ({
+  probeSdkInstall: vi.fn(),
+}));
+vi.mock('../../src/adapters/claude-code-headless/pre-flight', () => ({
+  probeClaudeBinary: vi.fn(),
+  probeClaudeAuth: vi.fn(),
+}));
+
+// SUT + mocked symbols (typed via `vi.mocked` for autocomplete).
+import { registerRecruitTool } from '../../src/tools/recruit';
+import { probeSdkInstall } from '../../src/utils/sdk-probe';
+import {
+  probeClaudeBinary,
+  probeClaudeAuth,
+} from '../../src/adapters/claude-code-headless/pre-flight';
+import type { Config } from '../../src/config';
+import type { AgentType } from '../../src/types';
+
+const probeSdkMock = vi.mocked(probeSdkInstall);
+const probeBinMock = vi.mocked(probeClaudeBinary);
+const probeAuthMock = vi.mocked(probeClaudeAuth);
+
+// ── Fakes (mirror `test/recruit-hosts-preflight.test.ts` pattern) ────
+
+type CapturedHandler = (args: Record<string, unknown>) => Promise<{
+  content: Array<{ text: string }>;
+  isError?: boolean;
+}>;
+
+function makeFakeServer(): {
+  server: McpServer;
+  capture: { handler?: CapturedHandler };
+} {
+  const capture: { handler?: CapturedHandler } = {};
+  const server = {
+    tool: (
+      _name: unknown,
+      _desc: unknown,
+      _schema: unknown,
+      handler: CapturedHandler,
+    ) => {
+      capture.handler = handler;
+    },
+  } as unknown as McpServer;
+  return { server, capture };
+}
+
+/**
+ * Fake Client that satisfies `resolveSession` (returns no matches) and
+ * the conductor-presence probe (`workflow.getHandle().describe()`
+ * throws → handler treats as "no conductor"). Anything else throws
+ * loudly so an unexpected-access regression is observable.
+ */
+function makeFakeClient(): Client {
+  return new Proxy({} as Client, {
+    get(_t, prop) {
+      if (prop === 'workflow') {
+        return {
+          getHandle: () => ({
+            describe: async () => {
+              throw new Error('no conductor');
+            },
+            terminate: async () => {
+              /* no-op */
+            },
+            signal: async () => {
+              /* no-op */
+            },
+          }),
+          // resolveSession iterates this — empty generator → null match.
+          list: async function* () {
+            /* no sessions */
+          },
+        };
+      }
+      throw new Error(
+        `Unexpected Client access in recruit-preflight test: ${String(prop)}`,
+      );
+    },
+  });
+}
+
+function makeFakeHandle(): {
+  handle: WorkflowHandle;
+  outboxEntries: Array<unknown>;
+} {
+  const outboxEntries: Array<unknown> = [];
+  const handle = {
+    executeUpdate: async (_update: unknown, opts: { args: unknown[] }) => {
+      outboxEntries.push(opts.args[0]);
+      return `outbox-${outboxEntries.length}`;
+    },
+  } as unknown as WorkflowHandle;
+  return { handle, outboxEntries };
+}
+
+// Minimal Config shim — only the fields recruit.ts actually reads in
+// pre-flight + outbox-submit paths.
+const cfg = {
+  ensemble: 'test-ensemble-recruit-preflight',
+  taskQueue: 'claude-tempo',
+  temporalNamespace: 'default',
+  temporalAddress: 'localhost:7233',
+  defaultAgent: 'claude' as const,
+} as unknown as Config;
+
+interface SetupResult {
+  capture: { handler?: CapturedHandler };
+  outboxEntries: Array<unknown>;
+}
+
+function setup(): SetupResult {
+  const { server, capture } = makeFakeServer();
+  const client = makeFakeClient();
+  const { handle, outboxEntries } = makeFakeHandle();
+  // Stub listHostsFn to a no-op — local-spawn tests never set `host`.
+  registerRecruitTool(
+    server,
+    client,
+    cfg,
+    () => 'test-player',
+    handle,
+    'claude',
+    { listHostsFn: async () => [] },
+  );
+  return { capture, outboxEntries };
+}
+
+// ── Per-adapter parametrization ──────────────────────────────────────
+//
+// Each row describes ONE pre-flight gate: how to flip its probe to
+// "missing" and what substrings the error message must include.
+
+type AdapterCase = {
+  /** Display name in `describe.each` titles. */
+  label: string;
+  agent: AgentType;
+  /** Configure mocks/env so this adapter's gate trips. */
+  setupMissing: () => void;
+  /** Substrings that the fail message MUST contain. */
+  expectedSubstrings: string[];
+};
+
+const cases: AdapterCase[] = [
+  {
+    label: 'claude-api (missing ANTHROPIC_API_KEY)',
+    agent: 'claude-api' as AgentType,
+    setupMissing: () => {
+      delete process.env.ANTHROPIC_API_KEY;
+    },
+    expectedSubstrings: ['claude-api', 'ANTHROPIC_API_KEY', 'force: true'],
+  },
+  {
+    label: 'opencode (SDK not installed)',
+    agent: 'opencode' as AgentType,
+    setupMissing: () => {
+      // probeSdkInstall returns false ONLY for the opencode SDK; the
+      // copilot gate is unrelated, so its probe must still pass through
+      // happily for unrelated agents in the same test run.
+      probeSdkMock.mockImplementation(
+        (pkg: string) => pkg !== '@opencode-ai/sdk',
+      );
+    },
+    expectedSubstrings: ['opencode', '@opencode-ai/sdk', 'force: true'],
+  },
+  {
+    label: 'claude-code-headless (claude binary missing)',
+    agent: 'claude-code-headless' as AgentType,
+    setupMissing: () => {
+      probeBinMock.mockReturnValue({
+        ok: false,
+        error:
+          'claude binary not found on PATH. Install Claude Code from https://claude.ai/code.',
+      });
+    },
+    expectedSubstrings: ['claude-code-headless', 'force: true'],
+  },
+  {
+    label: 'copilot (SDK not installed) — #532',
+    agent: 'copilot' as AgentType,
+    setupMissing: () => {
+      probeSdkMock.mockImplementation(
+        (pkg: string) => pkg !== '@github/copilot-sdk',
+      );
+    },
+    expectedSubstrings: ['copilot', '@github/copilot-sdk', 'force: true'],
+  },
+];
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+describe('recruit pre-flight — parametrized adapter gates (#532)', () => {
+  // Snapshot ANTHROPIC_API_KEY across the suite so the claude-api row's
+  // `delete` doesn't bleed into the developer's shell or other tests.
+  const savedAnthropicKey = process.env.ANTHROPIC_API_KEY;
+
+  beforeEach(() => {
+    vi.resetAllMocks();
+    // Defaults: every probe reports "installed / working". Each test
+    // that wants a miss flips its specific probe in setupMissing().
+    probeSdkMock.mockReturnValue(true);
+    probeBinMock.mockReturnValue({ ok: true });
+    probeAuthMock.mockReturnValue({ loggedIn: true });
+    // Default: claude-api env var present so that path doesn't trip
+    // unless the test explicitly deletes it.
+    process.env.ANTHROPIC_API_KEY = 'sk-test-token-not-real';
+  });
+
+  afterEach(() => {
+    if (savedAnthropicKey === undefined) {
+      delete process.env.ANTHROPIC_API_KEY;
+    } else {
+      process.env.ANTHROPIC_API_KEY = savedAnthropicKey;
+    }
+  });
+
+  describe.each(cases)('$label', ({ agent, setupMissing, expectedSubstrings }) => {
+    it('fails fast with an actionable message when the probe reports missing', async () => {
+      setupMissing();
+      const { capture, outboxEntries } = setup();
+      const result = await capture.handler!({
+        workDir: '/tmp/work',
+        name: 'new-player',
+        agent,
+      });
+      expect(result.isError).toBe(true);
+      for (const sub of expectedSubstrings) {
+        expect(result.content[0].text).toContain(sub);
+      }
+      // Most important regression assertion: the gate fired BEFORE the
+      // outbox submit, so no recruit entry was queued.
+      expect(outboxEntries).toHaveLength(0);
+    });
+
+    it('`force: true` bypasses the gate even when the probe reports missing', async () => {
+      setupMissing();
+      const { capture, outboxEntries } = setup();
+      const result = await capture.handler!({
+        workDir: '/tmp/work',
+        name: 'new-player',
+        agent,
+        force: true,
+      });
+      // Bypass means the recruit proceeds all the way to the outbox.
+      expect(result.isError).not.toBe(true);
+      expect(outboxEntries).toHaveLength(1);
+    });
+  });
+});
+
+// ── #532-specific edge cases ─────────────────────────────────────────
+//
+// These don't fit cleanly into the parametrized table above — they
+// assert the **copilot** gate's bounds rather than its body.
+
+describe('copilot pre-flight specifics (#532)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    probeSdkMock.mockReturnValue(true);
+    probeBinMock.mockReturnValue({ ok: true });
+    probeAuthMock.mockReturnValue({ loggedIn: true });
+    process.env.ANTHROPIC_API_KEY = 'sk-test-token-not-real';
+  });
+
+  it('does NOT fire for non-copilot agents, even when @github/copilot-sdk is missing', async () => {
+    // Make ONLY the copilot SDK probe fail — opencode/anthropic stay green.
+    probeSdkMock.mockImplementation(
+      (pkg: string) => pkg !== '@github/copilot-sdk',
+    );
+    const { capture, outboxEntries } = setup();
+    // Recruit a `claude` agent — the copilot gate must not interfere.
+    const result = await capture.handler!({
+      workDir: '/tmp/work',
+      name: 'new-player',
+      agent: 'claude',
+    });
+    expect(result.isError).not.toBe(true);
+    // Defensive: the copilot fail wording must NOT appear in the
+    // success message (regression tripwire if someone ever moves the
+    // gate above the agent-equality check).
+    expect(result.content[0].text).not.toContain('@github/copilot-sdk');
+    expect(outboxEntries).toHaveLength(1);
+  });
+
+  it('proceeds normally when @github/copilot-sdk IS installed', async () => {
+    // Default mock returns true for every package, including copilot.
+    const { capture, outboxEntries } = setup();
+    const result = await capture.handler!({
+      workDir: '/tmp/work',
+      name: 'new-player',
+      agent: 'copilot',
+    });
+    expect(result.isError).not.toBe(true);
+    expect(outboxEntries).toHaveLength(1);
+    // probeSdkInstall must have been consulted with the copilot SDK
+    // package specifier — proves the gate was actually exercised.
+    expect(probeSdkMock).toHaveBeenCalledWith('@github/copilot-sdk');
+  });
+
+  it('skips the local pre-flight entirely when `host` is set (cross-host path)', async () => {
+    // SDK is missing locally — but with `host` set, the local gate
+    // must be skipped (target daemon's availableAgentTypes is the
+    // gate there, not us). We can't reach the cross-host pre-flight
+    // happy path in this harness without a richer hosts list, so we
+    // assert the negative: the message does NOT contain the
+    // local-pre-flight wording. The downstream cross-host gate
+    // produces its own (different) error message.
+    probeSdkMock.mockImplementation(
+      (pkg: string) => pkg !== '@github/copilot-sdk',
+    );
+    const { capture } = setup();
+    const result = await capture.handler!({
+      workDir: '/tmp/work',
+      name: 'new-player',
+      agent: 'copilot',
+      host: 'some-other-host',
+    });
+    // The local gate's NPM-install hint must not be present — that
+    // would mean we tripped the local gate on a cross-host recruit.
+    expect(result.content[0].text).not.toContain(
+      'npm install @github/copilot-sdk',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Closes #532. Two parity fixes that retrofit the copilot adapter with the recruit pre-flight + host-profile probe affordances every newer SDK adapter (`claude-api`, `opencode`, `claude-code-headless`) shipped with. Net effect: copilot users now get fast, actionable feedback when the SDK isn't installed locally, AND cross-host recruits of `agent: 'copilot'` stop being silently rejected on healthy hosts.

### Fix A — Recruit pre-flight (`src/tools/recruit.ts`)

Before this PR: `recruit { agent: 'copilot' }` proceeded with no SDK / auth check. The `@github/copilot-sdk` import is hard-required at module load (`src/adapters/copilot/adapter.ts:71`), so the user only learned the dep was missing AFTER the bridge subprocess started and `process.exit(1)`'d — by which point the workflow had moved past `booting` and the player sat in a broken state until lease timeout.

After: SDK-only pre-flight (mirrors `claude-api`) gated on `agent === 'copilot' && !host && !force`. Probe via `probeSdkInstall('@github/copilot-sdk')` (FS walk through `node_modules`) — the same helper the `opencode` gate uses, which is universal across pnpm/npm/yarn layouts. On miss, returns an actionable `fail(...)` with the npm install hint + `force: true` bypass.

GITHUB_TOKEN / Copilot CLI login are intentionally NOT checked: the SDK falls through to the logged-in user (`adapter.ts:31, :263`), so token presence isn't a hard requirement.

### Fix B — Host-profile probe (`src/daemon.ts`)

Before this PR: `computeHostProfile()` only conditionally added `'claude-code-headless'` to `HostProfile.availableAgentTypes`. Cross-host recruit gating at `src/tools/recruit.ts:407-412` reads this list and rejects with `Host "X" cannot run copilot (supports: …)` — and that rejection fired on **every** cross-host copilot recruit because the list never contained `'copilot'`.

After: extended `computeHostProfile()` with a synchronous copilot probe mirroring the existing `claude-code-headless` block (lines 278-288). Reuses `defaultResolveCopilotSdkVersion`'s require pattern via a new exported sync sibling `resolveCopilotSdkVersionSync` in `src/daemon-adapter-versions.ts` — single require source of truth, no async cascade to `computeHostProfile` call sites.

Updated the deferred-comment at `daemon.ts:295-298` to drop copilot from the "future PRs" list (claude-api / opencode remain — separate issues if a maintainer wants the same retrofit there).

### What's NOT in scope

- claude-api / opencode host-profile probes (issue #532 explicitly scoped to copilot; same retrofit can land in a follow-up).
- Refactor of the four pre-flight gates into a shared registry. Each currently has its own probe shape (`require.resolve` for claude-api, `probeSdkInstall + hasOpencodeOnPath` for opencode, etc.); a uniform abstraction would be a larger architectural change.

## Test plan

- [x] **NEW** `tests/tools/recruit-preflight.test.ts` (vitest) — 11 tests covering all four SDK adapters parametrized: `claude-api`, `opencode`, `claude-code-headless`, `copilot`. Each adapter asserted on (a) fail-fast wording when the probe reports missing, (b) `force: true` bypasses the gate. Plus three copilot-specific edge cases:
  - non-copilot agent recruit doesn't trip the copilot gate
  - SDK-installed copilot recruit reaches the outbox + probe was consulted
  - `host` set skips the local gate (cross-host path)
  - **Result**: `pnpm exec vitest run tests/tools/recruit-preflight.test.ts` → 11/11 passing in 1.15s
- [x] **EXTENDED** `test/daemon-boot.test.ts` (mocha) — 5 new `computeHostProfile copilot probe` cases:
  - SDK probe returns version → `'copilot'` in `availableAgentTypes`
  - SDK probe returns undefined → `'copilot'` excluded
  - SDK probe throws → no crash, `'copilot'` excluded (defensive guard)
  - `defaultAgent: 'copilot'` + probe hit → no double-add (count == 1)
  - No deps passed → smoke check the production fall-through wires correctly
  - **Result**: `pnpm exec mocha --grep "computeHostProfile copilot probe" dist-test/test/daemon-boot.test.js` → 5/5 passing
- [x] **REGRESSION** existing daemon-boot pure-unit tests (16 across `scrubHostProfile` / `advertiseHostProfile retry behavior` / `scrubHostProfile #399 pass-through` / `warnIfDevNamespaceDrift`) → still passing
- [x] **REGRESSION** existing recruit-hosts-preflight tests (13 across `checkHostPreflight` / `nearestHostname`) → still passing
- [x] No new TypeScript errors introduced (39 pre-existing TS errors on the Temporal SDK type-definition surface remain, identical count with and without this branch — verified via `git stash` round-trip).
- [ ] **Manual verification (deferred to maintainer)**: on a host without `@github/copilot-sdk`, confirm `claude-tempo hosts` does NOT list copilot under available agents. Install the SDK, restart the daemon, confirm it now appears. Cross-host recruit from a peer should then succeed without `force: true`.

> _Authored via the tempo-impl ensemble (eng + composer + tuner + conductor). PR opened under maintainer identity because GitHub App credentials weren't provisioned at PR-open time._
