### PR TITLE
chore(comments): correct stale legacy-SA-fallback comments to memo-only (#788)

### DIFF
--- a/src/client/core.ts
+++ b/src/client/core.ts
@@ -340,10 +340,9 @@ export function createTempoClientCore(
           // agent — counting it produced confusing "(2 players)" rows on
           // a fresh ensemble with one real player. Mirrors the
           // `filterRealPlayers` rule used in StatusBar (cf6becd). Detect
-          // via the `AgentTempoPlayerType` memo (v1.8 SA diet; legacy-SA
-          // fallback via the dual-read helper), with a workflow-id-suffix
-          // fallback for the brief post-start window before visibility
-          // propagates.
+          // via the `AgentTempoPlayerType` memo (memo-only after the #788
+          // legacy-SA prune), with a workflow-id-suffix fallback for the
+          // brief post-start window before visibility propagates.
           const playerType = getPlayerType(wf);
           const isMaestroSession = playerType === 'maestro'
             || (wf.workflowId?.endsWith('-maestro') ?? false);

--- a/src/utils/search-attributes.ts
+++ b/src/utils/search-attributes.ts
@@ -36,9 +36,10 @@ export interface SearchAttributeCarrier {
  *
  * T0.5 (#747): the read-only metadata fields (`gitRoot`, `playerType`,
  * `isConductor`, plus `part`) migrated from search attributes to the workflow
- * memo. The dual-read helpers below prefer the memo (new runs) and fall back
- * to the legacy search attribute (runs started before the v1.8-sa-diet patch)
- * — this file is the single choke point for that migration window.
+ * memo. The memo readers below are now memo-only — #788 pruned the legacy-SA
+ * fallback, since the 2.0 clean cutover (guarded by #786) leaves no pre-v1.8
+ * SA-only run for a 2.0 worker to read. This file is the single choke point
+ * for those reads.
  */
 export interface WorkflowMetaCarrier extends SearchAttributeCarrier {
   memo?: Record<string, unknown>;
@@ -47,7 +48,7 @@ export interface WorkflowMetaCarrier extends SearchAttributeCarrier {
 /**
  * Canonical memo key names (T0.5, #747) — single registry shared by every
  * write site (session workflow, the five `client.workflow.start({ memo })`
- * seeds) and the dual-read helpers below, so a key can never silently
+ * seeds) and the memo readers below, so a key can never silently
  * drift between writer and reader. Wire-stable: renaming a key is a
  * breaking change (docs/WIRE-PROTOCOL.md §Workflow memo).
  *
@@ -229,11 +230,11 @@ export function getEnsembleName(
 }
 
 /**
- * Read the conductor flag — memo `AgentTempoIsConductor` preferred (T0.5),
- * legacy search attribute as fallback for pre-v1.8 runs.
+ * Read the conductor flag from memo `AgentTempoIsConductor` (T0.5; memo-only
+ * after the #788 legacy-SA prune).
  *
- * Returns `undefined` when absent in both (e.g. transiently un-indexed after
- * a conductor spawn). Callers wanting the pre-#178 workflow-id-suffix
+ * Returns `undefined` when absent (e.g. transiently un-indexed after a
+ * conductor spawn). Callers wanting the pre-#178 workflow-id-suffix
  * fallback (`endsWith('-conductor')`) should apply it on `undefined`.
  */
 export function getIsConductor(
@@ -243,10 +244,9 @@ export function getIsConductor(
 }
 
 /**
- * Read the player type — memo `AgentTempoPlayerType` preferred (T0.5),
- * legacy search attribute as fallback for pre-v1.8 runs. Callers keep their
- * existing workflow-id-suffix fallback (`endsWith('-maestro')`) on
- * `undefined`.
+ * Read the player type from memo `AgentTempoPlayerType` (T0.5; memo-only
+ * after the #788 legacy-SA prune). Callers keep their existing
+ * workflow-id-suffix fallback (`endsWith('-maestro')`) on `undefined`.
  */
 export function getPlayerType(
   carrier: WorkflowMetaCarrier,

--- a/src/workflows/session.ts
+++ b/src/workflows/session.ts
@@ -193,7 +193,7 @@ export async function agentSessionWorkflow(input: SessionInput): Promise<void> {
    * Shared by the run-start upsert and the updateMetadata handler so the
    * two write sites can't drift. Key names come from the shared
    * {@link MEMO_KEYS} registry (also used by the client-side
-   * `workflow.start({ memo })` seeds and the dual-read helpers).
+   * `workflow.start({ memo })` seeds and the memo readers).
    */
   const metaMemo = (): Record<string, unknown> => ({
     ...(input.metadata.gitRoot ? { [MEMO_KEYS.gitRoot]: input.metadata.gitRoot } : {}),


### PR DESCRIPTION
Fill-in cleanup flagged during #870. After #788 the metadata memo readers (`getWorkflowMetaString/Bool`, `getIsConductor`, `getPlayerType`) are **memo-only** — the legacy search-attribute fallback was pruned (the 2.0 clean cutover leaves no pre-v1.8 SA-only run for a 2.0 worker to read). Several doc-comments still described a "dual-read" / "legacy-SA fallback" path that no longer exists. The #868 nit corrected 3 of them; this sweep catches the remainder.

## Fixed (comment-only)
- `src/utils/search-attributes.ts` — `WorkflowMetaCarrier` doc, `MEMO_KEYS` doc, and the `getIsConductor` / `getPlayerType` getter docs (all "dual-read" / "legacy SA fallback for pre-v1.8 runs" → memo-only post-#788)
- `src/client/core.ts` — the `listEnsemblesBounded` maestro-detection comment ("legacy-SA fallback via the dual-read helper" → memo-only)
- `src/workflows/session.ts` — `metaMemo` doc ("dual-read helpers" → "memo readers")

## Verified accurate, left as-is
- `search-attributes.ts:259` (`getPart`) — "part was never a search attribute, so there is no SA fallback" is correct (memo-only by origin)
- `cli/sa-preflight.ts:40` — "SA diet trimmed 9 → 5" is a historical fact, still true
- `pi/workflow-client.ts:66` — "legacy two-query" fallback is a query-path fallback, unrelated to SA/memo

## Out of scope (flagged, not touched)
- `activities/resolve.ts:223` — "pre-v1.8 runs … fall back to the legacy per-player getMetadata/getPart queries" describes a *query-path* fallback (observation-memo absence), not an SA fallback. Post-cutover that branch is unreachable; worth a follow-up to confirm whether #794 already removed the fallback code before editing the comment.

Comment-only — no behavior change; `npm run build` clean.

Refs #788

🤖 Generated with [Claude Code](https://claude.com/claude-code)