### PR TITLE
feat: headless adapter dashboard polish (#537)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Dashboard: muted adapter-badge chip now renders for headless players (copilot, claude-code-headless, opencode, claude-api, mock) when no explicit type is set, making them visually distinguishable from interactive Claude Code sessions (#537)
+
 ### Changed
 
+- Default session part for headless adapters now reads "Headless \<adapter\> session" instead of the generic "Session in \<repo\>" — explicit `set_part` calls still override (#537)
 - **Wire protocol: `PlayerSummaryV1.agentType` union expanded** to mirror
   `AgentType` in `src/types.ts` — adds `'claude-api'`, `'opencode'`, and
   `'claude-code-headless'` alongside the existing `'claude'`, `'copilot'`,

--- a/dashboard/src/components/RosterItem.tsx
+++ b/dashboard/src/components/RosterItem.tsx
@@ -34,6 +34,10 @@ interface RosterItemProps {
 export function RosterItem({ player, selected = false, onSelect }: RosterItemProps) {
   const cls = 'roster-item' + (selected ? ' is-active' : '');
   const part = player.part?.trim();
+  // Issue #537 — when no playerType is set but agentType is a
+  // non-default value (i.e. not the coerced 'claude'), render a
+  // muted fallback chip so headless adapters are visually identified.
+  const showFallbackChip = !player.playerType && player.agentType && player.agentType !== 'claude';
   return (
     <button
       type="button"
@@ -91,6 +95,24 @@ export function RosterItem({ player, selected = false, onSelect }: RosterItemPro
         </span>
         <span className="rp">
           {player.playerType && <TypeBadge type={player.playerType} />}
+          {showFallbackChip && (
+            <span
+              data-testid={`adapter-badge-${player.agentType}`}
+              style={{
+                display: 'inline-block',
+                padding: '1px 6px',
+                fontFamily: 'var(--ff-mono)',
+                fontSize: 11,
+                letterSpacing: '0.02em',
+                borderRadius: 4,
+                color: 'var(--muted)',
+                border: '1px solid var(--rule)',
+                background: 'transparent',
+              }}
+            >
+              {player.agentType}
+            </span>
+          )}
           {part && <span style={{ marginLeft: 6 }}>{part}</span>}
         </span>
       </span>

--- a/dashboard/src/components/RosterItem.tsx
+++ b/dashboard/src/components/RosterItem.tsx
@@ -37,7 +37,7 @@ export function RosterItem({ player, selected = false, onSelect }: RosterItemPro
   // Issue #537 — when no playerType is set but agentType is a
   // non-default value (i.e. not the coerced 'claude'), render a
   // muted fallback chip so headless adapters are visually identified.
-  const showFallbackChip = !player.playerType && player.agentType && player.agentType !== 'claude';
+  const showFallbackChip = !player.playerType && player.agentType !== 'claude';
   return (
     <button
       type="button"

--- a/dashboard/tests/roster-item.test.tsx
+++ b/dashboard/tests/roster-item.test.tsx
@@ -1,0 +1,87 @@
+/**
+ * RosterItem — fallback adapter-type chip tests (#537).
+ *
+ * Verifies that:
+ *   - A typed player renders a TypeBadge (existing behaviour).
+ *   - An untyped player with a non-default agentType renders a muted
+ *     adapter-badge fallback chip.
+ *   - An untyped player with the default 'claude' agentType renders
+ *     no chip at all (avoids noise on the pre-#535 wire).
+ *   - When both playerType and a non-default agentType are set, only
+ *     the TypeBadge renders (no double-chip).
+ */
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { RosterItem } from '../src/components/RosterItem';
+import { makePlayer } from './fixtures/factories';
+
+describe('RosterItem fallback chip (#537)', () => {
+  it('renders TypeBadge when playerType is set', () => {
+    render(
+      <RosterItem
+        player={makePlayer({ playerId: 'eng', playerType: 'tempo-soloist', agentType: 'claude' })}
+      />,
+    );
+    expect(screen.getByTestId('type-badge-tempo-soloist')).toBeInTheDocument();
+    expect(screen.queryByTestId(/^adapter-badge-/)).not.toBeInTheDocument();
+  });
+
+  it('renders muted adapter-badge when playerType is absent and agentType is non-default', () => {
+    render(
+      <RosterItem
+        player={makePlayer({
+          playerId: 'scribe',
+          playerType: undefined,
+          agentType: 'copilot' as any,
+        })}
+      />,
+    );
+    expect(screen.queryByTestId(/^type-badge-/)).not.toBeInTheDocument();
+    const chip = screen.getByTestId('adapter-badge-copilot');
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toBe('copilot');
+  });
+
+  it('renders no chip when playerType is absent and agentType is "claude"', () => {
+    render(
+      <RosterItem
+        player={makePlayer({
+          playerId: 'scribe',
+          playerType: undefined,
+          agentType: 'claude',
+        })}
+      />,
+    );
+    expect(screen.queryByTestId(/^type-badge-/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId(/^adapter-badge-/)).not.toBeInTheDocument();
+  });
+
+  it('renders only TypeBadge when both playerType and non-default agentType are set', () => {
+    render(
+      <RosterItem
+        player={makePlayer({
+          playerId: 'eng',
+          playerType: 'tempo-soloist',
+          agentType: 'copilot' as any,
+        })}
+      />,
+    );
+    expect(screen.getByTestId('type-badge-tempo-soloist')).toBeInTheDocument();
+    expect(screen.queryByTestId(/^adapter-badge-/)).not.toBeInTheDocument();
+  });
+
+  it('renders adapter-badge for mock agentType (dev mode)', () => {
+    render(
+      <RosterItem
+        player={makePlayer({
+          playerId: 'mock-player',
+          playerType: undefined,
+          agentType: 'mock',
+        })}
+      />,
+    );
+    const chip = screen.getByTestId('adapter-badge-mock');
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toBe('mock');
+  });
+});

--- a/dashboard/tests/roster-item.test.tsx
+++ b/dashboard/tests/roster-item.test.tsx
@@ -92,8 +92,7 @@ describe('RosterItem fallback chip (#537)', () => {
         player={makePlayer({
           playerId: 'oc-player',
           playerType: undefined,
-          // Post-#535 wire value; pre-#535 this would be coerced to 'claude'
-          agentType: 'opencode' as any,
+          agentType: 'opencode',
         })}
       />,
     );
@@ -109,7 +108,7 @@ describe('RosterItem fallback chip (#537)', () => {
         player={makePlayer({
           playerId: 'headless-player',
           playerType: undefined,
-          agentType: 'claude-code-headless' as any,
+          agentType: 'claude-code-headless',
         })}
       />,
     );

--- a/dashboard/tests/roster-item.test.tsx
+++ b/dashboard/tests/roster-item.test.tsx
@@ -26,13 +26,13 @@ describe('RosterItem fallback chip (#537)', () => {
     expect(screen.queryByTestId(/^adapter-badge-/)).not.toBeInTheDocument();
   });
 
-  it('renders muted adapter-badge when playerType is absent and agentType is non-default', () => {
+  it('renders muted adapter-badge when playerType is absent and agentType is copilot', () => {
     render(
       <RosterItem
         player={makePlayer({
           playerId: 'scribe',
           playerType: undefined,
-          agentType: 'copilot' as any,
+          agentType: 'copilot',
         })}
       />,
     );
@@ -62,7 +62,7 @@ describe('RosterItem fallback chip (#537)', () => {
         player={makePlayer({
           playerId: 'eng',
           playerType: 'tempo-soloist',
-          agentType: 'copilot' as any,
+          agentType: 'copilot',
         })}
       />,
     );
@@ -83,5 +83,38 @@ describe('RosterItem fallback chip (#537)', () => {
     const chip = screen.getByTestId('adapter-badge-mock');
     expect(chip).toBeInTheDocument();
     expect(chip.textContent).toBe('mock');
+  });
+
+  it('renders adapter-badge for opencode agentType', () => {
+    // Post-#535 wire will carry real adapter types — verify opencode renders
+    render(
+      <RosterItem
+        player={makePlayer({
+          playerId: 'oc-player',
+          playerType: undefined,
+          // Post-#535 wire value; pre-#535 this would be coerced to 'claude'
+          agentType: 'opencode' as any,
+        })}
+      />,
+    );
+    const chip = screen.getByTestId('adapter-badge-opencode');
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toBe('opencode');
+  });
+
+  it('renders adapter-badge for claude-code-headless agentType', () => {
+    // Post-#535 wire value — the motivating case from the issue screenshot
+    render(
+      <RosterItem
+        player={makePlayer({
+          playerId: 'headless-player',
+          playerType: undefined,
+          agentType: 'claude-code-headless' as any,
+        })}
+      />,
+    );
+    const chip = screen.getByTestId('adapter-badge-claude-code-headless');
+    expect(chip).toBeInTheDocument();
+    expect(chip.textContent).toBe('claude-code-headless');
   });
 });

--- a/src/activities/outbox.ts
+++ b/src/activities/outbox.ts
@@ -443,6 +443,7 @@ export function createOutboxActivities(client: Client, config: Config): OutboxAc
             playerType: agentDefinition,
             isConductor,
             workDir,
+            adapterType: agent,
           }),
           disableStaleDetection: true,
           // When held: store the initial message for delivery on release, inject standby message instead

--- a/src/cli/commands.ts
+++ b/src/cli/commands.ts
@@ -155,6 +155,7 @@ async function seedConductorWorkflow(args: {
       playerType: resolvedConductorType?.name,
       isConductor: true,
       workDir: process.cwd(),
+      adapterType: args.conductorAgent,
     }),
     disableStaleDetection: true,
     temporalConfig: {
@@ -253,6 +254,7 @@ async function applyLineupPlayersAndSchedules(args: {
         playerType: resolvedPlayerType?.name,
         isConductor: false,
         workDir: resolve(playerWorkDir),
+        adapterType: playerAgent,
       }),
       disableStaleDetection: true,
       temporalConfig: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -121,7 +121,7 @@ async function main() {
     // `'Session in <basename>'` otherwise. Routed through the helper so
     // any future server-side player-type discovery picks up the typed
     // default automatically.
-    autoSummary: defaultPart({ isConductor, workDir }),
+    autoSummary: defaultPart({ isConductor, workDir, adapterType: isBridgeMode ? 'copilot' : 'claude' }),
     temporalConfig: {
       temporalAddress: config.temporalAddress,
       temporalNamespace: config.temporalNamespace,

--- a/src/utils/default-part.ts
+++ b/src/utils/default-part.ts
@@ -36,7 +36,7 @@ const ROLE_ABBREVIATIONS: Record<string, string> = {
  *
  * Issue #537.
  */
-const HEADLESS_ADAPTERS = new Set([
+export const HEADLESS_ADAPTERS = new Set([
   'claude-code-headless',
   'copilot',
   'opencode',

--- a/src/utils/default-part.ts
+++ b/src/utils/default-part.ts
@@ -29,6 +29,22 @@ const ROLE_ABBREVIATIONS: Record<string, string> = {
 };
 
 /**
+ * Adapter types that are considered "headless" — i.e. they run without
+ * an interactive terminal. When a session has no explicit `part` and no
+ * player type, a headless adapter gets `'Headless <adapter> session'`
+ * instead of the generic `'Session in <basename>'`.
+ *
+ * Issue #537.
+ */
+const HEADLESS_ADAPTERS = new Set([
+  'claude-code-headless',
+  'copilot',
+  'opencode',
+  'claude-api',
+  'mock',
+]);
+
+/**
  * Compute the default `part` text seeded into a fresh session workflow.
  *
  * Issue #450 — replaces the hardcoded `'Conductor session'` literal
@@ -51,13 +67,16 @@ const ROLE_ABBREVIATIONS: Record<string, string> = {
  *   2. Else if `isConductor`, return `'Conductor session'` (the
  *      pre-#450 conductor literal — kept so untyped conductor sessions
  *      still read correctly).
- *   3. Else fall back to `'Session in <basename(workDir)>'`, or
+ *   3. Else if the adapter is headless (#537), return
+ *      `'Headless <adapterType> session'`.
+ *   4. Else fall back to `'Session in <basename(workDir)>'`, or
  *      `'New session'` when no `workDir` is provided.
  */
 export function defaultPart(opts: {
   playerType?: string;
   isConductor?: boolean;
   workDir?: string;
+  adapterType?: string;
 }): string {
   const playerType = opts.playerType?.trim();
   if (playerType) {
@@ -73,6 +92,12 @@ export function defaultPart(opts: {
   }
   if (opts.isConductor) {
     return 'Conductor session';
+  }
+  // Issue #537 — headless adapters get a descriptive default when
+  // neither playerType nor isConductor identify the session.
+  const adapterType = opts.adapterType?.trim();
+  if (adapterType && HEADLESS_ADAPTERS.has(adapterType)) {
+    return `Headless ${adapterType} session`;
   }
   if (opts.workDir && opts.workDir.trim()) {
     return `Session in ${path.basename(opts.workDir)}`;

--- a/tests/utils/default-part.test.ts
+++ b/tests/utils/default-part.test.ts
@@ -8,7 +8,8 @@
  * `src/server.ts`).
  */
 import { describe, it, expect } from 'vitest';
-import { defaultPart } from '../../src/utils/default-part';
+import { defaultPart, HEADLESS_ADAPTERS } from '../../src/utils/default-part';
+import { AGENT_TYPES } from '../../src/types';
 
 describe('defaultPart', () => {
   describe('player-type-aware defaults', () => {
@@ -168,6 +169,32 @@ describe('defaultPart', () => {
       expect(defaultPart({ adapterType: '  opencode  ' })).toBe(
         'Headless opencode session',
       );
+    });
+  });
+
+  describe('HEADLESS_ADAPTERS drift detector (#537)', () => {
+    it('every non-claude member of AGENT_TYPES is in HEADLESS_ADAPTERS', () => {
+      // If a future adapter is added to AGENT_TYPES but not categorised
+      // here, this test fails loudly. If the new adapter is intentionally
+      // interactive (like 'claude'), add it to the opt-out list below.
+      const INTERACTIVE_OPT_OUT = new Set(['claude']);
+      for (const t of AGENT_TYPES) {
+        if (INTERACTIVE_OPT_OUT.has(t)) continue;
+        expect(
+          HEADLESS_ADAPTERS.has(t),
+          `AGENT_TYPES member '${t}' is not in HEADLESS_ADAPTERS — ` +
+          `add it there or to INTERACTIVE_OPT_OUT if intentionally interactive`,
+        ).toBe(true);
+      }
+    });
+
+    it('HEADLESS_ADAPTERS contains only known AGENT_TYPES members', () => {
+      for (const h of HEADLESS_ADAPTERS) {
+        expect(
+          (AGENT_TYPES as readonly string[]).includes(h),
+          `HEADLESS_ADAPTERS member '${h}' is not in AGENT_TYPES`,
+        ).toBe(true);
+      }
     });
   });
 });

--- a/tests/utils/default-part.test.ts
+++ b/tests/utils/default-part.test.ts
@@ -110,4 +110,64 @@ describe('defaultPart', () => {
       );
     });
   });
+
+  describe('headless-adapter defaults (#537)', () => {
+    it('returns headless default for claude-code-headless adapter', () => {
+      expect(defaultPart({ adapterType: 'claude-code-headless', workDir: '/work' })).toBe(
+        'Headless claude-code-headless session',
+      );
+    });
+
+    it('returns headless default for copilot adapter', () => {
+      expect(defaultPart({ adapterType: 'copilot', workDir: '/work' })).toBe(
+        'Headless copilot session',
+      );
+    });
+
+    it('returns headless default for opencode adapter', () => {
+      expect(defaultPart({ adapterType: 'opencode' })).toBe(
+        'Headless opencode session',
+      );
+    });
+
+    it('returns headless default for claude-api adapter', () => {
+      expect(defaultPart({ adapterType: 'claude-api' })).toBe(
+        'Headless claude-api session',
+      );
+    });
+
+    it('returns headless default for mock adapter', () => {
+      expect(defaultPart({ adapterType: 'mock' })).toBe(
+        'Headless mock session',
+      );
+    });
+
+    it('interactive claude adapter falls through to workDir default', () => {
+      expect(defaultPart({ adapterType: 'claude', workDir: '/repos/my-project' })).toBe(
+        'Session in my-project',
+      );
+    });
+
+    it('interactive claude adapter with no workDir falls through to New session', () => {
+      expect(defaultPart({ adapterType: 'claude' })).toBe('New session');
+    });
+
+    it('playerType takes priority over headless adapter default', () => {
+      expect(
+        defaultPart({ playerType: 'tempo-soloist', adapterType: 'claude-code-headless' }),
+      ).toBe('Soloist session');
+    });
+
+    it('isConductor takes priority over headless adapter default', () => {
+      expect(
+        defaultPart({ isConductor: true, adapterType: 'copilot' }),
+      ).toBe('Conductor session');
+    });
+
+    it('is whitespace-tolerant on adapterType', () => {
+      expect(defaultPart({ adapterType: '  opencode  ' })).toBe(
+        'Headless opencode session',
+      );
+    });
+  });
 });


### PR DESCRIPTION
Closes #537

## Summary

**Sub-A — Frontend (RosterItem fallback chip):**
When a player has no playerType but has a non-default gentType (anything other than 'claude'), a muted adapter-badge chip now renders in the roster row. This surfaces headless adapter types like copilot, claude-code-headless, opencode, and mock so they're visually identifiable in the dashboard.

- Uses ar(--muted) text + ar(--rule) border + transparent background — consistent with the existing muted/inactive token palette
- data-testid="adapter-badge-{agentType}" for test targeting
- Pre-#535 wire (everything coerced to 'claude') renders no chip (same as before)
- Post-#535 wire (real adapter types) renders the fallback chip for untyped headless players

**Sub-B — Backend (default part for headless adapters):**
defaultPart() gains an dapterType slot. When neither playerType nor isConductor identify the session and the adapter is headless (claude-code-headless, copilot, opencode, claude-api, mock), the default part reads 'Headless <adapter> session' instead of the generic 'Session in <basename>'.

- New HEADLESS_ADAPTERS set in src/utils/default-part.ts
- Resolution order updated: playerType → isConductor → headless adapter → workDir → 'New session'
- Threaded through all four call sites: outbox recruit, CLI conductor, CLI lineup player, server self-bootstrap

**Tests:**
- 9 new vitest cases for defaultPart headless-adapter branch (each adapter type, priority over workDir, priority under playerType/isConductor, whitespace tolerance)
- 5 new vitest cases for RosterItem fallback chip (typed player → TypeBadge only, untyped + non-default agentType → adapter-badge, untyped + 'claude' → no chip, both set → TypeBadge only, mock agentType)

## Files changed
- src/utils/default-part.ts — added HEADLESS_ADAPTERS set and dapterType opt
- src/activities/outbox.ts — threaded dapterType: agent to defaultPart()
- src/cli/commands.ts — threaded dapterType at conductor + lineup player call sites
- src/server.ts — threaded dapterType at self-bootstrap call site
- dashboard/src/components/RosterItem.tsx — fallback adapter-badge chip
- 	ests/utils/default-part.test.ts — 9 new headless-adapter test cases
- dashboard/tests/roster-item.test.tsx — new test file, 5 cases

> _Authored via the tempo-impl ensemble (polish [copilot adapter] + lead [scouting] + composer + tuner + conductor). PR opened under maintainer identity because GitHub App credentials weren't provisioned at PR-open time._
