### PR TITLE
fix(deps): declare @temporalio/common and @temporalio/proto as production dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,8 @@
     "@modelcontextprotocol/sdk": "~1.28.0",
     "@temporalio/activity": "~1.15.0",
     "@temporalio/client": "~1.15.0",
+    "@temporalio/common": "~1.15.0",
+    "@temporalio/proto": "~1.15.0",
     "@temporalio/worker": "~1.15.0",
     "@temporalio/workflow": "~1.15.0",
     "croner": "^10.0.1",
@@ -107,7 +109,6 @@
   },
   "devDependencies": {
     "@size-limit/preset-app": "^12.1.0",
-    "@temporalio/common": "^1.15.0",
     "@temporalio/testing": "~1.15.0",
     "@types/chai": "^4.3.20",
     "@types/mocha": "^10.0.10",


### PR DESCRIPTION
## Problem

The daemon crashes with `MODULE_NOT_FOUND: Cannot find module '@temporalio/common'` when agent-tempo is installed globally via **pnpm**.

`@temporalio/common` was in `devDependencies` and `@temporalio/proto` was undeclared, despite both being imported in production code. With npm's flat `node_modules` they resolved as transitive deps of `@temporalio/client`, but pnpm's strict isolation correctly rejects undeclared dependencies.

## Fix

Move `@temporalio/common` from `devDependencies` → `dependencies` and add `@temporalio/proto` to `dependencies`.

## Imports in production code

- `@temporalio/common`: `src/tools/unschedule.ts`, `src/workflows/session.ts`, `src/utils/query-timeout.ts`
- `@temporalio/proto`: `src/utils/hosts.ts`