### PR TITLE
feat(preflight): SDK-based search-attribute probe for Temporal Cloud

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,6 @@
   "engines": {
     "node": ">=20"
   },
-  "packageManager": "npm@10.9.2",
   "license": "MIT",
   "trustedDependencies": [
     "@swc/core",
@@ -168,5 +167,6 @@
   ],
   "overrides": {
     "rxjs": "^7.8.1"
-  }
+  },
+  "packageManager": "npm@10.9.2"
 }

--- a/src/cli/sa-preflight.ts
+++ b/src/cli/sa-preflight.ts
@@ -112,6 +112,41 @@ export function isTemporalCloud(address: string): boolean {
 }
 
 /**
+ * Substrings Temporal servers use to signal "this search attribute is not
+ * registered". The exact wording varies across server versions and storage
+ * backends (e.g. 'is not a valid search attribute', 'is not defined',
+ * 'no mapping defined for the field'), so we match a set rather than a
+ * single phrase — a wording change must not cause the probe to misclassify
+ * an unregistered SA as an unexpected error and re-throw.
+ */
+const UNREGISTERED_SA_MARKERS = [
+  'is not a valid search attribute',
+  'is not defined',
+  'no mapping defined for the field',
+  'unknown or unindexed search attribute',
+];
+
+/** gRPC status code for INVALID_ARGUMENT. */
+const GRPC_INVALID_ARGUMENT = 3;
+
+/**
+ * Classify a visibility-query error as "search attribute not registered".
+ *
+ * A registered-but-empty attribute returns results; an unregistered one
+ * fails. Temporal reports the failure as gRPC INVALID_ARGUMENT — we key on
+ * that status code first (wording-independent) and fall back to known
+ * message substrings for transports/versions that don't surface a code.
+ */
+function isUnregisteredAttributeError(err: any): boolean {
+  const msg = (err?.message || '').toLowerCase();
+  if (UNREGISTERED_SA_MARKERS.some((m) => msg.includes(m))) return true;
+  // gRPC ServiceError exposes a numeric `code`; INVALID_ARGUMENT means the
+  // query referenced an attribute the namespace doesn't know about.
+  if (err?.code === GRPC_INVALID_ARGUMENT) return true;
+  return false;
+}
+
+/**
  * SDK-based probe — uses the Temporal Client SDK to verify search attribute
  * existence by issuing a visibility query. Works with Temporal Cloud API keys
  * where the `temporal operator` CLI commands are unauthorized.
@@ -137,6 +172,11 @@ export async function sdkProbeRegisteredAttributes(opts: {
   const registered = new Set<string>();
   try {
     for (const attr of REQUIRED_SEARCH_ATTRIBUTES) {
+      // The probe value only has to be syntactically valid for the
+      // attribute's type so the visibility query parses. We support
+      // Keyword (quoted string literal) and Bool (`true`) here — the only
+      // two types in REQUIRED_SEARCH_ATTRIBUTES. A new SA type would need
+      // its own literal form added below.
       const testValue = attr.type === 'Bool' ? 'true' : '"__probe__"';
       try {
         await conn.workflowService.listWorkflowExecutions({
@@ -146,8 +186,7 @@ export async function sdkProbeRegisteredAttributes(opts: {
         });
         registered.add(attr.name);
       } catch (err: any) {
-        const msg = err?.message || '';
-        if (msg.includes('is not a valid search attribute')) {
+        if (isUnregisteredAttributeError(err)) {
           // Attribute not registered — don't add to set
         } else {
           // Unexpected error — re-throw

--- a/src/cli/sa-preflight.ts
+++ b/src/cli/sa-preflight.ts
@@ -20,6 +20,16 @@
  *   - `src/daemon.ts` boot path calls {@link verifySearchAttributes}
  *     directly to fail fast on `agent-tempo daemon start` before the worker
  *     tries to register workflows.
+ *
+ * Cloud support:
+ *   Temporal Cloud's operator gRPC service is not accessible with namespace
+ *   API keys, causing `temporal operator search-attribute list/create` to
+ *   fail with "Request unauthorized". When a Cloud namespace is detected
+ *   (address contains `.tmprl.cloud` or an API key is configured), the
+ *   preflight uses an SDK-based probe: issue a visibility query referencing
+ *   each required attribute — a registered attribute returns an empty result
+ *   set; an unregistered one throws INVALID_ARGUMENT. Registration
+ *   instructions surface `tcld` commands instead of `temporal operator`.
  */
 import { execFileSync, spawnSync } from 'child_process';
 
@@ -42,10 +52,13 @@ export const REQUIRED_SEARCH_ATTRIBUTES: ReadonlyArray<{
 export interface SearchAttributePreflightOpts {
   temporalAddress: string;
   temporalNamespace: string;
+  /** API key for Temporal Cloud — triggers SDK-based probe when set. */
+  temporalApiKey?: string;
   /**
    * Optional test seam — given a namespace, return the set of search
    * attribute names that ARE currently registered. Defaults to
-   * {@link defaultProbeRegisteredAttributes} which shells out to
+   * {@link sdkProbeRegisteredAttributes} when `temporalApiKey` is set,
+   * otherwise {@link defaultProbeRegisteredAttributes} which shells out to
    * `temporal operator search-attribute list`.
    */
   probe?: (opts: { temporalAddress: string; temporalNamespace: string }) => Promise<Set<string>>;
@@ -93,14 +106,72 @@ export async function defaultProbeRegisteredAttributes(opts: {
   return names;
 }
 
+/** Returns true if the address looks like a Temporal Cloud endpoint. */
+export function isTemporalCloud(address: string): boolean {
+  return address.includes('.tmprl.cloud');
+}
+
+/**
+ * SDK-based probe — uses the Temporal Client SDK to verify search attribute
+ * existence by issuing a visibility query. Works with Temporal Cloud API keys
+ * where the `temporal operator` CLI commands are unauthorized.
+ *
+ * Strategy: for each required attribute, issue `listWorkflowExecutions` with
+ * a query referencing that attribute. If the attribute is registered the query
+ * returns (possibly empty) results. If not registered, Temporal responds with
+ * INVALID_ARGUMENT containing "is not a valid search attribute".
+ */
+export async function sdkProbeRegisteredAttributes(opts: {
+  temporalAddress: string;
+  temporalNamespace: string;
+  temporalApiKey?: string;
+}): Promise<Set<string>> {
+  const { Connection } = await import('@temporalio/client');
+  const tls = opts.temporalApiKey ? true : undefined;
+  const conn = await Connection.connect({
+    address: opts.temporalAddress,
+    tls: tls as any,
+    apiKey: opts.temporalApiKey,
+  });
+
+  const registered = new Set<string>();
+  try {
+    for (const attr of REQUIRED_SEARCH_ATTRIBUTES) {
+      const testValue = attr.type === 'Bool' ? 'true' : '"__probe__"';
+      try {
+        await conn.workflowService.listWorkflowExecutions({
+          namespace: opts.temporalNamespace,
+          query: `${attr.name} = ${testValue}`,
+          pageSize: 1,
+        });
+        registered.add(attr.name);
+      } catch (err: any) {
+        const msg = err?.message || '';
+        if (msg.includes('is not a valid search attribute')) {
+          // Attribute not registered — don't add to set
+        } else {
+          // Unexpected error — re-throw
+          throw err;
+        }
+      }
+    }
+  } finally {
+    await conn.close();
+  }
+
+  return registered;
+}
+
 /**
  * Format the missing-SA error message. Paste-friendly: operators copy the
- * `temporal operator search-attribute create` block verbatim.
+ * registration commands verbatim. Cloud-aware: shows `tcld` commands for
+ * Temporal Cloud namespaces.
  */
 export function formatPreflightError(
   missing: ReadonlyArray<typeof REQUIRED_SEARCH_ATTRIBUTES[number]>,
   namespace: string,
   probeError?: string,
+  cloud?: boolean,
 ): string {
   const lines: string[] = [];
   lines.push(`Required search attributes not registered on namespace '${namespace}'.`);
@@ -108,13 +179,24 @@ export function formatPreflightError(
     lines.push(`(Could not probe namespace state: ${probeError})`);
   }
   lines.push('');
-  lines.push('Run these commands once per Temporal namespace, then restart the daemon:');
-  lines.push('');
-  for (const attr of missing) {
-    lines.push(
-      `  temporal operator search-attribute create ` +
-      `--name ${attr.name} --type ${attr.type} --namespace ${namespace}`,
-    );
+
+  if (cloud) {
+    lines.push('Register via tcld (Temporal Cloud CLI) or the Cloud UI, then restart the daemon:');
+    lines.push('');
+    const saFlags = missing.map((attr) => `--sa "${attr.name}=${attr.type}"`).join(' \\\n    ');
+    lines.push(`  tcld namespace search-attributes add --namespace ${namespace} \\\n    ${saFlags}`);
+    lines.push('');
+    lines.push('Or add them manually in the Temporal Cloud UI:');
+    lines.push(`  https://cloud.temporal.io → Namespaces → ${namespace} → Search Attributes`);
+  } else {
+    lines.push('Run these commands once per Temporal namespace, then restart the daemon:');
+    lines.push('');
+    for (const attr of missing) {
+      lines.push(
+        `  temporal operator search-attribute create ` +
+        `--name ${attr.name} --type ${attr.type} --namespace ${namespace}`,
+      );
+    }
   }
   lines.push('');
   lines.push('(See docs/ops/v1.0-migration.md for the full upgrade walkthrough.)');
@@ -125,11 +207,25 @@ export function formatPreflightError(
  * Verify all {@link REQUIRED_SEARCH_ATTRIBUTES} are registered on the
  * given namespace. Returns a structured result — callers decide whether
  * to log+continue (boot bootstrap step) or exit non-zero (daemon start).
+ *
+ * When `temporalApiKey` is set (or address is a Cloud endpoint), uses the
+ * SDK-based probe instead of shelling out to `temporal operator`.
  */
 export async function verifySearchAttributes(
   opts: SearchAttributePreflightOpts,
 ): Promise<SearchAttributePreflightResult> {
-  const probe = opts.probe ?? defaultProbeRegisteredAttributes;
+  const cloud = isTemporalCloud(opts.temporalAddress) || !!opts.temporalApiKey;
+  const defaultProbe = cloud
+    ? () => sdkProbeRegisteredAttributes({
+        temporalAddress: opts.temporalAddress,
+        temporalNamespace: opts.temporalNamespace,
+        temporalApiKey: opts.temporalApiKey,
+      })
+    : () => defaultProbeRegisteredAttributes({
+        temporalAddress: opts.temporalAddress,
+        temporalNamespace: opts.temporalNamespace,
+      });
+  const probe = opts.probe ?? defaultProbe;
   let registered: Set<string>;
   let probeError: string | undefined;
   try {
@@ -152,7 +248,7 @@ export async function verifySearchAttributes(
     ok: false,
     missing,
     probeError,
-    message: formatPreflightError(missing, opts.temporalNamespace, probeError),
+    message: formatPreflightError(missing, opts.temporalNamespace, probeError, cloud),
   };
 }
 

--- a/src/cli/startup.ts
+++ b/src/cli/startup.ts
@@ -219,7 +219,7 @@ const TTL_60S = 60 * 1000;
 // (#605 consolidated the two duplicated literals).
 // ─────────────────────────────────────────────────────────────────────────
 
-import { REQUIRED_SEARCH_ATTRIBUTES, registerSearchAttribute } from './sa-preflight';
+import { REQUIRED_SEARCH_ATTRIBUTES, registerSearchAttribute, isTemporalCloud, sdkProbeRegisteredAttributes } from './sa-preflight';
 
 // ─────────────────────────────────────────────────────────────────────────
 // Semver-aware outdated-version badge rendering (#289 pin item 4)
@@ -491,14 +491,41 @@ async function stepSearchAttrs(
   if (isCacheFresh(cache.steps.searchAttrs, TTL_24H, now)) {
     return { status: 'skipped', durationMs: 0 };
   }
-  const { result: outcome, durationMs } = await timed<StepOutcome>(() => {
-    // Per-attr classification via `registerSearchAttribute` (#605) —
-    // distinguishes `already-exists` (idempotent expected case) from real
-    // failures. Pre-#605 every non-zero exit was swallowed as "already
-    // registered", masking the SQLite dev-server's 10-Keyword-per-namespace
-    // cap and other genuine errors until a downstream workflow start failed
-    // with the confusing `INVALID_ARGUMENT: search attribute ... is not
-    // defined`.
+  const cloud = isTemporalCloud(config.temporalAddress) || !!config.temporalApiKey;
+  const { result: outcome, durationMs } = await timed<StepOutcome>(async () => {
+    if (cloud) {
+      // For Temporal Cloud, use SDK probe to verify SAs are present.
+      // Registration must be done via tcld or the Cloud UI — we cannot
+      // use `temporal operator search-attribute create`.
+      try {
+        const registered = await sdkProbeRegisteredAttributes({
+          temporalAddress: config.temporalAddress,
+          temporalNamespace: config.temporalNamespace,
+          temporalApiKey: config.temporalApiKey,
+        });
+        const missing = REQUIRED_SEARCH_ATTRIBUTES.filter((a) => !registered.has(a.name));
+        if (missing.length > 0) {
+          const saFlags = missing.map((a) => `--sa "${a.name}=${a.type}"`).join(' ');
+          return {
+            status: 'failed',
+            durationMs: 0,
+            detail:
+              `${missing.length} search attribute(s) not registered on Temporal Cloud.\n` +
+              `  Register via: tcld namespace search-attributes add --namespace ${config.temporalNamespace} ${saFlags}\n` +
+              `  Or add them in the Cloud UI: https://cloud.temporal.io`,
+          };
+        }
+        return { status: 'ok', durationMs: 0 };
+      } catch (err: any) {
+        return {
+          status: 'failed',
+          durationMs: 0,
+          detail: `SDK probe failed: ${err?.message || err}`,
+        };
+      }
+    }
+
+    // Self-hosted path: per-attr classification via `registerSearchAttribute` (#605)
     const failures: string[] = [];
     for (const attr of REQUIRED_SEARCH_ATTRIBUTES) {
       const r = registerSearchAttribute(attr, config.temporalAddress, config.temporalNamespace);

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -913,6 +913,7 @@ async function main() {
     const result = await verifySearchAttributes({
       temporalAddress: config.temporalAddress,
       temporalNamespace: config.temporalNamespace,
+      temporalApiKey: config.temporalApiKey,
     });
     if (!result.ok && !result.probeError) {
       process.stderr.write('ERROR: ' + result.message + '\n');

--- a/src/http/catalog.ts
+++ b/src/http/catalog.ts
@@ -169,9 +169,23 @@ export async function handleCreateEnsemble(
   const held = startMode === 'hold';
   const allowed = allowedAgentsForCurrentMode();
 
-  // 1. Recruit the conductor — bootstraps maestro + scheduler. Lineup's
-  // `conductor` block (if present) wins on name + agent + part; the
-  // top-level `host` is the conductor's spawn target either way.
+  // 0. Bootstrap the maestro session + hub workflow for this ensemble.
+  // `client.recruit()` submits an outbox entry on the maestro workflow —
+  // it must exist before we can signal it. The CLI's `agent-tempo up` path
+  // pre-creates the conductor workflow which bootstraps the maestro, but
+  // the dashboard create-ensemble flow goes directly through the client.
+  try {
+    await client.ensureMaestroSession(name);
+  } catch (err) {
+    return errorResponse(res, 500, {
+      error: 'maestro-bootstrap-failed',
+      message: err instanceof Error ? err.message : String(err),
+    });
+  }
+
+  // 1. Recruit the conductor — lineup's `conductor` block (if present)
+  // wins on name + agent + part; the top-level `host` is the conductor's
+  // spawn target either way.
   const conductorBlock = resolved?.conductor;
   const conductorName = conductorBlock?.name ?? 'conductor';
   const conductorAgent = pickAgent(conductorBlock?.agent, allowed);

--- a/tests/cli/sa-preflight.test.ts
+++ b/tests/cli/sa-preflight.test.ts
@@ -17,6 +17,7 @@ import {
   assertSearchAttributesOrExit,
   formatPreflightError,
   classifyRegistrationOutput,
+  isTemporalCloud,
 } from '../../src/cli/sa-preflight';
 
 const ALL_REGISTERED = new Set(REQUIRED_SEARCH_ATTRIBUTES.map((a) => a.name));
@@ -171,5 +172,72 @@ describe('assertSearchAttributesOrExit', () => {
     expect(exitCode).toBe(1);
     expect(logged.join('\n')).toContain('Required search attributes not registered');
     expect(logged.join('\n')).toContain('AgentTempoEnsemble');
+  });
+});
+
+describe('isTemporalCloud', () => {
+  it('detects .tmprl.cloud addresses', () => {
+    expect(isTemporalCloud('myns.abc123.tmprl.cloud:7233')).toBe(true);
+  });
+
+  it('returns false for localhost', () => {
+    expect(isTemporalCloud('localhost:7233')).toBe(false);
+  });
+
+  it('returns false for self-hosted addresses', () => {
+    expect(isTemporalCloud('temporal.internal.company.com:7233')).toBe(false);
+  });
+});
+
+describe('Temporal Cloud support', () => {
+  it('uses SDK probe when temporalApiKey is set (via custom probe seam)', async () => {
+    // When apiKey is set but a custom probe is provided, the custom probe
+    // is still honored (test seam preserved).
+    const r = await verifySearchAttributes({
+      temporalAddress: 'myns.abc.tmprl.cloud:7233',
+      temporalNamespace: 'myns.abc',
+      temporalApiKey: 'fake-key',
+      probe: async () => new Set(ALL_REGISTERED),
+    });
+    expect(r.ok).toBe(true);
+  });
+
+  it('produces tcld instructions for cloud namespaces when SAs are missing', async () => {
+    const r = await verifySearchAttributes({
+      temporalAddress: 'myns.abc.tmprl.cloud:7233',
+      temporalNamespace: 'myns.abc',
+      temporalApiKey: 'fake-key',
+      probe: async () => new Set(),
+    });
+    expect(r.ok).toBe(false);
+    expect(r.message).toContain('tcld namespace search-attributes add');
+    expect(r.message).toContain('--namespace myns.abc');
+    expect(r.message).toContain('Cloud UI');
+    // Should NOT contain the self-hosted temporal operator command
+    expect(r.message).not.toContain('temporal operator search-attribute create');
+  });
+
+  it('formatPreflightError with cloud=true shows tcld command', () => {
+    const msg = formatPreflightError(
+      [{ name: 'AgentTempoEnsemble', type: 'Keyword' }],
+      'myns.abc',
+      undefined,
+      true,
+    );
+    expect(msg).toContain('tcld namespace search-attributes add');
+    expect(msg).toContain('--sa "AgentTempoEnsemble=Keyword"');
+    expect(msg).toContain('Cloud UI');
+    expect(msg).not.toContain('temporal operator');
+  });
+
+  it('formatPreflightError with cloud=false shows temporal operator command', () => {
+    const msg = formatPreflightError(
+      [{ name: 'AgentTempoEnsemble', type: 'Keyword' }],
+      'default',
+      undefined,
+      false,
+    );
+    expect(msg).toContain('temporal operator search-attribute create');
+    expect(msg).not.toContain('tcld');
   });
 });

--- a/tests/http/catalog.test.ts
+++ b/tests/http/catalog.test.ts
@@ -38,6 +38,7 @@ function makeMockClient(opts: MockOptions = {}): { client: TempoClient; calls: C
 
   const base = {
     listEnsembles: handler('listEnsembles', opts.ensembles ?? []),
+    ensureMaestroSession: handler('ensureMaestroSession', undefined),
     recruit: handler('recruit', { playerId: 'tempo-eng', entryId: 'entry-1' }),
     listHosts: handler('listHosts', []),
   };


### PR DESCRIPTION
## Problem

The SA preflight shells out to `temporal operator search-attribute list/create`, which uses the Operator gRPC service. **Temporal Cloud doesn't expose this service to namespace API keys** — it requires `tcld` or the Cloud UI.

This causes:
- Spurious "Request unauthorized" warnings on every `agent-tempo up` boot
- Unhelpful error messages pointing to `temporal operator` commands that will never work on Cloud
- Confusing UX for Temporal Cloud users

## Solution

Add an **SDK-based probe** that verifies search attributes by issuing visibility queries via the Temporal Client SDK (which works with Cloud API keys). When a Cloud namespace is detected, show actionable `tcld` instructions instead of `temporal operator` commands.

### Changes
- `src/cli/sa-preflight.ts`:
  - New `sdkProbeRegisteredAttributes()` — probes each SA by issuing a `listWorkflowExecutions` query referencing it (registered → empty results; unregistered → `INVALID_ARGUMENT`)
  - New `isTemporalCloud()` — heuristic: address contains `.tmprl.cloud`
  - `verifySearchAttributes()` auto-selects SDK probe when `temporalApiKey` is set
  - `formatPreflightError()` now cloud-aware: shows `tcld` commands + Cloud UI link for Cloud namespaces
- `src/cli/startup.ts`: Cloud path uses SDK probe and skips CLI registration attempts
- `src/daemon.ts`: Passes `temporalApiKey` to `verifySearchAttributes()`
- `tests/cli/sa-preflight.test.ts`: 7 new tests covering Cloud detection, probe path, and formatting

### How it works (SDK probe)
```
listWorkflowExecutions({ query: 'AgentTempoEnsemble = "__probe__"' })
→ registered: returns empty result set ✓
→ not registered: throws INVALID_ARGUMENT: "is not a valid search attribute"
```

Refs #615