### PR TITLE
test(vitest): harden suite against ambient env (#744)

### DIFF
--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,0 +1,61 @@
+/**
+ * Global Vitest setup — environment isolation (#744).
+ *
+ * Problem: ~20 test files read `AGENT_TEMPO_*` / `CLAUDE_TEMPO_*` env vars.
+ * When a developer runs `npm run test:tui` from an ensemble-player shell that
+ * already exports these vars (e.g. `AGENT_TEMPO_DEV_MODE=1`), config-reading
+ * tests see wrong values and produce false-negatives. The symptom: 19+ healthy
+ * tests appear to fail, quarantining 64 passing tests (#742).
+ *
+ * Fix: this file is wired as `setupFiles` in `vitest.config.ts` so Vitest
+ * executes it once per worker (= once per test file) before any test runs.
+ * On load it scrubs all managed env keys to a known-clean baseline. The
+ * `afterEach` below then restores that same baseline after every individual
+ * test, catching mutations that individual tests make but do not clean up.
+ *
+ * Rules for individual test files:
+ *   - Tests that need a specific env var set it explicitly in `beforeEach`.
+ *   - Tests SHOULD keep their own save/restore for vars they mutate — the
+ *     global afterEach is a safety net, not a replacement.
+ *   - The original ambient env is intentionally NOT restored: the test
+ *     process is isolated from the developer's shell by design.
+ */
+import { afterEach } from 'vitest';
+
+const MANAGED_PREFIXES = ['AGENT_TEMPO_', 'CLAUDE_TEMPO_'] as const;
+
+function isManagedKey(key: string): boolean {
+  return MANAGED_PREFIXES.some((p) => key.startsWith(p));
+}
+
+/**
+ * Collect every managed key present in the ambient environment at startup
+ * and immediately delete them. This snapshot is kept only for the log
+ * message below — the clean baseline IS simply "all managed keys absent".
+ */
+const ambientKeys = Object.keys(process.env).filter(isManagedKey);
+if (ambientKeys.length > 0) {
+  // Emit a single warning so a developer can see which vars were scrubbed.
+  // We intentionally do NOT throw here — the scrub IS the fix, not a blocker.
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[tests/setup.ts] Scrubbed ${ambientKeys.length} ambient managed env var(s) from this test worker: ${ambientKeys.join(', ')}. ` +
+      'Tests run against a clean baseline. Set them explicitly in beforeEach if a test needs them.',
+  );
+  for (const key of ambientKeys) {
+    delete process.env[key];
+  }
+}
+
+/**
+ * After each test: delete any managed env vars the test left set.
+ * This catches tests that set vars without a matching cleanup, preventing
+ * bleed to the next test in the same file.
+ */
+afterEach(() => {
+  for (const key of Object.keys(process.env)) {
+    if (isManagedKey(key)) {
+      delete process.env[key];
+    }
+  }
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,6 +51,9 @@ export default defineConfig({
       // schema module; pure fs round-trip + validation guards).
       'tests/upgrade/**/*.test.ts',
     ],
+    // Scrub ambient AGENT_TEMPO_*/CLAUDE_TEMPO_* env vars before each file
+    // and restore the clean baseline after each test (#744).
+    setupFiles: ['tests/setup.ts'],
     environment: 'node',
     globals: false,
     // Keep these tests fast — no Ink, no Temporal, no I/O beyond mocks.


### PR DESCRIPTION
## Summary

- Adds `tests/setup.ts` as a global Vitest setup file
- On worker load: scrubs all `AGENT_TEMPO_*` / `CLAUDE_TEMPO_*` env keys, emits one warn listing what was found (so devs know what was sanitized)
- Global `afterEach` clears any managed vars a test leaves set, catching mutations without teardown
- Wired via `vitest.config.ts` `setupFiles: ['tests/setup.ts']`

## Why

Ensemble-player shells export `AGENT_TEMPO_ENSEMBLE`, `AGENT_TEMPO_PLAYER_NAME`, `AGENT_TEMPO_DEV_MODE`, etc. Without a centralized scrub, ~20 config-reading test files see wrong values and produce false-negatives. This caused ~19 test failures that appeared to quarantine 64 healthy tests (#742).

## Test plan

- [x] Clean run: 127 files / 1414 tests pass with no ambient env
- [x] Polluted run: 127 files / 1414 tests pass with `AGENT_TEMPO_DEV_MODE=1 AGENT_TEMPO_ENSEMBLE=polluted` exported — the scrub warning fires, tests see clean baseline
- [x] `npm run build` clean (test-infra only change, no product code)
- [x] Existing per-test save/restore patterns are unaffected (global afterEach is a safety net, not a replacement)

Closes #744

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MUVBJybteZfAWRoyvmjpZ9