### PR TITLE
fix(cli): guard against Temporal "Channel has been shut down" crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- **`agent-tempo` no longer crashes with `Error: Channel has been shut down`** during
+  the bare-invocation bootstrap (and any other Temporal-touching command). Root cause:
+  `@temporalio/client`'s gRPC retry interceptor schedules call retries via `setTimeout`,
+  but `Connection.close()` does not clear those pending timers. When a retry timer fired
+  *after* the channel was closed, `InternalChannel.createCall` threw synchronously **inside
+  the timer callback** — off any awaited path, so the `try/catch` around `connection.close()`
+  could not catch it, and it escaped to `uncaughtException` and killed the process. New
+  `src/utils/grpc-shutdown-guard.ts` installs a single process-level guard at CLI/daemon/MCP-
+  server entry that swallows exactly this benign post-shutdown error (the connection's result
+  was already captured or degraded) and re-throws everything else, preserving normal crash
+  semantics. The guard imports no Temporal/grpc modules, so it does not regress the #157
+  crash-proof-module isolation guarantee.
+
 ## [1.3.0] - 2026-05-24
 
 ### Added

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -30,6 +30,7 @@ import { AGENT_TYPES, AgentType } from './types';
 import { ENV, CliOverrides, getConfig, isDevMode } from './config';
 import { formatMigrationResult, type LegacyMigrationResult } from './cli/legacy-migration';
 import { refreshEntrypoint } from './cli/global-wrapper';
+import { installGrpcShutdownGuard } from './utils/grpc-shutdown-guard';
 
 /** Package root — cli.js compiles to dist/cli.js, so one level up. Used by the inline `version` handler. */
 const PACKAGE_ROOT = resolve(__dirname, '..');
@@ -331,6 +332,13 @@ function reportMigrationResult(result: LegacyMigrationResult): void {
 }
 
 async function main() {
+  // Neutralize the Temporal/grpc-js "Channel has been shut down" retry-after-
+  // close race before any Temporal-touching command runs. See
+  // src/utils/grpc-shutdown-guard.ts. Cheap, import-clean, and idempotent — it
+  // attaches a single `uncaughtException` listener and pulls in no Temporal/grpc
+  // modules, so it is safe above the crash-proof fast paths below.
+  installGrpcShutdownGuard();
+
   const args = parseArgs(process.argv.slice(2));
   const overrides = cliOverrides(args);
 

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -27,6 +27,7 @@ import {
 import { emitDevBannerIfActive } from './cli/dev-banner';
 import { createWorkers } from './worker';
 import { createTemporalConnection } from './connection';
+import { installGrpcShutdownGuard } from './utils/grpc-shutdown-guard';
 import { DAEMON_PID_PATH, DAEMON_LOG_PATH, DAEMON_HEARTBEAT_PATH, HEARTBEAT_INTERVAL_MS } from './cli/daemon';
 import { createTempoClient } from './client';
 import { queryOrphanedSessions, restoreOrphansOnce, type OrphanCandidate } from './reconcile/orphans';
@@ -821,6 +822,11 @@ export function startCleanupLoop(
 }
 
 async function main() {
+  // Neutralize the Temporal/grpc-js "Channel has been shut down" retry-after-
+  // close race so a stray retry timer can't kill the long-lived daemon. See
+  // src/utils/grpc-shutdown-guard.ts.
+  installGrpcShutdownGuard();
+
   // ADR 0014 §5.4 / gate 4 — dev daemon log self-identifies. Banner fires
   // first so it lands at the top of `~/.agent-tempo-dev/daemon.log` for
   // grep-friendly identification regardless of subsequent log volume.

--- a/src/server.ts
+++ b/src/server.ts
@@ -23,11 +23,15 @@ import { buildServerInstructions, registerAllTempoTools } from './server-tools';
 import { registry, InteractiveAttachment } from './adapters';
 import { resolveAgentType } from './ensemble/agent-types';
 import { installParentDeathWatchdog } from './utils/parent-death-watchdog';
+import { installGrpcShutdownGuard } from './utils/grpc-shutdown-guard';
 
 const log = (...args: unknown[]) => console.error('[agent-tempo]', ...args);
 
 async function main() {
   installParentDeathWatchdog();
+  // Neutralize the Temporal/grpc-js "Channel has been shut down" retry-after-
+  // close race. See src/utils/grpc-shutdown-guard.ts.
+  installGrpcShutdownGuard();
 
   // Only activate when explicitly opted in via AGENT_TEMPO_ENSEMBLE
   if (!process.env[ENV.ENSEMBLE]) {

--- a/src/utils/grpc-shutdown-guard.ts
+++ b/src/utils/grpc-shutdown-guard.ts
@@ -24,6 +24,20 @@
  * preserving normal crash semantics.
  *
  * Install once at CLI entry. Idempotent.
+ *
+ * Coupling notes:
+ * - The match string is grpc-js's exact `close()` error
+ *   (`@grpc/grpc-js/build/src/internal-channel.js`, the `SHUTDOWN`-state throw).
+ *   That state is reachable ONLY via an explicit `close()` — a live connection
+ *   hitting a transient error reports `TRANSIENT_FAILURE`, never this message —
+ *   so swallowing it cannot mask a failure we'd want to surface. If grpc-js ever
+ *   renames the message this guard silently becomes a no-op (crash resurfaces);
+ *   update `CHANNEL_SHUTDOWN_MESSAGE` to match.
+ * - This handler is registered first (it's installed at process entry). When it
+ *   re-throws a non-benign error, Node exits immediately and any LATER
+ *   `uncaughtException` listener is bypassed. The codebase currently registers
+ *   no other `uncaughtException` listeners, so this is benign today — revisit if
+ *   a crash reporter is ever added.
  */
 
 const CHANNEL_SHUTDOWN_MESSAGE = 'Channel has been shut down';
@@ -52,8 +66,9 @@ const handler = (err: unknown): void => {
   }
   // Not ours — restore default crash behavior. Throwing from inside an
   // 'uncaughtException' handler causes Node to print the error and exit with a
-  // non-zero code (it does not re-enter this handler), preserving the original
-  // failure's visibility and exit semantics.
+  // non-zero code (exit code 7, "Uncaught Exception Handler Error", on current
+  // Node — not 1) without re-entering this handler, preserving the original
+  // failure's visibility and crash semantics.
   throw err;
 };
 

--- a/src/utils/grpc-shutdown-guard.ts
+++ b/src/utils/grpc-shutdown-guard.ts
@@ -1,0 +1,78 @@
+/**
+ * Process-level guard for the Temporal/grpc-js "Channel has been shut down"
+ * shutdown race.
+ *
+ * `@temporalio/client`'s gRPC retry interceptor (`grpc-retry.js`) schedules
+ * call retries with `setTimeout`. `Connection.close()` shuts down the
+ * underlying grpc-js channel but does NOT clear those pending timers. When a
+ * retry timer fires *after* the channel is closed, `InternalChannel.createCall`
+ * throws `Error: Channel has been shut down` **synchronously inside the timer
+ * callback** — off any awaited path, so no surrounding `try/catch` (including
+ * the one around `connection.close()`) can catch it. It escapes to
+ * `uncaughtException` and kills the process.
+ *
+ * Observed stack (the crash this guards against):
+ *   InternalChannel.createCall (@grpc/grpc-js/.../internal-channel.js)
+ *   ...
+ *   Timeout.retry [as _onTimeout] (@temporalio/client/lib/grpc-retry.js)
+ *
+ * This artifact is always benign: it only occurs for a connection we have
+ * already finished with (its query result was captured, or we degraded), as
+ * the channel tears down. Swallowing exactly this error — and nothing else —
+ * removes the crash without masking real failures. Any other uncaught
+ * exception is re-thrown, which Node treats as fatal (print + non-zero exit),
+ * preserving normal crash semantics.
+ *
+ * Install once at CLI entry. Idempotent.
+ */
+
+const CHANNEL_SHUTDOWN_MESSAGE = 'Channel has been shut down';
+
+let installed = false;
+
+function isBenignChannelShutdown(err: unknown): err is Error {
+  return (
+    err instanceof Error &&
+    typeof err.message === 'string' &&
+    err.message.includes(CHANNEL_SHUTDOWN_MESSAGE)
+  );
+}
+
+const handler = (err: unknown): void => {
+  if (isBenignChannelShutdown(err)) {
+    // A Temporal gRPC retry timer fired after we closed the connection. The
+    // result we cared about was already captured (or degraded). Drop it.
+    if (process.env.CLAUDE_TEMPO_DEBUG) {
+      // eslint-disable-next-line no-console
+      console.error(
+        '[agent-tempo] ignored post-shutdown gRPC channel error (benign Temporal retry-after-close race)',
+      );
+    }
+    return;
+  }
+  // Not ours — restore default crash behavior. Throwing from inside an
+  // 'uncaughtException' handler causes Node to print the error and exit with a
+  // non-zero code (it does not re-enter this handler), preserving the original
+  // failure's visibility and exit semantics.
+  throw err;
+};
+
+/**
+ * Register the guard on `process`. Safe to call multiple times — only the
+ * first call attaches a listener.
+ */
+export function installGrpcShutdownGuard(): void {
+  if (installed) return;
+  installed = true;
+  process.on('uncaughtException', handler);
+}
+
+/**
+ * Test-only escape hatch — removes the listener and resets the install latch so
+ * a fresh `installGrpcShutdownGuard()` can be exercised. Never call from
+ * production code. See docs/adr/0006-test-hooks-naming.md.
+ */
+export function __resetGrpcShutdownGuardForTests(): void {
+  process.off('uncaughtException', handler);
+  installed = false;
+}

--- a/tests/utils/grpc-shutdown-guard.test.ts
+++ b/tests/utils/grpc-shutdown-guard.test.ts
@@ -6,6 +6,13 @@
  * `'uncaughtException'` synchronously and asserting throw / no-throw behavior.
  * Other listeners in the test runner are stashed and restored around each case
  * so we observe only the guard's own behavior.
+ *
+ * Limitation: in production, re-throwing from the handler makes Node exit the
+ * process (code 7). That cannot be reproduced in-process without killing the
+ * test runner, so the "re-throws ..." cases below assert only that the handler
+ * does NOT swallow non-benign errors (the throw surfaces synchronously through
+ * `process.emit`). They do not — and cannot, here — verify the actual exit-code
+ * behavior; that is covered by reasoning, not by this unit.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import {

--- a/tests/utils/grpc-shutdown-guard.test.ts
+++ b/tests/utils/grpc-shutdown-guard.test.ts
@@ -1,0 +1,64 @@
+/**
+ * Unit tests for the Temporal/grpc-js "Channel has been shut down" guard.
+ *
+ * The guard swallows exactly the benign post-`Connection.close()` retry-timer
+ * error and re-throws everything else. We drive it by emitting
+ * `'uncaughtException'` synchronously and asserting throw / no-throw behavior.
+ * Other listeners in the test runner are stashed and restored around each case
+ * so we observe only the guard's own behavior.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  installGrpcShutdownGuard,
+  __resetGrpcShutdownGuardForTests,
+} from '../../src/utils/grpc-shutdown-guard';
+
+describe('grpc-shutdown-guard', () => {
+  let stashed: NodeJS.UncaughtExceptionListener[];
+
+  beforeEach(() => {
+    __resetGrpcShutdownGuardForTests();
+    // Isolate from the runner's own uncaughtException listeners so emitting
+    // a synthetic error doesn't trip vitest's harness.
+    stashed = process.listeners('uncaughtException');
+    process.removeAllListeners('uncaughtException');
+  });
+
+  afterEach(() => {
+    __resetGrpcShutdownGuardForTests();
+    process.removeAllListeners('uncaughtException');
+    for (const l of stashed) process.on('uncaughtException', l);
+  });
+
+  it('swallows the benign "Channel has been shut down" error', () => {
+    installGrpcShutdownGuard();
+    const err = new Error('Channel has been shut down');
+    expect(() => process.emit('uncaughtException', err)).not.toThrow();
+  });
+
+  it('swallows errors whose message merely contains the marker', () => {
+    installGrpcShutdownGuard();
+    const err = new Error('14 UNAVAILABLE: Channel has been shut down');
+    expect(() => process.emit('uncaughtException', err)).not.toThrow();
+  });
+
+  it('re-throws any other error to preserve crash semantics', () => {
+    installGrpcShutdownGuard();
+    const err = new Error('something genuinely broken');
+    expect(() => process.emit('uncaughtException', err)).toThrow('something genuinely broken');
+  });
+
+  it('re-throws non-Error throwables', () => {
+    installGrpcShutdownGuard();
+    // grpc/temporal always throw Error instances, but be defensive.
+    expect(() => process.emit('uncaughtException', 'plain string' as unknown as Error)).toThrow();
+  });
+
+  it('is idempotent — only one listener attaches across repeated installs', () => {
+    const before = process.listenerCount('uncaughtException');
+    installGrpcShutdownGuard();
+    installGrpcShutdownGuard();
+    installGrpcShutdownGuard();
+    expect(process.listenerCount('uncaughtException')).toBe(before + 1);
+  });
+});


### PR DESCRIPTION
@
## Problem

Running `agent-tempo` (bare invocation) intermittently crashed the process with:

```
Error: Channel has been shut down
    at InternalChannel.createCall (@grpc/grpc-js/.../internal-channel.js:596:19)
    ...
    at Timeout.retry [as _onTimeout] (@temporalio/client/lib/grpc-retry.js:142:34)
```

## Root cause

`@temporalio/client`s gRPC retry interceptor schedules call retries with `setTimeout`, but `Connection.close()` does **not** clear those pending timers. When a retry timer fires *after* the channel is closed, `InternalChannel.createCall` throws **synchronously inside the timer callback** — off any awaited path, so the `try/catch` around `connection.close()` in `src/cli/startup.ts` cannot catch it. It escapes to `uncaughtException` and kills the process.

Most visible during the bare-invocation bootstrap → TUI handoff (`runBootstrap` opens a connection, runs `discoverEnsembles` / `queryOrphanedSessions`, then closes), but applies to any Temporal-touching command. Timing-dependent — only crashes when a transient retry happens to be in flight at close time, which is why `status` and warm boots usually survived.

## Fix

New `src/utils/grpc-shutdown-guard.ts` installs a single process-level `uncaughtException` guard that:
- **swallows exactly** the benign `Channel has been shut down` error (by the time it fires, the connections result was already captured or degraded), and
- **re-throws everything else** — throwing from inside an `uncaughtException` handler makes Node exit fatally, preserving normal crash semantics.

Installed at the three JS-client entrypoints: `cli.ts`, `daemon.ts`, `server.ts`.

The guard imports **no** Temporal/grpc modules, so it does not regress the #157 crash-proof-module isolation guarantee.

## Tests

`tests/utils/grpc-shutdown-guard.test.ts` (5 cases, all passing): swallow benign / substring match / re-throw real errors / re-throw non-Errors / idempotent install.

## Verification

- `npm run build` clean
- new unit tests pass
- `agent-tempo status` runs cleanly against a live ensemble
- crash-proof isolation guarantee verified intact by inspection (no crash-proof module imports the guard; the guard imports nothing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@