### PR TITLE
fix(cli): correct migrate hint in removed-verbs to use /migrate form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- CLI: `claude-tempo migrate` removed-verb hint now points to `/migrate <player> <host>` — previously pointed to `/restart <player> --host <hostname>` which is not a valid form (the `/restart` TUI command accepts no `--host` flag), sending operators to a dead end since #288
+
 ## [0.28.0-beta.19] - 2026-05-11
 
 ### Added

--- a/src/cli/removed-verbs.ts
+++ b/src/cli/removed-verbs.ts
@@ -27,7 +27,7 @@ export const REMOVED_VERBS: Record<string, string> = {
   detach: '/shutdown (ensemble-wide) — detach is no longer a user-facing verb',
   restart: '/restart <player>',
   recruit: '/recruit <name>',
-  migrate: '/restart <player> --host <hostname>',
+  migrate: '/migrate <player> <host>',
   resume: '/play',
 };
 


### PR DESCRIPTION
## Summary

The `migrate` entry in `REMOVED_VERBS` (`src/cli/removed-verbs.ts:30`) pointed operators to `/restart <player> --host <hostname>` — a form that does not parse, since the TUI `/restart` command accepts no `--host` flag. Anyone running the legacy `claude-tempo migrate` CLI verb received a redirect hint that led to an immediate usage error in the TUI.

The correct TUI form for cross-host migration is `/migrate <player> <host>` (handler at `src/tui/commands.ts:503–535`). Fixed to match.

CHANGELOG entry added under `[Unreleased] / Fixed`.

Found by tempo-architect during #151 spec verification — no separate issue filed since fix is < 5 LoC.

## Test plan

- [ ] Run `node dist/cli.js migrate foo` — confirm error message now reads `Use the TUI: claude-tempo → /migrate <player> <host>`
- [ ] Verify `/migrate <player> <host>` in the TUI resolves correctly (existing coverage)
- [ ] CI green

---
🎼 _Posted by [claude-tempo\[bot\]](https://github.com/apps/claude-tempo) —
an AI ensemble acting on behalf of @vinceblank. For a human, mention @vinceblank directly._