### PR TITLE
feat(observability): nondeterminism alarm + degraded-flag on observation drops (#886)

### DIFF
--- a/docs/SSE-PROTOCOL.md
+++ b/docs/SSE-PROTOCOL.md
@@ -212,6 +212,12 @@ interface PlayerSummaryV1 {
   // round-trip; the maestro hub already populates these fields).
   activityCount?: number;
   lastActivityAt?: string;     // ISO
+  // #886 slice 2 — true when the observation scan could only produce a
+  // DEGRADED row (the workflow was listed but its metadata extraction
+  // failed). Identity (playerId) is preserved; non-identity fields are
+  // best-effort blanks. Render an "uncertain" badge instead of dropping the
+  // player — the row's presence prevents roster flapping (contra #777).
+  degraded?: boolean;
 }
 ```
 

--- a/docs/daemon.md
+++ b/docs/daemon.md
@@ -35,6 +35,30 @@ memory: rss=128mb heapUsed=64 heapTotal=80 external=4 arrayBuffers=1
 
 Pre-#336 daemons return `n/a` for memory fields — `daemon stats` handles this gracefully.
 
+### Nondeterminism alarm (#886)
+
+The daemon installs a process-global nondeterminism alarm before its Temporal
+workers start. It wraps the Temporal Runtime logger and watches for
+nondeterminism / determinism-violation records (e.g. a 2.0 worker replaying a
+1.x-recorded history, or a workflow-code/bundle skew — the incident class
+Temporal codes as `TMPRL1100`). On each hit it:
+
+- **Promotes** a prominent, greppable line to `~/.agent-tempo/daemon.log`:
+  ```
+  [agent-tempo:ALARM] nondeterminism #N — workflowType=… runId=… <message snippet>
+  ```
+  (The #801 incident produced 57 workflow-task failures in 3 minutes with *zero*
+  operator signal — this NAMES the flap the instant it starts.)
+- **Surfaces** a rolling snapshot on `GET /v1/health` under `nondeterminism`:
+  ```jsonc
+  "nondeterminism": {
+    "count": 3,                       // total hits since boot (0 = healthy)
+    "firstSeenAt": "…", "lastSeenAt": "…",
+    "recent": [{ "at": "…", "detail": "…" }]   // capped, newest last
+  }
+  ```
+  External monitors and the dashboard can poll this without scraping logs.
+
 ## How It Works
 
 - On first use, any agent-tempo command calls `startDaemon()` and waits up to 10 seconds for it to confirm startup (by writing `~/.agent-tempo/daemon.pid`)

--- a/src/activities/maestro.ts
+++ b/src/activities/maestro.ts
@@ -152,6 +152,9 @@ export function createMaestroActivities(
     // tempo bucket can diff across refreshes.
     activityCount: s.activityCount,
     lastActivityAt: s.lastActivityAt,
+    // #886 slice 2 — carry the degraded flag through to the wire so the
+    // dashboard/board can render an uncertain row instead of dropping it.
+    ...(s.degraded ? { degraded: true } : {}),
   });
 
   // #753 — attribute every Temporal call made by these activities (however

--- a/src/activities/resolve.ts
+++ b/src/activities/resolve.ts
@@ -205,6 +205,17 @@ export interface EnsembleSessionInfo {
    * session. Undefined when the session predates W2 or the query failed.
    */
   lastActivityAt?: string;
+  /**
+   * #886 slice 2 — `true` when this row was produced from a DEGRADED scan:
+   * the visibility list returned the workflow, but extracting its observation
+   * fields threw, so the rich metadata (part/workDir/hostname/…) is a
+   * best-effort blank rather than authoritative. The row's IDENTITY
+   * (`workflowId` + best-effort `playerId`) is preserved so the player stays
+   * in the roster marked uncertain — instead of being silently dropped, which
+   * reads as "player absent" and causes roster flapping (contra #777). Absent
+   * / `false` on every healthy row.
+   */
+  degraded?: boolean;
 }
 
 /**
@@ -271,9 +282,40 @@ export async function scanEnsembleSessionsCloud(
         // BPM fields filled in below — kept out of the enumeration loop so
         // per-player query latency can't eat the visibility deadline.
         sessions.push({ workflowId: workflow.workflowId, ...row, phase });
-      } catch {
-        // Workflow may have just completed (its memo/SA row vanished mid-scan)
-        // — skip this row; the next tick fills it in.
+      } catch (rowErr) {
+        // #886 slice 2 — observation extraction threw for this workflow. The
+        // OLD behaviour silently dropped the row, which makes a transient
+        // failure read as "player absent" → roster flapping (contra #777). The
+        // workflow IS in the visibility list, so the player exists; emit a
+        // DEGRADED row that preserves identity (workflowId + best-effort
+        // playerId) and flags `degraded: true`, instead of dropping it.
+        //
+        // playerId is salvaged in its own guard so a throwing getter can't
+        // escape to the outer (visibility-timeout-only) catch and fail the
+        // whole scan; it falls back to the workflowId. Identity preservation
+        // is the point — a row keyed on the real playerId avoids the
+        // remove+add churn that dropping (or re-keying on workflowId) causes.
+        let salvagedPlayerId = workflow.workflowId;
+        try {
+          salvagedPlayerId =
+            getSearchAttrString(workflow, 'AgentTempoPlayerId') ?? workflow.workflowId;
+        } catch {
+          /* keep workflowId */
+        }
+        sessions.push({
+          workflowId: workflow.workflowId,
+          playerId: salvagedPlayerId,
+          part: '',
+          hostname: '',
+          workDir: '',
+          isConductor: workflow.workflowId.endsWith('-conductor'),
+          agentType: 'claude',
+          degraded: true,
+        });
+        log(
+          `scanEnsembleSessionsCloud: degraded row for ${workflow.workflowId} ` +
+          `(observation extraction failed: ${rowErr instanceof Error ? rowErr.message : String(rowErr)})`,
+        );
       }
     }
   } catch (err) {

--- a/src/daemon.ts
+++ b/src/daemon.ts
@@ -38,6 +38,12 @@ import { InnerLoopRegistry } from './http/inner-loop';
 import { DoorbellRegistry } from './http/doorbell';
 import { IngestTokenRegistry } from './http/ingest-registry';
 import { installGrpcShutdownGuard } from './utils/grpc-shutdown-guard';
+import { Runtime, DefaultLogger } from '@temporalio/worker';
+import {
+  NondeterminismAlarm,
+  wrapLoggerWithAlarm,
+  setGlobalNondeterminismAlarm,
+} from './observability/nondeterminism-alarm';
 import { actionCountingInterceptors } from './utils/action-counters';
 import { DAEMON_PID_PATH, DAEMON_LOG_PATH, DAEMON_HEARTBEAT_PATH, HEARTBEAT_INTERVAL_MS } from './cli/daemon';
 import { createTempoClient } from './client';
@@ -1047,6 +1053,36 @@ async function main() {
   // close race so a stray retry timer can't kill the long-lived daemon. See
   // src/utils/grpc-shutdown-guard.ts.
   installGrpcShutdownGuard();
+
+  // #886 slice 1 — install the nondeterminism alarm BEFORE any Worker.create.
+  // Wraps Temporal's Runtime logger so a nondeterminism / determinism-violation
+  // flap (the #801 incident: 57 workflow-task failures in 3min with ZERO
+  // operator signal) is NAMED instantly — a prominent `[agent-tempo:ALARM]`
+  // line with a running count — and surfaced on `GET /v1/health`
+  // (`HealthV1.nondeterminism`). Runtime.install must precede worker creation
+  // and can only run once per process; both hold here (daemon entry point).
+  {
+    const alarm = new NondeterminismAlarm({
+      onHit: (count, sample) => {
+        // Prominent + greppable (`ALARM`), distinct from normal daemon chatter.
+        log(`[agent-tempo:ALARM] nondeterminism #${count} — ${sample.detail}`);
+      },
+    });
+    setGlobalNondeterminismAlarm(alarm);
+    try {
+      // Match the SDK default logger level ('INFO') so verbosity is unchanged;
+      // the wrapper only ADDS alarm detection on WARN/ERROR records.
+      Runtime.install({ logger: wrapLoggerWithAlarm(new DefaultLogger('INFO'), alarm) });
+    } catch (err) {
+      // Runtime.install throws if a Runtime already exists this process. Non-
+      // fatal: the alarm singleton still backs /v1/health; we just couldn't
+      // intercept Core logs. (Shouldn't happen — this is the daemon entry.)
+      log(
+        'nondeterminism alarm: Runtime.install skipped (runtime already initialized):',
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
 
   // ADR 0014 §5.4 / gate 4 — dev daemon log self-identifies. Banner fires
   // first so it lands at the top of `~/.agent-tempo-dev/daemon.log` for

--- a/src/http/event-types.ts
+++ b/src/http/event-types.ts
@@ -56,6 +56,27 @@ export interface HealthV1 {
    * semantics. Optional so legacy clients ignoring the field don't break.
    */
   memory?: MemoryUsageV1;
+  /**
+   * #886 slice 1 — daemon-side nondeterminism alarm state. Present when the
+   * daemon installed the alarm (always, in 2.0+); a non-zero `count` means a
+   * nondeterminism / determinism-violation flap was observed since boot (e.g.
+   * a 2.0 worker replaying a 1.x history, or a code/bundle skew). Lets external
+   * monitors and the dashboard poll the alarm without scraping `daemon.log`.
+   * Optional so pre-#886 clients (and non-daemon health responders) ignore it.
+   */
+  nondeterminism?: NondeterminismAlarmV1;
+}
+
+/** #886 — `/v1/health` shape of the nondeterminism alarm snapshot. */
+export interface NondeterminismAlarmV1 {
+  /** Total nondeterminism records seen since daemon boot (0 = healthy). */
+  count: number;
+  /** ISO timestamp of the first hit; absent when `count === 0`. */
+  firstSeenAt?: string;
+  /** ISO timestamp of the most recent hit; absent when `count === 0`. */
+  lastSeenAt?: string;
+  /** Most-recent samples (capped, newest last) — `{ at, detail }`. */
+  recent: Array<{ at: string; detail: string }>;
 }
 
 /** Snapshot of `process.memoryUsage()` at request time. All values in bytes. */
@@ -220,6 +241,16 @@ export interface PlayerSummaryV1 {
   contextTokens?: number;
   /** 3c Tier-1 coarse — context usage as a percentage of the model window. Additive. */
   contextPercent?: number;
+  /**
+   * #886 slice 2 — `true` when the daemon's observation scan could only produce
+   * a DEGRADED row for this player: the session workflow was listed but its
+   * metadata extraction failed, so the non-identity fields (part/workDir/phase/…)
+   * are best-effort blanks. Lets the dashboard/board render an "uncertain" badge
+   * instead of dropping the player, which would read as a departure and cause
+   * roster flapping (contra #777). Additive + optional per the §6 stability rule;
+   * absent on every healthy row.
+   */
+  degraded?: boolean;
 }
 
 // ── §5. SSE framing — event-id token format ─────────────────────────────

--- a/src/http/server.ts
+++ b/src/http/server.ts
@@ -82,6 +82,10 @@ import {
   handleSseRequest,
 } from './sse-handler';
 import type { HealthV1 } from './event-types';
+// #886 slice 1 — surface the daemon nondeterminism alarm on /v1/health. The
+// alarm core is Temporal-VALUE-free, so this import doesn't pull the worker
+// runtime into the HTTP layer.
+import { getGlobalNondeterminismAlarm } from '../observability/nondeterminism-alarm';
 
 const log = (...args: unknown[]) =>
   console.error(`[agent-tempo:http ${new Date().toISOString()}]`, ...args);
@@ -865,6 +869,12 @@ function handleHealth(res: http.ServerResponse, ctx: HandleContext): void {
       external: mem.external,
       arrayBuffers: mem.arrayBuffers,
     },
+    // #886 slice 1 — nondeterminism alarm snapshot (present when the daemon
+    // installed the alarm; `count > 0` signals an observed flap since boot).
+    ...(() => {
+      const snap = getGlobalNondeterminismAlarm()?.snapshot();
+      return snap ? { nondeterminism: snap } : {};
+    })(),
   };
   // Best-effort ensemble count — soft-fail to 0 rather than 500ing on a
   // healthcheck. `/v1/health` MUST stay reachable even when Temporal is

--- a/src/http/snapshot.ts
+++ b/src/http/snapshot.ts
@@ -160,6 +160,9 @@ export function toPlayerSummaryV1(
     ...(wireMeta?.coarse?.currentTool !== undefined ? { currentTool: wireMeta.coarse.currentTool } : {}),
     ...(wireMeta?.coarse?.contextTokens !== undefined ? { contextTokens: wireMeta.coarse.contextTokens } : {}),
     ...(wireMeta?.coarse?.contextPercent !== undefined ? { contextPercent: wireMeta.coarse.contextPercent } : {}),
+    // #886 slice 2 — carry the degraded/uncertain flag onto the wire so the
+    // dashboard/board can badge the player instead of dropping it (anti-flap).
+    ...(p.degraded ? { degraded: true } : {}),
   };
 }
 

--- a/src/observability/nondeterminism-alarm.ts
+++ b/src/observability/nondeterminism-alarm.ts
@@ -1,0 +1,227 @@
+/**
+ * Nondeterminism alarm (#886 slice 1).
+ *
+ * The #801 incident produced **57 workflow-task failures in 3 minutes with
+ * ZERO operator signal** — a nondeterminism flap (a 2.0 worker replaying a
+ * 1.x-recorded history, or a code/bundle skew) surfaces only as Temporal's
+ * own `WARN`-level Core log line, buried in `daemon.log` among normal chatter.
+ * Nothing NAMED the flap, counted it, or raised its severity.
+ *
+ * This module gives the daemon a tiny, process-global counter that:
+ *   1. Intercepts Temporal Runtime log records (via {@link wrapLoggerWithAlarm},
+ *      installed in the daemon's `Runtime.install({ logger })`).
+ *   2. Classifies nondeterminism / determinism-violation records
+ *      ({@link isNondeterminismLog}) — wording-tolerant, like the SA-preflight
+ *      marker set, so a Core/SDK phrasing change can't silently disarm it.
+ *   3. PROMOTES each hit to a prominent, greppable `[agent-tempo:ALARM]` line
+ *      with a running count — so a flap is named the instant it starts.
+ *   4. Keeps a small rolling snapshot ({@link NondeterminismAlarm.snapshot})
+ *      surfaced on `GET /v1/health` so external monitors / the dashboard can
+ *      poll the alarm state without scraping logs.
+ *
+ * **Temporal-VALUE-free by design:** this module imports only the `Logger`
+ * TYPE from `@temporalio/common` (erased at compile). The worker `Runtime` /
+ * `DefaultLogger` VALUES are imported by the daemon, which wraps a real logger
+ * with {@link wrapLoggerWithAlarm} and installs it. That keeps the HTTP layer
+ * (`/v1/health`) able to read {@link getGlobalNondeterminismAlarm} without
+ * pulling `@temporalio/worker` into the HTTP module graph.
+ *
+ * NOTE: daemon-side observability code — NOT workflow code — so `Date`/clocks
+ * are fine here; `now` is injected purely for deterministic unit tests.
+ */
+import type { Logger, LogLevel, LogMetadata } from '@temporalio/common';
+
+/**
+ * Substrings (matched case-insensitively against the log message) that mark a
+ * nondeterminism / determinism-violation record. A SET rather than one phrase
+ * because the exact wording varies across Core (Rust) and SDK (JS) sources and
+ * versions — `DeterminismViolationError` surfaces "Replay failed with a
+ * nondeterminism error", Core forwards a `WARN` referencing nondeterminism, and
+ * Temporal surfaces the incident class under the `TMPRL1100` code. Matching a
+ * set keeps the alarm armed across phrasing drift (same rationale as
+ * `UNREGISTERED_SA_MARKERS` in `sa-preflight.ts`).
+ */
+export const NONDETERMINISM_MARKERS: readonly string[] = Object.freeze([
+  'nondetermin',
+  'non-determin',
+  'determinismviolation',
+  'tmprl1100',
+]);
+
+/** A single recorded nondeterminism hit (most-recent-N kept by the alarm). */
+export interface NondeterminismSample {
+  /** ISO timestamp of the hit. */
+  at: string;
+  /** Best-effort detail: workflow type / id from log meta + a message snippet. */
+  detail: string;
+}
+
+/** Pollable alarm state — embedded in `GET /v1/health` (`HealthV1.nondeterminism`). */
+export interface NondeterminismAlarmSnapshot {
+  /** Total nondeterminism records seen since daemon boot. */
+  count: number;
+  /** ISO timestamp of the first hit, or `undefined` when count === 0. */
+  firstSeenAt?: string;
+  /** ISO timestamp of the most recent hit, or `undefined` when count === 0. */
+  lastSeenAt?: string;
+  /** Most-recent samples (capped), newest last. */
+  recent: NondeterminismSample[];
+}
+
+/** Max recent samples retained for the `/v1/health` snapshot. */
+const RECENT_CAP = 10;
+/** Max message characters kept per sample (logs can be long stack-y blobs). */
+const DETAIL_SNIPPET_MAX = 200;
+
+export interface NondeterminismAlarmOpts {
+  /** Injectable clock (epoch ms) — defaults to `Date.now`. Test seam only. */
+  now?: () => number;
+  /**
+   * Promotion sink — invoked on EVERY hit with the running count + sample, so
+   * the daemon can emit the prominent `[agent-tempo:ALARM]` line. Defaults to a
+   * no-op; the daemon passes a `console.error`-backed promoter. Kept injectable
+   * so unit tests can assert promotion without capturing stderr.
+   */
+  onHit?: (count: number, sample: NondeterminismSample) => void;
+}
+
+/**
+ * Process-global nondeterminism counter. One per daemon. Records hits, promotes
+ * each, and exposes a rolling snapshot.
+ */
+export class NondeterminismAlarm {
+  private _count = 0;
+  private _firstSeenAt?: string;
+  private _lastSeenAt?: string;
+  private readonly _recent: NondeterminismSample[] = [];
+  private readonly now: () => number;
+  private readonly onHit: (count: number, sample: NondeterminismSample) => void;
+
+  constructor(opts: NondeterminismAlarmOpts = {}) {
+    this.now = opts.now ?? (() => Date.now());
+    this.onHit = opts.onHit ?? (() => { /* no-op */ });
+  }
+
+  /** Record one nondeterminism hit from a log record. */
+  record(message: string, meta?: LogMetadata): void {
+    const at = new Date(this.now()).toISOString();
+    this._count += 1;
+    if (this._firstSeenAt === undefined) this._firstSeenAt = at;
+    this._lastSeenAt = at;
+
+    const sample: NondeterminismSample = { at, detail: buildDetail(message, meta) };
+    this._recent.push(sample);
+    if (this._recent.length > RECENT_CAP) this._recent.shift();
+
+    // Promote — fire the prominent, greppable alarm line (the whole point: the
+    // #801 flap produced zero operator signal). Never let a throwing sink eat
+    // the count.
+    try {
+      this.onHit(this._count, sample);
+    } catch {
+      /* a broken promoter must not disarm the counter */
+    }
+  }
+
+  /** Current count (total hits since boot). */
+  get count(): number {
+    return this._count;
+  }
+
+  /** Immutable snapshot for `/v1/health`. */
+  snapshot(): NondeterminismAlarmSnapshot {
+    return {
+      count: this._count,
+      ...(this._firstSeenAt !== undefined ? { firstSeenAt: this._firstSeenAt } : {}),
+      ...(this._lastSeenAt !== undefined ? { lastSeenAt: this._lastSeenAt } : {}),
+      recent: this._recent.slice(),
+    };
+  }
+}
+
+/** Build the best-effort sample detail from log meta + a message snippet. */
+function buildDetail(message: string, meta?: LogMetadata): string {
+  const bits: string[] = [];
+  const wfType = meta?.['workflowType'];
+  const wfId = meta?.['workflowId'];
+  const runId = meta?.['runId'];
+  if (typeof wfType === 'string') bits.push(`workflowType=${wfType}`);
+  if (typeof wfId === 'string') bits.push(`workflowId=${wfId}`);
+  if (typeof runId === 'string') bits.push(`runId=${runId}`);
+  const snippet = (message ?? '').slice(0, DETAIL_SNIPPET_MAX);
+  bits.push(snippet);
+  return bits.join(' · ');
+}
+
+/**
+ * True when a log record (its message) signals a nondeterminism / determinism
+ * violation. Case-insensitive substring match over {@link NONDETERMINISM_MARKERS}.
+ */
+export function isNondeterminismLog(message: string, _meta?: LogMetadata): boolean {
+  if (!message) return false;
+  const m = message.toLowerCase();
+  return NONDETERMINISM_MARKERS.some((marker) => m.includes(marker));
+}
+
+/**
+ * Wrap a base {@link Logger} so every record still flows to `base`, but any
+ * `WARN`/`ERROR` record matching {@link isNondeterminismLog} also feeds the
+ * alarm. Transparent: trace/debug/info pass straight through; warn/error/log are
+ * classified first, then forwarded unchanged.
+ *
+ * Only `WARN`/`ERROR` are inspected — a nondeterminism failure is always logged
+ * at one of those levels, and ignoring lower levels avoids a hot classifier on
+ * the (high-volume) debug/trace path.
+ */
+export function wrapLoggerWithAlarm(base: Logger, alarm: NondeterminismAlarm): Logger {
+  const consider = (level: LogLevel, message: string, meta?: LogMetadata): void => {
+    if ((level === 'WARN' || level === 'ERROR') && isNondeterminismLog(message, meta)) {
+      alarm.record(message, meta);
+    }
+  };
+  return {
+    log(level: LogLevel, message: string, meta?: LogMetadata): void {
+      consider(level, message, meta);
+      base.log(level, message, meta);
+    },
+    trace(message: string, meta?: LogMetadata): void {
+      base.trace(message, meta);
+    },
+    debug(message: string, meta?: LogMetadata): void {
+      base.debug(message, meta);
+    },
+    info(message: string, meta?: LogMetadata): void {
+      base.info(message, meta);
+    },
+    warn(message: string, meta?: LogMetadata): void {
+      consider('WARN', message, meta);
+      base.warn(message, meta);
+    },
+    error(message: string, meta?: LogMetadata): void {
+      consider('ERROR', message, meta);
+      base.error(message, meta);
+    },
+  };
+}
+
+// ── Process singleton ───────────────────────────────────────────────────────
+// The daemon installs ONE alarm at boot; `/v1/health` reads it without
+// threading a reference through the HTTP server constructor (and without
+// importing `@temporalio/worker` into the HTTP layer).
+
+let globalAlarm: NondeterminismAlarm | undefined;
+
+/** Set the process-global alarm (daemon boot only). */
+export function setGlobalNondeterminismAlarm(alarm: NondeterminismAlarm): void {
+  globalAlarm = alarm;
+}
+
+/** Read the process-global alarm, or `undefined` if not installed (e.g. tests, non-daemon). */
+export function getGlobalNondeterminismAlarm(): NondeterminismAlarm | undefined {
+  return globalAlarm;
+}
+
+/** Test seam — reset the singleton between unit tests. */
+export function __resetGlobalNondeterminismAlarmForTests(): void {
+  globalAlarm = undefined;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -968,6 +968,14 @@ export interface MaestroPlayerInfo {
    * surfaces that want to show "last active 12s ago" per player.
    */
   lastActivityAt?: string;
+  /**
+   * #886 slice 2 — `true` when this row came from a DEGRADED observation scan
+   * (the workflow was listed but its metadata extraction failed, so non-identity
+   * fields are best-effort blanks). Surfaces to the dashboard/board so the
+   * player renders as "uncertain" rather than vanishing — preventing roster
+   * flapping (contra #777). Absent / `false` on healthy rows.
+   */
+  degraded?: boolean;
 }
 
 /** A message relayed through the global Maestro for dashboard visibility. */

--- a/test/pi-tool-parity.test.ts
+++ b/test/pi-tool-parity.test.ts
@@ -49,7 +49,9 @@ const STUB_OPTS: RegisterAllTempoToolsOpts = {
 };
 
 const CONDUCTOR_ONLY = [
-  'quality_gate', 'evaluate_gate', 'gates', 'worktree', 'stage', 'stages', 'cancel_stage',
+  // #793 — `gate` is the canonical conductor-only tool; `quality_gate`/`gates`
+  // are its forwarding aliases (also conductor-only).
+  'gate', 'quality_gate', 'evaluate_gate', 'gates', 'worktree', 'stage', 'stages', 'cancel_stage',
 ];
 
 /** Capture (name → zod param shape) from the MCP renderer via a fake server. */

--- a/tests/activities/scan-degraded.test.ts
+++ b/tests/activities/scan-degraded.test.ts
@@ -1,0 +1,105 @@
+/**
+ * #886 slice 2 — scanEnsembleSessionsCloud degraded-row behaviour.
+ *
+ * When extracting a workflow's observation fields throws, the OLD code
+ * silently dropped the row — making a transient failure read as "player
+ * absent" → roster flapping (contra #777). The new behaviour emits a DEGRADED
+ * row that preserves identity (workflowId + best-effort playerId) and flags
+ * `degraded: true`, so the player stays in the roster marked uncertain.
+ *
+ * The search-attribute getters are defensive (they return undefined rather
+ * than throw on odd input), so we mock the getter module to force an
+ * extraction throw for one specific workflow while the others extract cleanly.
+ */
+import { describe, it, expect, vi } from 'vitest';
+
+// Force `getPart` to throw for any workflow flagged `_boom`; everything else
+// extracts deterministically. Partial-mock keeps the module's real exports
+// the resolver imports (sanitizeQueryValue, MEMO_KEYS, …) present.
+vi.mock('../../src/utils/search-attributes', () => ({
+  getAttachmentPhase: (wf: any) => wf._phase ?? 'attached',
+  getSearchAttrString: (wf: any, key: string) =>
+    key === 'AgentTempoPlayerId' ? wf._playerId
+      : key === 'AgentTempoHostname' ? 'host-1'
+        : undefined,
+  getMemoString: () => 'memo-val',
+  getWorkflowMetaString: () => undefined,
+  getIsConductor: () => false,
+  getPlayerType: () => 'tempo-soloist',
+  getPart: (wf: any) => {
+    if (wf._boom) throw new Error('extraction boom');
+    return 'a part';
+  },
+  sanitizeQueryValue: (s: string) => s,
+  MEMO_KEYS: { workDir: 'wd', gitRoot: 'gr', gitBranch: 'gb', agentType: 'at' },
+}));
+
+import { scanEnsembleSessionsCloud } from '../../src/activities/resolve';
+
+function makeClient(workflows: any[]) {
+  async function* gen() {
+    for (const wf of workflows) yield wf;
+  }
+  return {
+    workflow: {
+      list: () => gen(),
+      // BPM getActivityState query — return a stable shape so healthy rows get
+      // their tempo fields; irrelevant to the degraded assertion.
+      getHandle: () => ({ query: async () => ({ activityCount: 1, lastActivityAt: 'now' }) }),
+    },
+  } as any;
+}
+
+describe('#886 scanEnsembleSessionsCloud degraded rows', () => {
+  it('emits a degraded row (preserving identity) instead of dropping on extraction failure', async () => {
+    const healthy = { workflowId: 'agent-session-ens-alice', _playerId: 'alice' };
+    const broken = { workflowId: 'agent-session-ens-bob', _playerId: 'bob', _boom: true };
+    const logs: string[] = [];
+
+    const rows = await scanEnsembleSessionsCloud(
+      makeClient([healthy, broken]),
+      'ens',
+      (...a) => logs.push(a.join(' ')),
+    );
+
+    // Both players present — the broken one was NOT dropped (anti-flap).
+    expect(rows.map((r) => r.playerId).sort()).toEqual(['alice', 'bob']);
+
+    const aliceRow = rows.find((r) => r.playerId === 'alice')!;
+    expect(aliceRow.degraded).toBeFalsy();
+    expect(aliceRow.part).toBe('a part');
+
+    const bobRow = rows.find((r) => r.playerId === 'bob')!;
+    expect(bobRow.degraded).toBe(true);
+    // Identity preserved (real playerId, not re-keyed on workflowId → no churn).
+    expect(bobRow.playerId).toBe('bob');
+    expect(bobRow.workflowId).toBe('agent-session-ens-bob');
+    // Non-identity fields are best-effort blanks.
+    expect(bobRow.part).toBe('');
+    expect(bobRow.hostname).toBe('');
+    // A degraded row is logged (named, not silent).
+    expect(logs.some((l) => l.includes('degraded row') && l.includes('agent-session-ens-bob'))).toBe(true);
+  });
+
+  it('a fully healthy scan flags no rows degraded', async () => {
+    const rows = await scanEnsembleSessionsCloud(
+      makeClient([
+        { workflowId: 'agent-session-ens-a', _playerId: 'a' },
+        { workflowId: 'agent-session-ens-b', _playerId: 'b' },
+      ]),
+      'ens',
+    );
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => !r.degraded)).toBe(true);
+  });
+
+  it('salvages playerId from the workflowId when even that getter throws', async () => {
+    // A workflow whose _playerId is undefined AND getPart throws: the salvage
+    // falls back to the workflowId, and the row is still emitted (never dropped).
+    const broken = { workflowId: 'agent-session-ens-ghost', _playerId: undefined, _boom: true };
+    const rows = await scanEnsembleSessionsCloud(makeClient([broken]), 'ens');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].degraded).toBe(true);
+    expect(rows[0].playerId).toBe('agent-session-ens-ghost');
+  });
+});

--- a/tests/observability/nondeterminism-alarm.test.ts
+++ b/tests/observability/nondeterminism-alarm.test.ts
@@ -1,0 +1,152 @@
+/**
+ * #886 slice 1 — nondeterminism alarm unit tests.
+ *
+ * Pure logic: the classifier, the counter/snapshot, the logger wrapper's
+ * passthrough + detection, and the process singleton. No Temporal runtime.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  NondeterminismAlarm,
+  isNondeterminismLog,
+  wrapLoggerWithAlarm,
+  NONDETERMINISM_MARKERS,
+  getGlobalNondeterminismAlarm,
+  setGlobalNondeterminismAlarm,
+  __resetGlobalNondeterminismAlarmForTests,
+} from '../../src/observability/nondeterminism-alarm';
+import type { Logger, LogLevel } from '@temporalio/common';
+
+afterEach(() => __resetGlobalNondeterminismAlarmForTests());
+
+describe('isNondeterminismLog', () => {
+  it('matches the marker set case-insensitively', () => {
+    expect(isNondeterminismLog('Replay failed with a nondeterminism error')).toBe(true);
+    expect(isNondeterminismLog('Workflow task failed: NonDeterminismError')).toBe(true);
+    expect(isNondeterminismLog('a DeterminismViolationError occurred')).toBe(true);
+    expect(isNondeterminismLog('non-determinism detected during replay')).toBe(true);
+    expect(isNondeterminismLog('error code TMPRL1100 in workflow')).toBe(true);
+  });
+
+  it('does NOT match unrelated logs', () => {
+    expect(isNondeterminismLog('Workflow completed successfully')).toBe(false);
+    expect(isNondeterminismLog('activity timed out')).toBe(false);
+    expect(isNondeterminismLog('')).toBe(false);
+    expect(isNondeterminismLog(undefined as unknown as string)).toBe(false);
+  });
+
+  it('exposes the marker set (frozen)', () => {
+    expect(NONDETERMINISM_MARKERS).toContain('nondetermin');
+    expect(NONDETERMINISM_MARKERS).toContain('determinismviolation');
+    expect(Object.isFrozen(NONDETERMINISM_MARKERS)).toBe(true);
+  });
+});
+
+describe('NondeterminismAlarm', () => {
+  it('counts hits and tracks first/last timestamps', () => {
+    let t = 1_000;
+    const alarm = new NondeterminismAlarm({ now: () => t });
+    expect(alarm.snapshot()).toEqual({ count: 0, recent: [] });
+
+    alarm.record('nondeterminism #1');
+    t = 5_000;
+    alarm.record('nondeterminism #2', { workflowType: 'agentSessionWorkflow', runId: 'r-9' });
+
+    const snap = alarm.snapshot();
+    expect(snap.count).toBe(2);
+    expect(snap.firstSeenAt).toBe(new Date(1_000).toISOString());
+    expect(snap.lastSeenAt).toBe(new Date(5_000).toISOString());
+    expect(snap.recent).toHaveLength(2);
+    // meta is woven into the detail.
+    expect(snap.recent[1].detail).toContain('workflowType=agentSessionWorkflow');
+    expect(snap.recent[1].detail).toContain('runId=r-9');
+  });
+
+  it('caps the recent ring at 10, newest last', () => {
+    const alarm = new NondeterminismAlarm({ now: () => 0 });
+    for (let i = 0; i < 15; i++) alarm.record(`nondeterminism ${i}`);
+    const snap = alarm.snapshot();
+    expect(snap.count).toBe(15);
+    expect(snap.recent).toHaveLength(10);
+    expect(snap.recent[snap.recent.length - 1].detail).toContain('nondeterminism 14');
+    expect(snap.recent[0].detail).toContain('nondeterminism 5');
+  });
+
+  it('invokes onHit with the running count + sample (promotion)', () => {
+    const hits: Array<{ count: number; detail: string }> = [];
+    const alarm = new NondeterminismAlarm({
+      now: () => 0,
+      onHit: (count, sample) => hits.push({ count, detail: sample.detail }),
+    });
+    alarm.record('nondeterminism a');
+    alarm.record('nondeterminism b');
+    expect(hits.map((h) => h.count)).toEqual([1, 2]);
+  });
+
+  it('a throwing onHit never disarms the counter', () => {
+    const alarm = new NondeterminismAlarm({ now: () => 0, onHit: () => { throw new Error('boom'); } });
+    expect(() => alarm.record('nondeterminism x')).not.toThrow();
+    expect(alarm.count).toBe(1);
+  });
+});
+
+describe('wrapLoggerWithAlarm', () => {
+  function makeBase() {
+    const calls: Array<{ method: string; level?: LogLevel; message: string }> = [];
+    const base: Logger = {
+      log: (level, message) => { calls.push({ method: 'log', level, message }); },
+      trace: (message) => { calls.push({ method: 'trace', message }); },
+      debug: (message) => { calls.push({ method: 'debug', message }); },
+      info: (message) => { calls.push({ method: 'info', message }); },
+      warn: (message) => { calls.push({ method: 'warn', message }); },
+      error: (message) => { calls.push({ method: 'error', message }); },
+    };
+    return { base, calls };
+  }
+
+  it('forwards every method to the base logger', () => {
+    const { base, calls } = makeBase();
+    const alarm = new NondeterminismAlarm({ now: () => 0 });
+    const w = wrapLoggerWithAlarm(base, alarm);
+    w.trace('t'); w.debug('d'); w.info('i'); w.warn('w'); w.error('e'); w.log('INFO', 'l');
+    expect(calls.map((c) => c.method)).toEqual(['trace', 'debug', 'info', 'warn', 'error', 'log']);
+    expect(alarm.count).toBe(0); // none were nondeterminism
+  });
+
+  it('records a nondeterminism WARN / ERROR / log(WARN) but still forwards', () => {
+    const { base, calls } = makeBase();
+    const alarm = new NondeterminismAlarm({ now: () => 0 });
+    const w = wrapLoggerWithAlarm(base, alarm);
+    w.warn('Replay failed with a nondeterminism error');
+    w.error('DeterminismViolationError');
+    w.log('WARN', 'nondeterminism via log()');
+    expect(alarm.count).toBe(3);
+    expect(calls).toHaveLength(3); // all still forwarded
+  });
+
+  it('does NOT record nondeterminism at trace/debug/info levels', () => {
+    const { base } = makeBase();
+    const alarm = new NondeterminismAlarm({ now: () => 0 });
+    const w = wrapLoggerWithAlarm(base, alarm);
+    w.info('nondeterminism mention at info');
+    w.debug('nondeterminism mention at debug');
+    w.log('INFO', 'nondeterminism mention via log INFO');
+    expect(alarm.count).toBe(0);
+  });
+
+  it('does NOT record a non-matching WARN', () => {
+    const { base } = makeBase();
+    const alarm = new NondeterminismAlarm({ now: () => 0 });
+    const w = wrapLoggerWithAlarm(base, alarm);
+    w.warn('Ignoring WorkerOptions.workflowsPath');
+    expect(alarm.count).toBe(0);
+  });
+});
+
+describe('process singleton', () => {
+  it('get returns undefined until set, then the installed alarm', () => {
+    expect(getGlobalNondeterminismAlarm()).toBeUndefined();
+    const alarm = new NondeterminismAlarm();
+    setGlobalNondeterminismAlarm(alarm);
+    expect(getGlobalNondeterminismAlarm()).toBe(alarm);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -50,6 +50,12 @@ export default defineConfig({
       // #785 — upgrade-to-2 snapshot schema + persistence (Temporal-free
       // schema module; pure fs round-trip + validation guards).
       'tests/upgrade/**/*.test.ts',
+      // #886 slice 1 — nondeterminism alarm (classifier, counter/snapshot,
+      // logger wrapper, singleton; Temporal-value-free, pure logic).
+      'tests/observability/**/*.test.ts',
+      // #886 slice 2 — scanEnsembleSessionsCloud degraded-row behaviour
+      // (getter module mocked to force the extraction-failure branch; no worker).
+      'tests/activities/**/*.test.ts',
     ],
     // Scrub ambient AGENT_TEMPO_*/CLAUDE_TEMPO_* env vars before each file
     // and restore the clean baseline after each test (#744).


### PR DESCRIPTION
## Summary

Two reliability-observability slices (#886) — the diagnostic net the architect wants landed with/before #704. Motivated by the #801 incident: **57 workflow-task failures in 3 minutes with ZERO operator signal**. Slice 3 (worker-versioning) is deferred.

### Slice 1 — TMPRL1100 nondeterminism alarm (daemon-side)

- New **`src/observability/nondeterminism-alarm.ts`** (Temporal-value-free): a process counter + wording-tolerant classifier (`nondetermin` / `determinismviolation` / `tmprl1100`) + a logger wrapper + a process singleton.
- The daemon installs it via `Runtime.install({ logger })` **before any `Worker.create`**, wrapping a `DefaultLogger('INFO')` (verbosity unchanged — the wrapper only *adds* detection on WARN/ERROR). Every nondeterminism / determinism-violation record is **promoted** to a prominent, greppable `[agent-tempo:ALARM] nondeterminism #N — …` line and counted.
- The rolling snapshot is surfaced on **`GET /v1/health`** (`HealthV1.nondeterminism`) so monitors/dashboards poll the alarm without scraping `daemon.log`.

### Slice 2 — degraded-flag on observation drops

- `scanEnsembleSessionsCloud`'s inner `catch{}` silently **dropped** a row on extraction failure, making a transient read as "player absent" → **roster flapping** (contra #777). It now emits a **degraded row** that preserves identity (`workflowId` + best-effort `playerId`, salvaged so a throwing getter can't fail the whole scan) and flags `degraded: true`, with a named log line.
- `degraded?: boolean` threaded `EnsembleSessionInfo → MaestroPlayerInfo → PlayerSummaryV1` (additive optional wire field, §6-safe) via the maestro mapper + `toPlayerSummaryV1` — the board/dashboard can badge the player as uncertain instead of it vanishing.

### #793 follow-up (conductor-requested)

- Added `gate` to the `pi-tool-parity` `CONDUCTOR_ONLY` list so the new canonical's conductor-only gating is actively asserted.

## Tests / docs

- `tests/observability/nondeterminism-alarm.test.ts` (12) + `tests/activities/scan-degraded.test.ts` (3), both vitest; `tests/observability/**` + `tests/activities/**` added to the vitest include allowlist.
- Docs: `SSE-PROTOCOL.md` (degraded field) + `daemon.md` (alarm). **`WIRE-PROTOCOL.md` untouched** (no signal/query/update change).

## Verification

- `npm run build` green; typecheck clean.
- **mocha 1610 passing**; **vitest 1458 passing** (incl. the new suites, run standalone).
- Lints (surface-drift, no-stray-src-js, …), `size-limit`, `verify-tarball`, dashboard lint — all green standalone.
- ⚠️ **Note for reviewers:** local Windows `check:all` intermittently fails the *vitest* step with a vite-worker `Failed to load url tests/setup.ts` race when many parallel workers spawn under load (it hits the **untouched** dashboard vitest identically, and small/single-threaded runs pass). This is a Windows resource/worker-spawn flake, not a code issue — CI runs on Linux and is unaffected.

Closes #886

🤖 Generated with [Claude Code](https://claude.com/claude-code)