### PR TITLE
docs(drift): add #793 tool files to CLAUDE.md + upgrade-to-2 to cli.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -102,15 +102,16 @@ src/
 │   ├── ensemble.ts / cue.ts / recruit.ts / report.ts / broadcast.ts / recall.ts / listen.ts
 │   ├── restart.ts / destroy.ts / migrate.ts / attachment-info.ts
 │   ├── schedule.ts / unschedule.ts / schedules.ts
-│   ├── quality-gate.ts / evaluate-gate.ts / gates.ts
+│   ├── gate.ts / quality-gate.ts / evaluate-gate.ts / gates.ts
 │   ├── worktree.ts / stage.ts / stages.ts / cancel-stage.ts
 │   ├── load-lineup.ts / save-lineup.ts / agent-types.ts / resolve.ts
 │   ├── set-name.ts / set-part.ts / who-am-i.ts / release.ts
 │   ├── pause.ts / play.ts / shutdown.ts / restore.ts / reset.ts
 │   ├── hosts.ts / set-ensemble-description.ts
-│   ├── save-state.ts / fetch-state.ts / clear-state.ts
-│   ├── coat-check-put.ts / coat-check-get.ts / coat-check-list.ts / coat-check-evict.ts
+│   ├── state.ts / save-state.ts / fetch-state.ts / clear-state.ts
+│   ├── coat-check.ts / coat-check-put.ts / coat-check-get.ts / coat-check-list.ts / coat-check-evict.ts
 │   ├── respond.ts
+│   ├── action-guard.ts  # Runtime per-action required-field enforcer (friendly "action=X requires Y" errors); shared by canonical multi-action tools (#793)
 │   └── descriptor.ts  # Transport-neutral tool descriptor (TempoToolDescriptor) + renderToMcp; per-tool `build*Tool` factories live in each tool file (MD-B, Phase 1)
 ├── pi/                # Pi-native integration — a Pi session as a first-class player over the Temporal core
 │   ├── extension.ts   # `export default function(pi)` — interactive runtime entry. Holds the MODULE-SCOPE singleton `Map<workflowId, PiPlayerRuntime>` that survives Pi's per-switch instance rebuild (rebind, not re-claim); full tool surface via renderToPi; Option-C reason-discriminated teardown

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -32,6 +32,7 @@ agent-tempo <command> [options]
 | `install-pi` | Install agent-tempo's Pi extensions (player + command-center) into Pi's settings.json. Idempotent; prunes stale/old-version paths on re-run. Use `--project` for per-directory installation. (#700, #738) |
 | `scenarios <sub>` | **Dev mode only.** Browse the shipped scenario library (`list`, `show <name>`). Requires `--dev`. See [dev-mode.md](dev-mode.md). |
 | `upgrade [version]` | Graceful self-update — stops daemon, installs new version, restarts daemon |
+| `upgrade-to-2` | **1.7.0 → 2.0 cutover verb.** Six-phase drain-and-destroy protocol: preflight → pause → drain → snapshot → destroy → done. Writes `~/.agent-tempo/upgrade-snapshot-v1.json`; resumable after interruption. Flags: `--dry-run` (inspect without pausing), `--force-drain` (proceed with non-empty outboxes), `--yes` / `-y` (skip confirm). Run on 1.7.0 **before** installing 2.0; then `agent-tempo up --from-upgrade` on 2.0 to restore the ensemble. See [ops/v2-cutover.md](ops/v2-cutover.md). (#785) |
 | `version` | Print the installed version |
 | `help` | Show usage info |
 


### PR DESCRIPTION
## Summary

Drift fixes found by the scheduled `docs-drift-check` routine.

- **CLAUDE.md `src/tools/` listing** — four files added by #793/#888 were absent: `gate.ts`, `state.ts`, `coat-check.ts` (the three new canonical tools) and `action-guard.ts` (runtime per-action field enforcer). Added to their family lines; `action-guard.ts` gets its own entry with a description.
- **`docs/cli.md`** — `upgrade-to-2` verb was only in a removed-verb cross-reference, not the command reference table. Added a full row (flags, resumability, cross-link to `ops/v2-cutover.md`).

**Note:** `docs/tools.md` has **no drift** — the fork's initial report was wrong on that point. `coat_check` (line 33), `state` (line 29), and `gate` (line 40) are all correctly documented there by #793/#888.

## Test plan

- [ ] Verify CLAUDE.md tool file names match `git ls-tree origin/v2 src/tools/ --name-only`
- [ ] Verify `upgrade-to-2` description matches `src/cli/upgrade-to-2-command.ts` flags

---
🎼 _Posted by [claude-tempo\[bot\]](https://github.com/apps/claude-tempo) —
an AI ensemble acting on behalf of @vinceblank. For a human, mention @vinceblank directly._