### PR TITLE
feat: expose headless adapter types in v1 wire protocol (#535)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Wire protocol: `PlayerSummaryV1.agentType` union expanded** to mirror
+  `AgentType` in `src/types.ts` — adds `'claude-api'`, `'opencode'`, and
+  `'claude-code-headless'` alongside the existing `'claude'`, `'copilot'`,
+  `'mock'`. Pre-fix, the snapshot projection coerced every headless
+  adapter to `'claude'`, making `claude-api` / `opencode` /
+  `claude-code-headless` players visually indistinguishable from
+  interactive Claude Code sessions in the dashboard. Additive extension
+  per the §6 stability rule in `src/http/event-types.ts` — no `/v1/` →
+  `/v2/` path bump. Aggregate diff loop now tracks `playerAgentTypes`
+  per-ensemble in lockstep with `playerPhases`, so the prior-snapshot
+  reconstruction carries each player's real adapter family instead of a
+  hardcoded stand-in. (#535)
+
 ### Fixed
 
 - copilot adapter: recruit pre-flight now fails fast with an actionable error

--- a/docs/SSE-PROTOCOL.md
+++ b/docs/SSE-PROTOCOL.md
@@ -159,7 +159,7 @@ interface PlayerSummaryV1 {
   ensemble: string;
   hostname: string;
   isConductor: boolean;
-  agentType: 'claude' | 'copilot' | 'mock';
+  agentType: 'claude' | 'copilot' | 'mock' | 'claude-api' | 'opencode' | 'claude-code-headless';  // #535 — mirrors AgentType in src/types.ts
   playerType?: string;
   phase?: AttachmentPhase;     // from WIRE-PROTOCOL §Type Reference
   part: string;

--- a/docs/WIRE-PROTOCOL.md
+++ b/docs/WIRE-PROTOCOL.md
@@ -347,7 +347,7 @@ Limits (enforced by `savePlayerState` validator and the `save_state` Zod schema)
 | `gitRoot` | `string?` | Git repository root, if detected. |
 | `gitBranch` | `string?` | Current git branch, if detected. |
 | `isConductor` | `boolean` | Whether this player is the conductor. |
-| `agentType` | `string` | Agent backend (`claude` or `copilot`). |
+| `agentType` | `string` | Agent backend — one of `claude`, `copilot`, `mock` (dev-mode-only), `claude-api`, `opencode`, `claude-code-headless`. Mirrors `AgentType` in `src/types.ts`. (#535) |
 | `playerType` | `string?` | Named agent type (e.g. `tempo-soloist`), if set. |
 | `status` | `string?` | Session lifecycle status (`pending`, `active`, `stale`, `blocked`, `terminated`). |
 

--- a/src/http/aggregate.ts
+++ b/src/http/aggregate.ts
@@ -51,6 +51,18 @@ interface EnsembleTrack {
   bus: EnsembleEventBus;
   /** Last seen player phase, keyed by playerId. */
   playerPhases: Map<string, string | undefined>;
+  /**
+   * Adapter family per playerId — used to faithfully reconstruct the
+   * prior `AggregateEnsembleSnapshot` view at tick boundaries (see #535).
+   * Pre-#535 the prior carried a hardcoded `agentType: 'claude'` because
+   * the wire union was closed at `'claude' | 'copilot' | 'mock'`; once the
+   * union mirrors `AgentType`, the prior must carry a real adapter type
+   * so the type system can't be blindsided by a future entry. Set in
+   * lockstep with `playerPhases` (`player.added` → `set`, `player.removed`
+   * → `delete`); agentType is treated as immutable for a player's
+   * lifetime (matches `MaestroPlayerInfo` semantics).
+   */
+  playerAgentTypes: Map<string, PlayerSummaryV1['agentType']>;
   /** Last (paused, held) tuple. */
   flags: { paused: boolean; held: boolean } | null;
   /** SHA-256 of last emitted schedules JSON. */
@@ -115,7 +127,7 @@ export interface DiffEvent {
 export function diffEnsembleSnapshot(
   prev: AggregateEnsembleSnapshot | null,
   next: AggregateEnsembleSnapshot,
-  track: Pick<EnsembleTrack, 'playerPhases' | 'flags' | 'schedulesHash' | 'chatIds' | 'chatIdOrder'>,
+  track: Pick<EnsembleTrack, 'playerPhases' | 'playerAgentTypes' | 'flags' | 'schedulesHash' | 'chatIds' | 'chatIdOrder'>,
   capturedAt: string,
 ): DiffEvent[] {
   const events: DiffEvent[] = [];
@@ -132,6 +144,11 @@ export function diffEnsembleSnapshot(
     if (!prevPlayers.has(p.playerId)) {
       events.push({ type: 'player.added', payload: p });
       track.playerPhases.set(p.playerId, p.phase);
+      // #535 — record the adapter family so the prior reconstruction at
+      // the next tick (aggregate.ts ~L600) carries the real agentType
+      // instead of a hardcoded `'claude'` stand-in. Treated as immutable
+      // for the player's lifetime; cleared on `player.removed` below.
+      track.playerAgentTypes.set(p.playerId, p.agentType);
       continue;
     }
     const lastPhase = track.playerPhases.get(p.playerId);
@@ -169,6 +186,7 @@ export function diffEnsembleSnapshot(
           },
         });
         track.playerPhases.delete(p.playerId);
+        track.playerAgentTypes.delete(p.playerId);
       }
     }
   }
@@ -419,6 +437,7 @@ export class AggregateRunner {
       track = {
         bus,
         playerPhases: new Map(),
+        playerAgentTypes: new Map(),
         flags: null,
         schedulesHash: null,
         chatIds: new Set(),
@@ -596,9 +615,17 @@ export class AggregateRunner {
         hasConductor: false, // not used by diffEnsembleSnapshot
         flags: track.flags ?? { paused: false, held: false }, // not used; uses track.flags directly
         players: [...track.playerPhases.keys()].map((id) => ({
-          // Minimal stand-in — only `playerId` is consulted by the diff.
+          // Minimal stand-in — only `playerId` is consulted by `diffEnsembleSnapshot`
+          // for `player.removed` events (see L154-L174). The other fields are
+          // zero-cost placeholders that satisfy `PlayerSummaryV1` typing without
+          // affecting any emitted event payload. `agentType` reads from the
+          // parallel track Map so the prior carries the player's real adapter
+          // family (#535) — pre-#535 this was hardcoded `'claude' as const`,
+          // which became a type lie once the wire union expanded to mirror
+          // `AgentType`. Fallback to `'claude'` covers the brief migration
+          // window where a long-running daemon's tracks predate the new Map.
           playerId: id, ensemble: eState.ensemble, hostname: '', isConductor: false,
-          agentType: 'claude' as const, part: '', workDir: '',
+          agentType: track.playerAgentTypes.get(id) ?? 'claude', part: '', workDir: '',
           phase: track.playerPhases.get(id) as import('../types').AttachmentPhase | undefined,
         })),
         schedules: [],

--- a/src/http/event-types.ts
+++ b/src/http/event-types.ts
@@ -148,12 +148,22 @@ export interface PlayerSummaryV1 {
   hostname: string;
   isConductor: boolean;
   /**
-   * Adapter family the player runs on. `'mock'` is dev-mode-only (recruit
-   * gate rejects it in production); the wire union exposes it so dashboards
-   * can render mock-jam ensembles without coercing the actual adapter to
-   * `'claude'`. Mirrors {@link AgentType} from `src/types.ts`.
+   * Adapter family the player runs on. Mirrors {@link AgentType} from
+   * `src/types.ts` — every shipped adapter is exposed verbatim so dashboards
+   * can render the actual backend instead of coercing headless adapters into
+   * `'claude'`. `'mock'` is dev-mode-only (recruit gate rejects it in
+   * production); the headless adapters (`'claude-api'`, `'opencode'`,
+   * `'claude-code-headless'`) ship as additive `/v1/` extensions per the
+   * stability rule at §6 — adding new adapters in future versions remains
+   * non-breaking, removing one requires `/v2/`. See #535.
    */
-  agentType: 'claude' | 'copilot' | 'mock';
+  agentType:
+    | 'claude'
+    | 'copilot'
+    | 'mock'
+    | 'claude-api'
+    | 'opencode'
+    | 'claude-code-headless';
   playerType?: string;
   /** Authoritative attachment phase (post-v0.26 — see WIRE-PROTOCOL.md). */
   phase?: AttachmentPhase;

--- a/src/http/snapshot.ts
+++ b/src/http/snapshot.ts
@@ -21,11 +21,25 @@
  */
 import type { TempoClient } from '../client/interface';
 import type { MaestroPlayerInfo, AttachmentPhase } from '../types';
+import { AGENT_TYPES } from '../types';
 import {
   PR1_SENTINEL_EVENT_ID,
   type EnsembleStateV1,
   type PlayerSummaryV1,
 } from './event-types';
+
+/**
+ * Runtime type guard — `MaestroPlayerInfo.agentType` is intentionally typed
+ * as open `string` so a forked daemon advertising a never-shipped adapter
+ * (e.g. `'gemini'`) doesn't crash the projection at the type level. The
+ * guard narrows the open-string input to the closed wire union before it
+ * reaches `PlayerSummaryV1`. Anything not in `AGENT_TYPES` (the canonical
+ * source-of-truth list at `src/types.ts`) falls back to `'claude'` in the
+ * caller — same defensive default as pre-#535, just over a wider whitelist.
+ */
+function isWireAgentType(s: string): s is PlayerSummaryV1['agentType'] {
+  return (AGENT_TYPES as readonly string[]).includes(s);
+}
 
 /**
  * Maximum chat messages embedded in the snapshot. Larger paging is left
@@ -78,10 +92,14 @@ export interface PlayerWireMeta {
 
 /**
  * Project a `MaestroPlayerInfo` into the wire-stable `PlayerSummaryV1`.
- * Drops fields that aren't part of the v1 contract; coerces `agentType`
- * from the open-string MaestroPlayerInfo to the `'claude' | 'copilot'`
- * union (anything unknown defaults to `'claude'` — the v1 contract
- * doesn't expose third-party adapters yet).
+ * Drops fields that aren't part of the v1 contract; passes `agentType`
+ * through verbatim — the wire union mirrors {@link AgentType} from
+ * `src/types.ts`, so every shipped adapter projects to its own label
+ * (#535). Pre-#535 the wire union was closed at `'claude' | 'copilot' |
+ * 'mock'` and headless adapters were coerced to `'claude'`, which made
+ * them indistinguishable from interactive Claude Code players in the
+ * dashboard. The union expansion is additive per the §6 stability rule
+ * in `event-types.ts` — no `/v1/` → `/v2/` bump.
  *
  * `wireMeta` is the session-level projection from
  * `TempoClient.getPlayerWireMeta` (Issue #399 W2). Pass `null` (or omit)
@@ -98,14 +116,16 @@ export function toPlayerSummaryV1(
   p: MaestroPlayerInfo,
   wireMeta: PlayerWireMeta | null = null,
 ): PlayerSummaryV1 {
-  // `MaestroPlayerInfo.agentType` is open (string); the wire contract is
-  // closed at `'claude' | 'copilot' | 'mock'`. Unknown values default to
-  // `'claude'` so a forked daemon advertising a new adapter can't poison
-  // the wire shape consumers are typed against.
+  // `MaestroPlayerInfo.agentType` is intentionally open (`string`) so a
+  // forked daemon advertising a never-shipped adapter doesn't crash the
+  // type system here. `isWireAgentType` narrows it against `AGENT_TYPES`
+  // (the canonical source-of-truth list); anything outside falls back to
+  // `'claude'` — same defensive default as pre-#535, just enforced over
+  // a wider whitelist. The drift detector in `test/snapshot.test.ts`
+  // asserts the wire union mirrors `AgentType`, so a future shipped
+  // adapter missing from one of the two surfaces fails CI.
   const agentType: PlayerSummaryV1['agentType'] =
-    p.agentType === 'copilot' || p.agentType === 'mock'
-      ? p.agentType
-      : 'claude';
+    isWireAgentType(p.agentType) ? p.agentType : 'claude';
   return {
     playerId: p.playerId,
     ensemble: p.ensemble,

--- a/test/snapshot.test.ts
+++ b/test/snapshot.test.ts
@@ -27,13 +27,15 @@
  */
 import { expect } from 'chai';
 import type { TempoClient } from '../src/client/interface';
-import type { MaestroPlayerInfo, HostProfile } from '../src/types';
+import type { MaestroPlayerInfo, HostProfile, AgentType } from '../src/types';
+import { AGENT_TYPES } from '../src/types';
 import {
   buildEnsembleSnapshot,
   EnsembleNotFoundError,
   toPlayerSummaryV1,
   type PlayerWireMeta,
 } from '../src/http/snapshot';
+import type { PlayerSummaryV1 } from '../src/http/event-types';
 
 // ────────────────────────────────────────────────────────────────────────
 // toPlayerSummaryV1 projection
@@ -118,16 +120,67 @@ describe('toPlayerSummaryV1 projection (#399 W2 + Q5.6)', function () {
     expect(out.agentType).to.equal('copilot');
   });
 
-  it('coerces unknown agentType to claude per v1 contract', function () {
-    // The wire union is closed at `'claude' | 'copilot' | 'mock'`. Anything
-    // outside that set (e.g. a future `'gemini'` recruited from a forked
-    // build connecting to this snapshot) defaults to `'claude'` so the
-    // dashboard never sees a value the consumer isn't typed to handle.
+  // #535 — pre-fix the projection coerced any non-{claude,copilot,mock}
+  // value to `'claude'`, making the three headless adapters indistinguishable
+  // from interactive Claude Code players in the dashboard. Post-fix the wire
+  // union mirrors `AgentType` and the projection passes the value verbatim.
+  it('preserves agentType="claude-api" through the projection (#535)', function () {
+    const out = toPlayerSummaryV1({ ...baseInfo, agentType: 'claude-api' });
+    expect(out.agentType).to.equal('claude-api');
+  });
+
+  it('preserves agentType="opencode" through the projection (#535)', function () {
+    const out = toPlayerSummaryV1({ ...baseInfo, agentType: 'opencode' });
+    expect(out.agentType).to.equal('opencode');
+  });
+
+  it('preserves agentType="claude-code-headless" through the projection (#535)', function () {
+    const out = toPlayerSummaryV1({ ...baseInfo, agentType: 'claude-code-headless' });
+    expect(out.agentType).to.equal('claude-code-headless');
+  });
+
+  it('falls back to "claude" for forked-daemon unknown agentType (defensive)', function () {
+    // `MaestroPlayerInfo.agentType` is intentionally typed as open `string`
+    // — a forked daemon advertising a never-shipped adapter (e.g.
+    // `'gemini'` from a downstream consumer) shouldn't poison the wire
+    // shape consumers are typed against. The projection narrows via
+    // `AGENT_TYPES`; anything outside that whitelist falls back to
+    // `'claude'`. Pre-#535 the same default existed but the whitelist
+    // was just `['claude','copilot','mock']`; post-#535 it's the full
+    // `AgentType`.
     const out = toPlayerSummaryV1({
       ...baseInfo,
-      agentType: 'gemini' as unknown as MaestroPlayerInfo['agentType'],
+      agentType: 'gemini' as MaestroPlayerInfo['agentType'],
     });
     expect(out.agentType).to.equal('claude');
+  });
+
+  // #535 — type-level + runtime drift detector. Asserts the wire union
+  // covers every shipped `AgentType`. If a future adapter is added to
+  // `AGENT_TYPES` in `src/types.ts` but not to `PlayerSummaryV1.agentType`,
+  // either the compile fails (the `_AgentTypeIsSubsetOfWire` static check)
+  // or the runtime loop trips. Closes the gap that #535 surfaced — a new
+  // adapter shipping with no corresponding wire-union extension would
+  // silently coerce to `'claude'` again under the old projection.
+  it('every shipped AgentType is exposable on the wire (drift detector)', function () {
+    type _AgentTypeIsSubsetOfWire = AgentType extends PlayerSummaryV1['agentType']
+      ? true
+      : never;
+    // Compile-time witness — `true` is only assignable when the conditional
+    // resolves to `true` (i.e. AgentType ⊆ PlayerSummaryV1['agentType']).
+    // If a future adapter slips into AgentType without a wire-union update,
+    // this line will fail to type-check.
+    const _check: _AgentTypeIsSubsetOfWire = true;
+    void _check;
+
+    // Runtime check — exercises the projection for every entry in the
+    // canonical list, asserts pass-through. If the union is widened but
+    // the projection regresses to coercion, this catches it at test time
+    // instead of in production dashboards.
+    for (const t of AGENT_TYPES) {
+      const out = toPlayerSummaryV1({ ...baseInfo, agentType: t });
+      expect(out.agentType, `passthrough for AgentType="${t}"`).to.equal(t);
+    }
   });
 });
 

--- a/tests/http/aggregate.test.ts
+++ b/tests/http/aggregate.test.ts
@@ -110,6 +110,11 @@ describe('diffHostProfiles', () => {
 describe('diffEnsembleSnapshot', () => {
   const baseTrack = () => ({
     playerPhases: new Map<string, string | undefined>(),
+    // #535 — parallel agentType Map. Set on `player.added`, deleted on
+    // `player.removed`, consumed by the prior reconstruction in
+    // `tick()` so the prior carries the player's real adapter family
+    // instead of a hardcoded `'claude'` stand-in.
+    playerAgentTypes: new Map<string, 'claude' | 'copilot' | 'mock' | 'claude-api' | 'opencode' | 'claude-code-headless'>(),
     flags: null as { paused: boolean; held: boolean } | null,
     schedulesHash: null as string | null,
     chatIds: new Set<string>(),
@@ -177,6 +182,36 @@ describe('diffEnsembleSnapshot', () => {
     expect(removed).toBeDefined();
     expect((removed!.payload as { playerId: string }).playerId).toBe('gone-one');
     expect(track.playerPhases.has('gone-one')).toBe(false);
+  });
+
+  // #535 — track.playerAgentTypes is set in lockstep with playerPhases on
+  // `player.added` and cleared on `player.removed`. The prior
+  // reconstruction inside `AggregateRunner.tick()` reads from this Map so
+  // every player carries its real adapter family — pre-#535 the prior
+  // hardcoded `'claude'`, which became a type lie once the wire union
+  // expanded. The headless-adapter case is the regression we're guarding.
+  it('records and clears playerAgentTypes for headless adapters (#535)', () => {
+    const track = baseTrack();
+    const next: AggregateEnsembleSnapshot = {
+      ensemble: 'demo', hasConductor: true,
+      flags: { paused: false, held: false },
+      players: [
+        { playerId: 'scribe', ensemble: 'demo', hostname: 'h', isConductor: false, agentType: 'claude-code-headless', part: '', workDir: '', phase: 'attached' },
+        { playerId: 'researcher', ensemble: 'demo', hostname: 'h', isConductor: false, agentType: 'opencode', part: '', workDir: '', phase: 'attached' },
+        { playerId: 'echo', ensemble: 'demo', hostname: 'h', isConductor: false, agentType: 'claude-api', part: '', workDir: '', phase: 'attached' },
+      ],
+      schedules: [], chat: [],
+    };
+    diffEnsembleSnapshot(null, next, track, at);
+    expect(track.playerAgentTypes.get('scribe')).toBe('claude-code-headless');
+    expect(track.playerAgentTypes.get('researcher')).toBe('opencode');
+    expect(track.playerAgentTypes.get('echo')).toBe('claude-api');
+
+    // After all three drop, the Map should be empty in lockstep with playerPhases.
+    const empty: AggregateEnsembleSnapshot = { ...next, players: [] };
+    diffEnsembleSnapshot(next, empty, track, at);
+    expect(track.playerAgentTypes.size).toBe(0);
+    expect(track.playerPhases.size).toBe(0);
   });
 
   it('does NOT re-emit flags / schedules when unchanged across polls', () => {


### PR DESCRIPTION
## Summary

Closes #535.

The HTTP/SSE wire contract (`/v1/state/:ensemble`, SSE event payloads) coerced every adapter that wasn't `'claude' | 'copilot' | 'mock'` into `agentType: 'claude'`. Headless adapters shipped after the v1 contract froze — `claude-api` (#131), `opencode` (#449), `claude-code-headless` (#520) — all rendered in the dashboard as indistinguishable from interactive Claude Code sessions. Wire-protocol gap, not a hide-bug: players were present in the snapshot, just mislabeled.

## Three coercion sites fixed

1. **`src/http/event-types.ts`** — `PlayerSummaryV1.agentType` union expanded from `'claude' | 'copilot' | 'mock'` to mirror `AgentType` in `src/types.ts`. Adds `'claude-api'`, `'opencode'`, `'claude-code-headless'`. Additive extension per the §6 stability rule in the same file ("New event types ship as additive `/v1/` additions; removals require `/v2/`"). **No `/v1/` → `/v2/` path bump.**

2. **`src/http/snapshot.ts`** — `toPlayerSummaryV1` no longer hardcodes the pre-#535 narrow whitelist. Replaced with an `isWireAgentType` type guard that narrows the open-string `MaestroPlayerInfo.agentType` against the canonical `AGENT_TYPES` list. Forked-daemon defensiveness preserved: anything outside the list still falls back to `'claude'`, just over a wider (and more honest) whitelist.

3. **`src/http/aggregate.ts`** — removed the `agentType: 'claude' as const` hardcode in the per-tick prior-snapshot reconstruction (`AggregateRunner.tick`). `EnsembleTrack` gained a parallel `playerAgentTypes` Map keyed by `playerId`, set in lockstep with `playerPhases` on `player.added` and cleared on `player.removed`. Prior reconstruction reads the real adapter family from the track instead of a misleading stand-in literal.

## Tests

- **`test/snapshot.test.ts`** — dropped the obsolete "coerces unknown agentType to claude per v1 contract" assertion. Added pass-through tests for each new adapter type, kept the forked-daemon defensive fallback test (with `'gemini'` as the unknown), and added a drift-detector test that combines a compile-time witness (`AgentType extends PlayerSummaryV1['agentType']`) with a runtime loop over `AGENT_TYPES`. If a future shipped adapter slips into one surface but not the other, this fails CI before it ships.

- **`tests/http/aggregate.test.ts`** — extended `baseTrack()` with the new `playerAgentTypes: new Map()` field. Added a regression test asserting headless players (`scribe`/`claude-code-headless`, `researcher`/`opencode`, `echo`/`claude-api`) populate the Map on add and clear it on remove — the canonical scenario from #535's repro section.

## Docs

- **`docs/SSE-PROTOCOL.md`** — updated the `PlayerSummaryV1.agentType` listing in the §4 type-reference block.
- **`docs/WIRE-PROTOCOL.md`** — updated the `agentType` row of the `MaestroPlayerInfo` table.
- **`CHANGELOG.md`** — Unreleased entry under `### Changed` documenting the wire-union expansion and the lockstep `playerAgentTypes` Map.

## Out of scope (deferred)

- **Dashboard frontend rendering** of the new adapter labels — composer deliberately deferred to #537. `RosterItem.tsx` already renders `{player.agentType}` verbatim, so this PR unblocks the chip-styling polish without touching any frontend code.
- **Write-side recruit allowlists** in `src/http/body.ts` — `ALLOWED_AGENTS_PROD` / `ALLOWED_AGENTS_DEV` still only permit `claude` / `copilot` (and `mock` in dev mode) on the HTTP recruit gate. Headless adapters are recruitable via the MCP `recruit` tool and lineup loading; the HTTP write gate is a separate consideration.

## Verification

```
$ tsc --noEmit -p tsconfig.json
# clean for all touched files (4 pre-existing pnpm-resolution errors
# in src/cli/startup.ts / src/daemon.ts / src/utils/hosts.ts are unrelated)

$ mocha dist-test/test/snapshot.test.js
  toPlayerSummaryV1 projection (#399 W2 + Q5.6)
    ✔ preserves agentType="claude-api" through the projection (#535)
    ✔ preserves agentType="opencode" through the projection (#535)
    ✔ preserves agentType="claude-code-headless" through the projection (#535)
    ✔ falls back to "claude" for forked-daemon unknown agentType (defensive)
    ✔ every shipped AgentType is exposable on the wire (drift detector)
    … (and 13 pre-existing assertions)
  18 passing
```

Vitest binary is missing from this dev box's `node_modules` (pre-existing — flagged in the #533 audit); `tests/http/aggregate.test.ts` validation falls to CI's `npm test` matrix (Node 20 / 22 / 24).

## Test plan

- [x] Type-check passes (`tsc --noEmit -p tsconfig.json` clean for all touched files).
- [x] Mocha snapshot suite green — 18/18 including the five new #535 tests.
- [ ] CI vitest matrix green for `tests/http/aggregate.test.ts` (validates the new `playerAgentTypes` lockstep regression test).
- [ ] CI mocha matrix green across Node 20 / 22 / 24.
- [ ] Manual repro from issue body: recruit a `claude-code-headless` player, observe the dashboard label correctly stamped (instead of the pre-fix `'claude'` coercion).

## Acceptance criteria (from #535)

- [x] `PlayerSummaryV1.agentType` union expanded to include `claude-api`, `opencode`, `claude-code-headless`.
- [x] `snapshot.ts:101-108` no longer coerces — passes through `p.agentType` (via the `isWireAgentType` narrowing), with unit tests asserting `claude-code-headless` projects to `agentType: 'claude-code-headless'`.
- [x] `aggregate.ts:601` hardcode removed; reconstructed prior carries the real adapter type via `track.playerAgentTypes`.
- [x] Wire-protocol drift detector — added in `test/snapshot.test.ts` (the SSE-side detector at `test/sse/wire-protocol.test.ts` referenced in the issue body doesn't exist in the tree; the new combined compile-time + runtime check in `snapshot.test.ts` provides the same guarantee for the `agentType` surface specifically).
- [ ] Manual repro — left for the polish soloist or maestro to confirm in the dashboard.
- [x] No `/v1/` → `/v2/` path bump — confirmed additive only.

## File pointers

| File | Change |
|---|---|
| `src/http/event-types.ts` | Wire union expanded to mirror `AgentType` |
| `src/http/snapshot.ts` | `isWireAgentType` type guard; coercion dropped |
| `src/http/aggregate.ts` | `playerAgentTypes` Map added to `EnsembleTrack`; hardcode removed |
| `test/snapshot.test.ts` | New pass-through tests + drift detector |
| `tests/http/aggregate.test.ts` | `baseTrack()` extended; lockstep regression test |
| `docs/SSE-PROTOCOL.md` | Wire union updated |
| `docs/WIRE-PROTOCOL.md` | `MaestroPlayerInfo` table updated |
| `CHANGELOG.md` | Unreleased entry |

---

> _Authored via the tempo-impl ensemble (composer designed the impl approach; lead implemented; tuner queued for QA; conductor coordinated). PR opened under maintainer identity because GitHub App credentials weren't provisioned at PR-open time._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
