### PR TITLE
fix(mock): keep handoff pending until downstream evidence

### DIFF
--- a/scenarios/multi-player-handoff.yaml
+++ b/scenarios/multi-player-handoff.yaml
@@ -4,9 +4,11 @@ description: |
   real LLM. When `alice` receives a "ship feature <topic>" cue, she splits the
   task: cues `bob` for implementation, `carol` for review, then reports an
   "in flight" update to the conductor. After a 2 s simulated thinking window
-  she fires a "shipped" report. The dashboard should render two outbox
-  branches under alice's audit trail and inbound cues on both bob's and
-  carol's rosters.
+  she reports that dispatch is complete but downstream evidence is still
+  pending. The scenario deliberately does not emit a `result`: outbound cues
+  prove delivery, not that bob implemented or carol reviewed the feature.
+  The dashboard should render two outbox branches under alice's audit trail
+  and inbound cues on both bob's and carol's rosters.
 
   Pair this with a `tempo-mock-jam`-shaped lineup (3 mock players named
   alice / bob / carol). Drive with: `agent-tempo --dev cue alice "ship
@@ -28,8 +30,8 @@ rules:
           text: "split '$message' into bob (impl) + carol (review); both notified"
       - delayMs: 2000
       - report:
-          type: "result"
-          text: "$message handoff complete — bob + carol coordinating downstream"
+          type: "update"
+          text: "$message dispatched — awaiting bob's implementation evidence and carol's review verdict"
 
   - when: "*"
     do:

--- a/tests/adapters/mock/scenario-library.test.ts
+++ b/tests/adapters/mock/scenario-library.test.ts
@@ -59,4 +59,16 @@ describe('scenarios/ library — every shipped YAML parses', () => {
       expect(scenario.name, `${file} should declare name: "${stem}"`).toBe(stem);
     }
   });
+
+  it('multi-player handoff does not report completion before downstream evidence', () => {
+    const yamlText = readFileSync(resolve(SCENARIOS_DIR, 'multi-player-handoff.yaml'), 'utf8');
+    const scenario = parseScenario(yamlText);
+    const handoffRule = scenario.rules.find((rule) => rule.when === 'ship feature');
+    const reportTypes = handoffRule?.do.flatMap((action) =>
+      'report' in action ? [action.report.type] : [],
+    );
+
+    expect(reportTypes).toContain('update');
+    expect(reportTypes).not.toContain('result');
+  });
 });


### PR DESCRIPTION
## What

Keep the shipped `multi-player-handoff` mock scenario in `update` state after it cues Bob and Carol, instead of reporting a terminal `result` after a fixed delay.

The scenario currently proves that the two outbound cues were dispatched, but it does not collect Bob's implementation result or Carol's review verdict. Marking the handoff complete at that point teaches a false-positive completion pattern in a first-class validation artifact.

This also adds a focused scenario-library invariant so the handoff cannot silently regress to `result` without downstream evidence.

## Why

Delivery and completion are separate states in multi-agent coordination. A durable transport can prove that work was delegated, but completion should require evidence from the downstream workers.

## Test plan

- `npx vitest run tests/adapters/mock/scenario-library.test.ts` (8/8 passing)
- `git diff --check`
