### PR TITLE
docs(cli): add home and version commands to help output

### DIFF
--- a/src/cli/help-text.ts
+++ b/src/cli/help-text.ts
@@ -35,6 +35,7 @@ ${out.bold('Usage:')}
   agent-tempo <command> [options]
 
 ${out.bold('Commands:')}
+  ${out.cyan('home')}                     Bare landing (default): auto-provision, show status, print operator hints
   ${out.cyan('up')}                       Start infrastructure only — Temporal, daemon, MCP registration
   ${out.cyan('down')}                     Stop infrastructure; workflows stay parked for the next ${out.dim('up')}
   ${out.cyan('down --destroy [-y]')}      Terminate every workflow across every ensemble, then stop infrastructure
@@ -59,6 +60,7 @@ ${out.bold('Commands:')}
   ${out.cyan('init')}                     Register MCP server globally (or --project for .mcp.json)
   ${out.cyan('install-pi')}               Install the Pi extensions into Pi settings (or --project for .pi/settings.json)
   ${out.cyan('preflight')}                Run preflight checks only
+  ${out.cyan('version')}                  Print the installed version (alias: --version, -v)
   ${out.cyan('help')}                     Show this help message
 
 ${out.bold('Removed — use the command-center board')} ${out.dim('(agent-tempo command-center)')}:


### PR DESCRIPTION
## Summary

Both `home` and `version` are implemented + documented but were missing from the `agent-tempo help` Commands section. This adds them.

- **`home`** — the bare-landing default command (`src/cli.ts:724`; `command` defaults to `'home'`). Auto-provision → status → operator hints.
- **`version`** — prints the installed version (`src/cli.ts:356`; alias `--version`/`-v`).

Both already appear in `docs/cli.md`; this closes the help-output gap.

## Verification

- `npm run build` — clean (workflow bundle rebuilt).
- `node dist/cli.js help` — both rows render, column-aligned.
- `cli-crash-proof-isolation` test (#157 guard) — 12 passing, incl. `help-text`. Change is additive strings, no new imports, so the no-Temporal-leak contract holds.

Closes #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)