### PR TITLE
test(v2): fix 3 vitest gate failures — stale tests from A-stream (#786/787/788)

### DIFF
--- a/tests/client/list-ensembles-bounded.test.ts
+++ b/tests/client/list-ensembles-bounded.test.ts
@@ -22,6 +22,10 @@ import { VisibilityIteratorTimeoutError } from '../../src/utils/visibility-deadl
 interface FakeWf {
   workflowId: string;
   searchAttributes?: Record<string, unknown>;
+  /** Decoded workflow memo — where conductor/playerType live after #788's
+   *  SA→memo migration (the readers `getIsConductor`/`getPlayerType` are
+   *  memo-only now). Ensemble name + phase stay in `searchAttributes`. */
+  memo?: Record<string, unknown>;
 }
 
 /** Build a minimal fake Client whose `workflow.list` returns the given entries. */
@@ -66,21 +70,32 @@ function makeFakeClient(opts: {
   } as unknown as Client;
 }
 
-/** Build an entry with the search attributes that `listEnsemblesBounded` reads. */
+/**
+ * Build an entry mirroring what `listEnsemblesBounded` reads. Ensemble name +
+ * phase are search attributes (`getEnsembleName`/`getAttachmentPhase` stay SA);
+ * conductor + playerType go in the **memo** (`getIsConductor`/`getPlayerType`
+ * are memo-only after #788's SA→memo migration). Memo values are plain decoded
+ * values, not the array-wrapped form search attributes use.
+ */
 function entry(ensemble: string, opts: {
   phase?: string;
   isConductor?: boolean;
   playerType?: string;
   workflowId?: string;
 } = {}): FakeWf {
+  const hasMeta = opts.isConductor !== undefined || opts.playerType !== undefined;
   return {
     workflowId: opts.workflowId ?? `${ensemble}-player-${Math.random().toString(36).slice(2)}`,
     searchAttributes: {
       AgentTempoEnsemble: [ensemble],
       ...(opts.phase !== undefined ? { AgentTempoAttachmentState: [opts.phase] } : {}),
-      ...(opts.isConductor !== undefined ? { AgentTempoIsConductor: [opts.isConductor] } : {}),
-      ...(opts.playerType !== undefined ? { AgentTempoPlayerType: [opts.playerType] } : {}),
     },
+    ...(hasMeta ? {
+      memo: {
+        ...(opts.isConductor !== undefined ? { AgentTempoIsConductor: opts.isConductor } : {}),
+        ...(opts.playerType !== undefined ? { AgentTempoPlayerType: opts.playerType } : {}),
+      },
+    } : {}),
   };
 }
 

--- a/tests/conformance/registration-order-fence.test.ts
+++ b/tests/conformance/registration-order-fence.test.ts
@@ -23,10 +23,12 @@
  *  - V3: destroyUpdate's kill-window interleave fence (the
  *    "abandoned by setPhase('gone')" comment) must stay present.
  *  - KNOWN EXCEPTION: `playerReportSignal` registers BEFORE its producer
- *    `setStageSignal` — protected by the #777 reconciliation
- *    (`v0.27-stage-reconcile-reports`), NOT by order. Pinned as
- *    consumer-first so an accidental "fix" reordering it doesn't silently
- *    change which protection is load-bearing.
+ *    `setStageSignal` — protected by the #777 reconciliation (the
+ *    "commutative reconciliation against pre-stage reports" block in the
+ *    setStage handler; formerly gated by `patched('v0.27-stage-reconcile-
+ *    reports')`, now unconditional after #787's patched-strip), NOT by order.
+ *    Pinned as consumer-first so an accidental "fix" reordering it doesn't
+ *    silently change which protection is load-bearing.
  *
  * ── Traps the convention names (adopted from the audit's caveats) ──
  *
@@ -134,7 +136,13 @@ describe('registration-order fences (#797 / #782)', () => {
     // If this flips, the #777 reconciliation becomes dead code and the
     // protection story changes — that's a conscious decision, not a drift.
     expect(report).toBeLessThan(setStage);
-    expect(src).toMatch(/v0\.27-stage-reconcile-reports/);
+    // The reconciliation that makes consumer-first SAFE was gated behind
+    // `patched('v0.27-stage-reconcile-reports')` until #787 stripped every
+    // patched() marker for the 2.0 clean slate (it is now UNCONDITIONAL).
+    // Pin its continued presence by the block comment AND a load-bearing code
+    // token, so deleting the reconciliation can never pass silently.
+    expect(src).toMatch(/commutative reconciliation against pre-stage reports/);
+    expect(src).toMatch(/playerEntry\.reconciled = true/);
   });
 
   it('C2 loudness: fireSchedule retry-exhaustion logs the lost fire (scheduler.ts)', () => {

--- a/tests/utils/visibility-deadline.test.ts
+++ b/tests/utils/visibility-deadline.test.ts
@@ -159,13 +159,15 @@ describe('VISIBILITY_DEADLINES_MS', () => {
   // Snapshot test — adding/removing a site is a deliberate change.
   // Keep the values in sync with `src/utils/visibility-deadline.ts`'s
   // doc-comment tuning rationale.
-  it('exposes all six site keys with positive values', () => {
+  it('exposes all seven site keys with positive values', () => {
     const keys = Object.keys(VISIBILITY_DEADLINES_MS).sort();
     expect(keys).toEqual([
       'discoverEnsembles',
       'fireScheduleAll',
       'orphanQueryBoot',
       'orphanQueryCleanup',
+      // #786 — daemon boot guard's protocol-stamp scan (fail-closed).
+      'protocolGuardBoot',
       'resolveSession',
       'scanEnsembleSessions',
     ]);


### PR DESCRIPTION
The new `test-vitest` gate (#867) caught **3 pre-existing failures on v2 HEAD** — invisible until vitest started gating on v2. They block the whole v2 line (#868, #794), so fixed on v2 directly. **All three are stale tests** tracking intentional A-stream changes; production code is correct in each (diagnosed, not literal-bumped).

## Verdicts

**1. `tests/client/list-ensembles-bounded.test.ts` — "parity with listEnsembles() shape" → STALE FIXTURE**
#788 migrated conductor/playerType reads from search attribute → memo (`getIsConductor`/`getPlayerType` are now memo-only). Both `listEnsembles` (core.ts:288) and `listEnsemblesBounded` (core.ts:422) read identically — **parity HOLDS**, `hasConductor` was *not* dropped. The test's `entry()` fixture still wrote `AgentTempoIsConductor` as an SA, so the memo-only reader saw `hasConductor=false`. **Fix:** fixture writes conductor/playerType to the `memo` (added `memo` to `FakeWf`).

**2. `tests/utils/visibility-deadline.test.ts` — "all six site keys" → STALE SNAPSHOT**
#786 added a 7th deadline site, `protocolGuardBoot` — the daemon boot-guard's fail-closed protocol-stamp scan (visibility-deadline.ts:120). Legit. **Fix:** add the key, six→seven.

**3. `tests/conformance/registration-order-fence.test.ts` — KNOWN-EXCEPTION pin → STALE MARKER (safety-verified)**
⚠ Safety conformance test. #787's patched-strip removed the `patched('v0.27-stage-reconcile-reports')` marker the test matched. **Verified the #777 reconciliation is fully intact** — just unconditional now (session.ts:1507-1568; the block comment even notes "was patched()-gated… now unconditional — #787"). **Fix:** pin its continued presence by the block comment AND a load-bearing code token (`playerEntry.reconciled = true`) instead of the deleted patched marker; updated the test's header doc to match.

## Verification
- The 3 files: 23/23 pass
- **Full vitest gate (`npm run test:vitest`): 128 files / 1428 tests, all green**

## Adjacent (NOT fixed here — flagged)
`getIsConductor`/`getPlayerType` doc-comments (search-attributes.ts:232-233, 246-247) still say "legacy search attribute as fallback" but are memo-only post-#788 — same stale-comment class as the #868 nit. Left for a docs sweep to avoid scope-creep.

Once merged, #868 rebases on top and the v2 line is unblocked.

Refs #786 #787 #788 #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)